### PR TITLE
Inline `EvaluationContext` methods only used in specific places

### DIFF
--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -14,7 +14,7 @@ auto EvaluationContext::prepare(const sourcemeta::jsontoolkit::JSON &instance)
   assert(this->resources_.empty());
   this->instances_.clear();
   this->instances_.emplace_back(instance);
-  this->labels.clear();
+  this->labels_.clear();
   this->property_as_instance = false;
   this->evaluated_.clear();
   this->evaluated_blacklist_.clear();
@@ -172,25 +172,12 @@ auto EvaluationContext::resolve_string_target() -> std::optional<
 
 auto EvaluationContext::mark(const std::size_t id, const Template &children)
     -> void {
-  this->labels.try_emplace(id, children);
+  this->labels_.try_emplace(id, children);
 }
 
-auto EvaluationContext::jump(const std::size_t id) const noexcept
-    -> const Template & {
-  assert(this->labels.contains(id));
-  return this->labels.at(id).get();
-}
-
-auto EvaluationContext::find_dynamic_anchor(const std::string &anchor) const
-    -> std::optional<std::size_t> {
-  for (const auto &resource : this->resources()) {
-    const auto label{this->hash(resource, anchor)};
-    if (this->labels.contains(label)) {
-      return label;
-    }
-  }
-
-  return std::nullopt;
+auto EvaluationContext::labels() const noexcept -> const
+    std::map<std::size_t, const std::reference_wrapper<const Template>> {
+  return this->labels_;
 }
 
 auto EvaluationContext::evaluate(

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -87,9 +87,8 @@ public:
             const std::string &fragment) const noexcept -> std::size_t;
   auto resources() const noexcept -> const std::vector<std::size_t> &;
   auto mark(const std::size_t id, const Template &children) -> void;
-  auto jump(const std::size_t id) const noexcept -> const Template &;
-  auto find_dynamic_anchor(const std::string &anchor) const
-      -> std::optional<std::size_t>;
+  auto labels() const noexcept -> const
+      std::map<std::size_t, const std::reference_wrapper<const Template>>;
 
   ///////////////////////////////////////////////
   // Evaluation
@@ -120,7 +119,7 @@ private:
   std::vector<std::pair<std::size_t, std::size_t>> frame_sizes;
   const std::hash<std::string> hasher_{};
   std::vector<std::size_t> resources_;
-  std::map<std::size_t, const std::reference_wrapper<const Template>> labels;
+  std::map<std::size_t, const std::reference_wrapper<const Template>> labels_;
   bool property_as_instance{false};
 
   // TODO: Turn these into a trie


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
