### PR TITLE
Implement `ControlGroup` as a more efficient `LogicalAnd` alternative

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -246,6 +246,10 @@ struct DescribeVisitor {
     return message.str();
   }
 
+  auto operator()(const ControlGroup &) const -> std::string {
+    return unknown();
+  }
+
   auto operator()(const ControlLabel &) const -> std::string {
     return describe_reference(this->target);
   }

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -261,6 +261,7 @@ struct StepVisitor {
   HANDLE_STEP("loop", "keys", LoopKeys)
   HANDLE_STEP("loop", "items", LoopItems)
   HANDLE_STEP("loop", "contains", LoopContains)
+  HANDLE_STEP("control", "group", ControlGroup)
   HANDLE_STEP("control", "label", ControlLabel)
   HANDLE_STEP("control", "mark", ControlMark)
   HANDLE_STEP("control", "evaluate", ControlEvaluate)

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -339,8 +339,8 @@ auto compiler_draft4_applicator_anyof(const Context &context,
   for (std::uint64_t index = 0;
        index < schema_context.schema.at(dynamic_context.keyword).size();
        index++) {
-    disjunctors.push_back(make<LogicalAnd>(
-        false, context, schema_context, relative_dynamic_context, ValueNone{},
+    disjunctors.push_back(make<ControlGroup>(
+        true, context, schema_context, relative_dynamic_context, ValueNone{},
         compile(context, schema_context, relative_dynamic_context,
                 {static_cast<sourcemeta::jsontoolkit::Pointer::Token::Index>(
                     index)})));
@@ -366,8 +366,8 @@ auto compiler_draft4_applicator_oneof(const Context &context,
   for (std::uint64_t index = 0;
        index < schema_context.schema.at(dynamic_context.keyword).size();
        index++) {
-    disjunctors.push_back(make<LogicalAnd>(
-        false, context, schema_context, relative_dynamic_context, ValueNone{},
+    disjunctors.push_back(make<ControlGroup>(
+        true, context, schema_context, relative_dynamic_context, ValueNone{},
         compile(context, schema_context, relative_dynamic_context,
                 {static_cast<sourcemeta::jsontoolkit::Pointer::Token::Index>(
                     index)})));
@@ -488,9 +488,9 @@ auto compiler_draft4_applicator_properties_with_options(
       }
 
       // Note that the evaluator completely ignores this wrapper anyway
-      children.push_back(make<LogicalAnd>(false, context, schema_context,
-                                          relative_dynamic_context, ValueNone{},
-                                          std::move(substeps)));
+      children.push_back(make<ControlGroup>(true, context, schema_context,
+                                            relative_dynamic_context,
+                                            ValueNone{}, std::move(substeps)));
       cursor += 1;
     }
 
@@ -872,11 +872,9 @@ auto compiler_draft4_applicator_items_array(
           sourcemeta::jsontoolkit::JSON{cursor}));
     }
 
-    // TODO: Can we "see through" this instruction and evaluate the children
-    // directly as an optimization?
-    children.push_back(make<LogicalAnd>(false, context, schema_context,
-                                        relative_dynamic_context, ValueNone{},
-                                        std::move(subchildren)));
+    children.push_back(make<ControlGroup>(true, context, schema_context,
+                                          relative_dynamic_context, ValueNone{},
+                                          std::move(subchildren)));
   }
 
   Template tail;
@@ -895,9 +893,9 @@ auto compiler_draft4_applicator_items_array(
                                         sourcemeta::jsontoolkit::JSON{true}));
   }
 
-  children.push_back(make<LogicalAnd>(false, context, schema_context,
-                                      relative_dynamic_context, ValueNone{},
-                                      std::move(tail)));
+  children.push_back(make<ControlGroup>(true, context, schema_context,
+                                        relative_dynamic_context, ValueNone{},
+                                        std::move(tail)));
 
   return {make<AssertionArrayPrefix>(
       true, context, schema_context, dynamic_context,

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
@@ -67,6 +67,7 @@ struct LoopPropertiesTypeStrict;
 struct LoopKeys;
 struct LoopItems;
 struct LoopContains;
+struct ControlGroup;
 struct ControlLabel;
 struct ControlMark;
 struct ControlEvaluate;
@@ -93,8 +94,8 @@ using Template = std::vector<std::variant<
     LoopPropertiesUnevaluated, LoopItemsUnevaluated, LoopPropertiesMatch,
     LoopProperties, LoopPropertiesRegex, LoopPropertiesExcept,
     LoopPropertiesType, LoopPropertiesTypeStrict, LoopKeys, LoopItems,
-    LoopContains, ControlLabel, ControlMark, ControlEvaluate, ControlJump,
-    ControlDynamicAnchorJump>>;
+    LoopContains, ControlGroup, ControlLabel, ControlMark, ControlEvaluate,
+    ControlJump, ControlDynamicAnchorJump>>;
 
 #if !defined(DOXYGEN)
 // For fast internal instruction dispatching. It must stay
@@ -153,6 +154,7 @@ enum class TemplateIndex : std::uint8_t {
   LoopKeys,
   LoopItems,
   LoopContains,
+  ControlGroup,
   ControlLabel,
   ControlMark,
   ControlEvaluate,
@@ -445,6 +447,11 @@ DEFINE_STEP_APPLICATOR(Loop, Items, ValueUnsignedInteger)
 /// @brief Represents a compiler step that checks array items match a given
 /// criteria
 DEFINE_STEP_APPLICATOR(Loop, Contains, ValueRange)
+
+/// @ingroup evaluator_instructions
+/// @brief Represents a compiler step that groups a set of steps but is not
+/// evaluated on its own
+DEFINE_STEP_APPLICATOR(Control, Group, ValueNone)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler step that consists of a mark to jump to while


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
