### PR TITLE
Use an efficient `ControlGroup` variant for `properties`

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -249,10 +249,6 @@ struct DescribeVisitor {
     return message.str();
   }
 
-  auto operator()(const ControlGroup &) const -> std::string {
-    return unknown();
-  }
-
   auto operator()(const ControlLabel &) const -> std::string {
     return describe_reference(this->target);
   }
@@ -1662,9 +1658,18 @@ struct DescribeVisitor {
 
   // These steps are never described, at least not right now
 
+  auto operator()(const ControlGroup &) const -> std::string {
+    return unknown();
+  }
+
+  auto operator()(const ControlGroupWhenDefines &) const -> std::string {
+    return unknown();
+  }
+
   auto operator()(const LogicalWhenArraySizeGreater &) const -> std::string {
     return unknown();
   }
+
   auto operator()(const LogicalWhenArraySizeEqual &) const -> std::string {
     return unknown();
   }

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -262,6 +262,7 @@ struct StepVisitor {
   HANDLE_STEP("loop", "items", LoopItems)
   HANDLE_STEP("loop", "contains", LoopContains)
   HANDLE_STEP("control", "group", ControlGroup)
+  HANDLE_STEP("control", "group-when-defines", ControlGroupWhenDefines)
   HANDLE_STEP("control", "label", ControlLabel)
   HANDLE_STEP("control", "mark", ControlMark)
   HANDLE_STEP("control", "evaluate", ControlEvaluate)

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -573,8 +573,8 @@ auto compiler_draft4_applicator_properties_with_options(
           dynamic_context.base_instance_location));
 
     } else {
-      children.push_back(make<LogicalWhenDefines>(
-          false, context, schema_context, relative_dynamic_context,
+      children.push_back(make<ControlGroupWhenDefines>(
+          true, context, schema_context, relative_dynamic_context,
           ValueString{name}, std::move(substeps)));
     }
   }

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -654,6 +654,22 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
       EVALUATE_END_PASS_THROUGH(ControlGroup);
     }
 
+    case IS_STEP(ControlGroupWhenDefines): {
+      EVALUATE_BEGIN_PASS_THROUGH(control, ControlGroupWhenDefines);
+      const auto &target{context.resolve_target()};
+
+      if (target.is_object() && target.defines(control.value)) {
+        for (const auto &child : control.children) {
+          if (!evaluate_step(child, callback, context)) {
+            result = false;
+            break;
+          }
+        }
+      }
+
+      EVALUATE_END_PASS_THROUGH(ControlGroupWhenDefines);
+    }
+
     case IS_STEP(ControlLabel): {
       EVALUATE_BEGIN_NO_PRECONDITION(control, ControlLabel);
       context.mark(control.value, control.children);

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
@@ -68,6 +68,7 @@ struct LoopKeys;
 struct LoopItems;
 struct LoopContains;
 struct ControlGroup;
+struct ControlGroupWhenDefines;
 struct ControlLabel;
 struct ControlMark;
 struct ControlEvaluate;
@@ -94,8 +95,8 @@ using Template = std::vector<std::variant<
     LoopPropertiesUnevaluated, LoopItemsUnevaluated, LoopPropertiesMatch,
     LoopProperties, LoopPropertiesRegex, LoopPropertiesExcept,
     LoopPropertiesType, LoopPropertiesTypeStrict, LoopKeys, LoopItems,
-    LoopContains, ControlGroup, ControlLabel, ControlMark, ControlEvaluate,
-    ControlJump, ControlDynamicAnchorJump>>;
+    LoopContains, ControlGroup, ControlGroupWhenDefines, ControlLabel,
+    ControlMark, ControlEvaluate, ControlJump, ControlDynamicAnchorJump>>;
 
 #if !defined(DOXYGEN)
 // For fast internal instruction dispatching. It must stay
@@ -155,6 +156,7 @@ enum class TemplateIndex : std::uint8_t {
   LoopItems,
   LoopContains,
   ControlGroup,
+  ControlGroupWhenDefines,
   ControlLabel,
   ControlMark,
   ControlEvaluate,
@@ -449,9 +451,14 @@ DEFINE_STEP_APPLICATOR(Loop, Items, ValueUnsignedInteger)
 DEFINE_STEP_APPLICATOR(Loop, Contains, ValueRange)
 
 /// @ingroup evaluator_instructions
-/// @brief Represents a compiler step that groups a set of steps but is not
+/// @brief Represents a compiler step that groups a set of steps, but is not
 /// evaluated on its own
 DEFINE_STEP_APPLICATOR(Control, Group, ValueNone)
+
+/// @ingroup evaluator_instructions
+/// @brief Represents a compiler step that groups a set of steps if a given
+/// object property exists, but is not evaluated on its own
+DEFINE_STEP_APPLICATOR(Control, GroupWhenDefines, ValueString)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler step that consists of a mark to jump to while


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
