### PR TITLE
Rename the `evaluate_path` step property to `track`

### DIFF
--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -91,7 +91,7 @@ auto unroll(const DynamicContext &dynamic_context, const Step &step,
           std::get<Type>(step).schema_resource,
           std::get<Type>(step).dynamic,
           std::get<Type>(step).report,
-          std::get<Type>(step).evaluate_path,
+          std::get<Type>(step).track,
           std::get<Type>(step).value};
 }
 

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -188,8 +188,7 @@ auto encode_step(const std::string_view category, const std::string_view type,
                 sourcemeta::jsontoolkit::JSON{step.schema_resource});
   result.assign("dynamic", sourcemeta::jsontoolkit::JSON{step.dynamic});
   result.assign("report", sourcemeta::jsontoolkit::JSON{step.report});
-  result.assign("evaluatePath",
-                sourcemeta::jsontoolkit::JSON{step.evaluate_path});
+  result.assign("track", sourcemeta::jsontoolkit::JSON{step.track});
   result.assign("value", value_to_json(step.value));
 
   if constexpr (requires { step.children; }) {

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -549,7 +549,7 @@ auto compiler_draft4_applicator_properties_with_options(
           dynamic_context.base_instance_location.concat(
               type_step.relative_instance_location),
           type_step.keyword_location, type_step.schema_resource,
-          type_step.dynamic, type_step.report, type_step.evaluate_path,
+          type_step.dynamic, type_step.report, type_step.track,
           type_step.value});
     } else if (context.mode == Mode::FastValidation && substeps.size() == 1 &&
                std::holds_alternative<AssertionType>(substeps.front())) {
@@ -559,7 +559,7 @@ auto compiler_draft4_applicator_properties_with_options(
           dynamic_context.base_instance_location.concat(
               type_step.relative_instance_location),
           type_step.keyword_location, type_step.schema_resource,
-          type_step.dynamic, type_step.report, type_step.evaluate_path,
+          type_step.dynamic, type_step.report, type_step.track,
           type_step.value});
     } else if (context.mode == Mode::FastValidation && substeps.size() == 1 &&
                std::holds_alternative<AssertionPropertyTypeStrict>(

--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -24,21 +24,21 @@ auto EvaluationContext::prepare(const sourcemeta::jsontoolkit::JSON &instance)
 auto EvaluationContext::push_without_traverse(
     const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
     const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
-    const std::size_t &schema_resource, const bool dynamic,
-    const bool track_evaluate_path) -> void {
+    const std::size_t &schema_resource, const bool dynamic, const bool track)
+    -> void {
   // Guard against infinite recursion in a cheap manner, as
   // infinite recursion will manifest itself through huge
   // ever-growing evaluate paths
   constexpr auto EVALUATE_PATH_LIMIT{300};
-  const auto stack_size{track_evaluate_path ? this->evaluate_path_.size()
-                                            : this->evaluate_path_size_};
+  const auto stack_size{track ? this->evaluate_path_.size()
+                              : this->evaluate_path_size_};
   if (stack_size > EVALUATE_PATH_LIMIT) [[unlikely]] {
     throw sourcemeta::blaze::EvaluationError(
         "The evaluation path depth limit was reached "
         "likely due to infinite recursion");
   }
 
-  if (track_evaluate_path) {
+  if (track) {
     this->evaluate_path_.push_back(relative_schema_location);
   } else {
     // We still need to somewhat keep track of this to prevent infinite
@@ -62,11 +62,11 @@ auto EvaluationContext::push_without_traverse(
 auto EvaluationContext::push(
     const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
     const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
-    const std::size_t &schema_resource, const bool dynamic,
-    const bool track_evaluate_path) -> void {
+    const std::size_t &schema_resource, const bool dynamic, const bool track)
+    -> void {
   this->push_without_traverse(relative_schema_location,
                               relative_instance_location, schema_resource,
-                              dynamic, track_evaluate_path);
+                              dynamic, track);
   if (!relative_instance_location.empty()) {
     assert(!this->instances_.empty());
     this->instances_.emplace_back(
@@ -77,22 +77,20 @@ auto EvaluationContext::push(
 auto EvaluationContext::push(
     const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
     const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
-    const std::size_t &schema_resource, const bool dynamic,
-    const bool track_evaluate_path,
+    const std::size_t &schema_resource, const bool dynamic, const bool track,
     std::reference_wrapper<const sourcemeta::jsontoolkit::JSON> &&new_instance)
     -> void {
   this->push_without_traverse(relative_schema_location,
                               relative_instance_location, schema_resource,
-                              dynamic, track_evaluate_path);
+                              dynamic, track);
   assert(!relative_instance_location.empty());
   this->instances_.emplace_back(new_instance);
 }
 
-auto EvaluationContext::pop(const bool dynamic, const bool track_evaluate_path)
-    -> void {
+auto EvaluationContext::pop(const bool dynamic, const bool track) -> void {
   assert(!this->frame_sizes.empty());
   const auto &sizes{this->frame_sizes.back()};
-  if (track_evaluate_path) {
+  if (track) {
     this->evaluate_path_.pop_back(sizes.first);
   } else {
     this->evaluate_path_size_ -= sizes.first;

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -26,15 +26,13 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
   SOURCEMETA_TRACE_END(trace_dispatch_id, "Dispatch");                         \
   SOURCEMETA_TRACE_START(trace_id, STRINGIFY(step_type));                      \
   const auto &step_category{std::get<step_type>(step)};                        \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path);                                           \
+               step_category.schema_resource, step_category.dynamic, track);   \
   const auto &target{context.resolve_target()};                                \
   if (!(precondition)) {                                                       \
-    context.pop(step_category.dynamic, track_evaluate_path);                   \
+    context.pop(step_category.dynamic, track);                                 \
     SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                      \
     return true;                                                               \
   }                                                                            \
@@ -48,15 +46,13 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
   SOURCEMETA_TRACE_END(trace_dispatch_id, "Dispatch");                         \
   SOURCEMETA_TRACE_START(trace_id, STRINGIFY(step_type));                      \
   const auto &step_category{std::get<step_type>(step)};                        \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path);                                           \
+               step_category.schema_resource, step_category.dynamic, track);   \
   const auto &maybe_target{context.resolve_string_target()};                   \
   if (!maybe_target.has_value()) {                                             \
-    context.pop(step_category.dynamic, track_evaluate_path);                   \
+    context.pop(step_category.dynamic, track);                                 \
     SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                      \
     return true;                                                               \
   }                                                                            \
@@ -75,12 +71,10 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
     SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                      \
     return true;                                                               \
   }                                                                            \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path);                                           \
+               step_category.schema_resource, step_category.dynamic, track);   \
   if (step_category.report && callback.has_value()) {                          \
     callback.value()(EvaluationType::Pre, true, step, context.evaluate_path(), \
                      context.instance_location(), context.null);               \
@@ -106,12 +100,11 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
     SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                      \
     return true;                                                               \
   }                                                                            \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path, std::move(target_check.value()));          \
+               step_category.schema_resource, step_category.dynamic, track,    \
+               std::move(target_check.value()));                               \
   if (step_category.report && callback.has_value()) {                          \
     callback.value()(EvaluationType::Pre, true, step, context.evaluate_path(), \
                      context.instance_location(), context.null);               \
@@ -122,12 +115,10 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
   SOURCEMETA_TRACE_END(trace_dispatch_id, "Dispatch");                         \
   SOURCEMETA_TRACE_START(trace_id, STRINGIFY(step_type));                      \
   const auto &step_category{std::get<step_type>(step)};                        \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path);                                           \
+               step_category.schema_resource, step_category.dynamic, track);   \
   if (step_category.report && callback.has_value()) {                          \
     callback.value()(EvaluationType::Pre, true, step, context.evaluate_path(), \
                      context.instance_location(), context.null);               \
@@ -156,7 +147,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
                      context.evaluate_path(), context.instance_location(),     \
                      context.null);                                            \
   }                                                                            \
-  context.pop(step_category.dynamic, track_evaluate_path);                     \
+  context.pop(step_category.dynamic, track);                                   \
   SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                        \
   return result;
 
@@ -177,19 +168,17 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
                             annotation_value)                                  \
   SOURCEMETA_TRACE_START(trace_id, STRINGIFY(step_type));                      \
   const auto &step_category{std::get<step_type>(step)};                        \
-  const auto track_evaluate_path{step_category.evaluate_path ||                \
-                                 callback.has_value()};                        \
+  const auto track{step_category.track || callback.has_value()};               \
   context.push(step_category.relative_schema_location,                         \
                step_category.relative_instance_location,                       \
-               step_category.schema_resource, step_category.dynamic,           \
-               track_evaluate_path);                                           \
+               step_category.schema_resource, step_category.dynamic, track);   \
   if (step_category.report && callback.has_value()) {                          \
     callback.value()(EvaluationType::Pre, true, step, context.evaluate_path(), \
                      destination, context.null);                               \
     callback.value()(EvaluationType::Post, true, step,                         \
                      context.evaluate_path(), destination, annotation_value);  \
   }                                                                            \
-  context.pop(step_category.dynamic, track_evaluate_path);                     \
+  context.pop(step_category.dynamic, track);                                   \
   SOURCEMETA_TRACE_END(trace_id, STRINGIFY(step_type));                        \
   return true;
 
@@ -629,7 +618,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
                                      : children_size};
       result = true;
       if (consequence_start > 0) {
-        if (track_evaluate_path) {
+        if (track) {
           context.retreat(logical.relative_schema_location);
 
           for (auto cursor = consequence_start; cursor < consequence_end;
@@ -781,7 +770,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
         }
       }
 
-      if (logical.value && track_evaluate_path) {
+      if (logical.value && track) {
         context.unevaluate();
       }
 
@@ -790,7 +779,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopPropertiesUnevaluated): {
       EVALUATE_BEGIN(loop, LoopPropertiesUnevaluated, target.is_object());
-      assert(track_evaluate_path);
+      assert(track);
       result = true;
 
       for (const auto &entry : target.as_object()) {
@@ -821,7 +810,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopItemsUnevaluated): {
       EVALUATE_BEGIN(loop, LoopItemsUnevaluated, target.is_array());
-      assert(track_evaluate_path);
+      assert(track);
       const auto &array{target.as_array()};
       result = true;
       for (auto iterator = array.cbegin(); iterator != array.cend();

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -45,16 +45,16 @@ public:
   auto push(const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
             const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
             const std::size_t &schema_resource, const bool dynamic,
-            const bool track_evaluate_path) -> void;
+            const bool track) -> void;
   // A performance shortcut for pushing without re-traversing the target
   // if we already know that the destination target will be
   auto push(const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
             const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
             const std::size_t &schema_resource, const bool dynamic,
-            const bool track_evaluate_path,
+            const bool track,
             std::reference_wrapper<const sourcemeta::jsontoolkit::JSON>
                 &&new_instance) -> void;
-  auto pop(const bool dynamic, const bool track_evaluate_path) -> void;
+  auto pop(const bool dynamic, const bool track) -> void;
   auto
   enter(const sourcemeta::jsontoolkit::WeakPointer::Token::Property &property)
       -> void;
@@ -70,8 +70,8 @@ private:
   auto push_without_traverse(
       const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
       const sourcemeta::jsontoolkit::Pointer &relative_instance_location,
-      const std::size_t &schema_resource, const bool dynamic,
-      const bool track_evaluate_path) -> void;
+      const std::size_t &schema_resource, const bool dynamic, const bool track)
+      -> void;
 
 public:
   ///////////////////////////////////////////////

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
@@ -171,7 +171,7 @@ enum class TemplateIndex : std::uint8_t {
     const std::size_t schema_resource;                                         \
     const bool dynamic;                                                        \
     const bool report;                                                         \
-    const bool evaluate_path;                                                  \
+    const bool track;                                                          \
     const type value;                                                          \
   };
 
@@ -183,7 +183,7 @@ enum class TemplateIndex : std::uint8_t {
     const std::size_t schema_resource;                                         \
     const bool dynamic;                                                        \
     const bool report;                                                         \
-    const bool evaluate_path;                                                  \
+    const bool track;                                                          \
     const type value;                                                          \
     const Template children;                                                   \
   };

--- a/test/compiler/compiler_json_test.cc
+++ b/test/compiler/compiler_json_test.cc
@@ -20,7 +20,7 @@ TEST(Compiler_json, defines_basic_root) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "value": {
         "category": "value",
@@ -51,7 +51,7 @@ TEST(Compiler_json, defines_basic_nested) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#/foo/bar",
       "value": {
         "category": "value",
@@ -81,7 +81,7 @@ TEST(Compiler_json, fail_basic_root) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "value": null
     }
@@ -108,7 +108,7 @@ TEST(Compiler_json, type_basic_root) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "value": {
         "category": "value",
@@ -143,7 +143,7 @@ TEST(Compiler_json, or_empty) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": []
     }
@@ -178,7 +178,7 @@ TEST(Compiler_json, or_single_child) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": [
         {
@@ -189,7 +189,7 @@ TEST(Compiler_json, or_single_child) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -232,7 +232,7 @@ TEST(Compiler_json, or_multiple_children) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": [
         {
@@ -243,7 +243,7 @@ TEST(Compiler_json, or_multiple_children) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -259,7 +259,7 @@ TEST(Compiler_json, or_multiple_children) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -292,7 +292,7 @@ TEST(Compiler_json, and_empty) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": []
     }
@@ -323,7 +323,7 @@ TEST(Compiler_json, and_single_child) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": [
         {
@@ -334,7 +334,7 @@ TEST(Compiler_json, and_single_child) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -373,7 +373,7 @@ TEST(Compiler_json, and_multiple_children) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "children": [
         {
@@ -384,7 +384,7 @@ TEST(Compiler_json, and_multiple_children) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -400,7 +400,7 @@ TEST(Compiler_json, and_multiple_children) {
           "schemaResource": 0,
           "dynamic": true,
           "report": true,
-          "evaluatePath": true,
+          "track": true,
           "absoluteKeywordLocation": "#",
           "value": {
             "category": "value",
@@ -433,7 +433,7 @@ TEST(Compiler_json, regex_basic) {
       "schemaResource": 0,
       "dynamic": true,
       "report": true,
-      "evaluatePath": true,
+      "track": true,
       "absoluteKeywordLocation": "#",
       "value": {
         "category": "value",


### PR DESCRIPTION
So we can use it for more than just the evaluate path.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
