### PR TITLE
Decouple `propertyNames` from the instance location pointer

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -987,22 +987,24 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
     case IS_STEP(LoopKeys): {
       EVALUATE_BEGIN(loop, LoopKeys, target.is_object());
       result = true;
-      context.target_type(EvaluationContext::TargetType::Key);
       for (const auto &entry : target.as_object()) {
         context.enter(entry.first);
+        context.set_property_target(entry.first);
+
         for (const auto &child : loop.children) {
           if (!evaluate_step(child, callback, context)) {
             result = false;
+            context.unset_property_target();
             context.leave();
             goto evaluate_loop_keys_end;
           }
         }
 
+        context.unset_property_target();
         context.leave();
       }
 
     evaluate_loop_keys_end:
-      context.target_type(EvaluationContext::TargetType::Value);
       EVALUATE_END(loop, LoopKeys);
     }
 

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -80,8 +80,11 @@ public:
 
   auto instances() const noexcept -> const std::vector<
       std::reference_wrapper<const sourcemeta::jsontoolkit::JSON>> &;
-  enum class TargetType : std::uint8_t { Key, Value };
-  auto target_type(const TargetType type) noexcept -> void;
+  auto
+  set_property_target(const sourcemeta::jsontoolkit::JSON::String &property)
+      -> void;
+  auto unset_property_target() -> void;
+
   auto resolve_target() -> const sourcemeta::jsontoolkit::JSON &;
   auto resolve_string_target() -> std::optional<
       std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>;
@@ -133,7 +136,9 @@ private:
   const std::hash<std::string> hasher_{};
   std::vector<std::size_t> resources_;
   std::map<std::size_t, const std::reference_wrapper<const Template>> labels;
-  bool property_as_instance{false};
+  std::optional<
+      std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
+      property_target;
 
   // TODO: Turn these into a trie
   std::vector<std::pair<sourcemeta::jsontoolkit::WeakPointer,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
