### PR TITLE
Add a meaningless `not` on the `unevaluatedProperties` benchmark case

### DIFF
--- a/benchmark/evaluator_2019_09.cc
+++ b/benchmark/evaluator_2019_09.cc
@@ -17,6 +17,9 @@ static void Evaluator_2019_09_Unevaluated_Properties(benchmark::State &state) {
       "name": true,
       "prohibited": false
     },
+    "not": {
+      "required": [ "prohibited" ]
+    },
     "unevaluatedProperties": false,
     "$ref": "#/$defs/extension",
     "$defs": {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
