### PR TITLE
Apply `PropertyType` object optimizations when marking evaluation

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -1334,7 +1334,49 @@ struct DescribeVisitor {
     return message.str();
   }
 
+  auto operator()(const AssertionPropertyTypeEvaluate &step) const
+      -> std::string {
+    std::ostringstream message;
+    const auto &value{step_value(step)};
+    if (!this->valid && value == sourcemeta::jsontoolkit::JSON::Type::Real &&
+        this->target.type() == sourcemeta::jsontoolkit::JSON::Type::Integer) {
+      message
+          << "The value was expected to be a real number but it was an integer";
+    } else if (!this->valid &&
+               value == sourcemeta::jsontoolkit::JSON::Type::Integer &&
+               this->target.type() ==
+                   sourcemeta::jsontoolkit::JSON::Type::Real) {
+      message
+          << "The value was expected to be an integer but it was a real number";
+    } else {
+      describe_type_check(this->valid, this->target.type(), value, message);
+    }
+
+    return message.str();
+  }
+
   auto operator()(const AssertionPropertyTypeStrict &step) const
+      -> std::string {
+    std::ostringstream message;
+    const auto &value{step_value(step)};
+    if (!this->valid && value == sourcemeta::jsontoolkit::JSON::Type::Real &&
+        this->target.type() == sourcemeta::jsontoolkit::JSON::Type::Integer) {
+      message
+          << "The value was expected to be a real number but it was an integer";
+    } else if (!this->valid &&
+               value == sourcemeta::jsontoolkit::JSON::Type::Integer &&
+               this->target.type() ==
+                   sourcemeta::jsontoolkit::JSON::Type::Real) {
+      message
+          << "The value was expected to be an integer but it was a real number";
+    } else {
+      describe_type_check(this->valid, this->target.type(), value, message);
+    }
+
+    return message.str();
+  }
+
+  auto operator()(const AssertionPropertyTypeStrictEvaluate &step) const
       -> std::string {
     std::ostringstream message;
     const auto &value{step_value(step)};

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -235,7 +235,11 @@ struct StepVisitor {
   HANDLE_STEP("assertion", "divisible", AssertionDivisible)
   HANDLE_STEP("assertion", "string-type", AssertionStringType)
   HANDLE_STEP("assertion", "property-type", AssertionPropertyType)
+  HANDLE_STEP("assertion", "property-type-evaluate",
+              AssertionPropertyTypeEvaluate)
   HANDLE_STEP("assertion", "property-type-strict", AssertionPropertyTypeStrict)
+  HANDLE_STEP("assertion", "property-type-strict-evaluate",
+              AssertionPropertyTypeStrictEvaluate)
   HANDLE_STEP("assertion", "array-prefix", AssertionArrayPrefix)
   HANDLE_STEP("assertion", "equals-any", AssertionEqualsAny)
   HANDLE_STEP("annotation", "emit", AnnotationEmit)

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -458,6 +458,30 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
       EVALUATE_END(assertion, AssertionPropertyType);
     }
 
+    case IS_STEP(AssertionPropertyTypeEvaluate): {
+      EVALUATE_BEGIN_TRY_TARGET(
+          assertion, AssertionPropertyTypeEvaluate,
+          // Note that here are are referring to the parent
+          // object that might hold the given property,
+          // before traversing into the actual property
+          target.is_object());
+      // Now here we refer to the actual property
+      const auto &effective_target{context.resolve_target()};
+      // In non-strict mode, we consider a real number that represents an
+      // integer to be an integer
+      result =
+          effective_target.type() == assertion.value ||
+          (assertion.value == sourcemeta::jsontoolkit::JSON::Type::Integer &&
+           effective_target.is_integer_real());
+
+      if (result) {
+        assert(track);
+        context.evaluate();
+      }
+
+      EVALUATE_END(assertion, AssertionPropertyTypeEvaluate);
+    }
+
     case IS_STEP(AssertionPropertyTypeStrict): {
       EVALUATE_BEGIN_TRY_TARGET(
           assertion, AssertionPropertyTypeStrict,
@@ -468,6 +492,24 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
       // Now here we refer to the actual property
       result = context.resolve_target().type() == assertion.value;
       EVALUATE_END(assertion, AssertionPropertyTypeStrict);
+    }
+
+    case IS_STEP(AssertionPropertyTypeStrictEvaluate): {
+      EVALUATE_BEGIN_TRY_TARGET(
+          assertion, AssertionPropertyTypeStrictEvaluate,
+          // Note that here are are referring to the parent
+          // object that might hold the given property,
+          // before traversing into the actual property
+          target.is_object());
+      // Now here we refer to the actual property
+      result = context.resolve_target().type() == assertion.value;
+
+      if (result) {
+        assert(track);
+        context.evaluate();
+      }
+
+      EVALUATE_END(assertion, AssertionPropertyTypeStrictEvaluate);
     }
 
     case IS_STEP(AssertionArrayPrefix): {

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
@@ -42,7 +42,9 @@ struct AssertionUnique;
 struct AssertionDivisible;
 struct AssertionStringType;
 struct AssertionPropertyType;
+struct AssertionPropertyTypeEvaluate;
 struct AssertionPropertyTypeStrict;
+struct AssertionPropertyTypeStrictEvaluate;
 struct AssertionArrayPrefix;
 struct AnnotationEmit;
 struct AnnotationToParent;
@@ -90,10 +92,12 @@ using Template = std::vector<std::variant<
     AssertionObjectSizeGreater, AssertionEqual, AssertionEqualsAny,
     AssertionGreaterEqual, AssertionLessEqual, AssertionGreater, AssertionLess,
     AssertionUnique, AssertionDivisible, AssertionStringType,
-    AssertionPropertyType, AssertionPropertyTypeStrict, AssertionArrayPrefix,
-    AnnotationEmit, AnnotationToParent, AnnotationBasenameToParent, LogicalNot,
-    LogicalOr, LogicalAnd, LogicalXor, LogicalCondition, LogicalWhenType,
-    LogicalWhenDefines, LogicalWhenArraySizeGreater, LoopPropertiesUnevaluated,
+    AssertionPropertyType, AssertionPropertyTypeEvaluate,
+    AssertionPropertyTypeStrict, AssertionPropertyTypeStrictEvaluate,
+    AssertionArrayPrefix, AnnotationEmit, AnnotationToParent,
+    AnnotationBasenameToParent, LogicalNot, LogicalOr, LogicalAnd, LogicalXor,
+    LogicalCondition, LogicalWhenType, LogicalWhenDefines,
+    LogicalWhenArraySizeGreater, LoopPropertiesUnevaluated,
     LoopItemsUnevaluated, LoopPropertiesMatch, LoopProperties,
     LoopPropertiesEvaluate, LoopPropertiesRegex, LoopPropertiesExcept,
     LoopPropertiesType, LoopPropertiesTypeEvaluate, LoopPropertiesTypeStrict,
@@ -133,7 +137,9 @@ enum class TemplateIndex : std::uint8_t {
   AssertionDivisible,
   AssertionStringType,
   AssertionPropertyType,
+  AssertionPropertyTypeEvaluate,
   AssertionPropertyTypeStrict,
+  AssertionPropertyTypeStrictEvaluate,
   AssertionArrayPrefix,
   AnnotationEmit,
   AnnotationToParent,
@@ -342,8 +348,18 @@ DEFINE_STEP_WITH_VALUE(Assertion, PropertyType, ValueType)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks that an instance
+/// property is of a given type if present and marks evaluation
+DEFINE_STEP_WITH_VALUE(Assertion, PropertyTypeEvaluate, ValueType)
+
+/// @ingroup evaluator_instructions
+/// @brief Represents a compiler assertion step that checks that an instance
 /// property is of a given type if present (strict mode)
 DEFINE_STEP_WITH_VALUE(Assertion, PropertyTypeStrict, ValueType)
+
+/// @ingroup evaluator_instructions
+/// @brief Represents a compiler assertion step that checks that an instance
+/// property is of a given type if present (strict mode) and marks evaluation
+DEFINE_STEP_WITH_VALUE(Assertion, PropertyTypeStrictEvaluate, ValueType)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that applies substeps to the

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -2668,40 +2668,31 @@ TEST(Evaluator_2019_09, unevaluatedProperties_1) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"baz\", \"bar\": true }")};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 5);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
 
-  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                     "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(2, ControlEvaluate, "/properties", "#/properties", "/foo");
-  EVALUATE_TRACE_PRE(3, LoopPropertiesUnevaluated, "/unevaluatedProperties",
+  EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrictEvaluate,
+                     "/properties/foo/type", "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
-  EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/unevaluatedProperties/type",
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/unevaluatedProperties/type",
                      "#/unevaluatedProperties/type", "/bar");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
-                              "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/properties", "#/properties",
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrictEvaluate,
+                              "/properties/foo/type", "#/properties/foo/type",
                               "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
-  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
                               "/unevaluatedProperties/type",
                               "#/unevaluatedProperties/type", "/bar");
-  EVALUATE_TRACE_POST_SUCCESS(4, LoopPropertiesUnevaluated,
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesUnevaluated,
                               "/unevaluatedProperties",
                               "#/unevaluatedProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The object value was expected to validate "
-                               "against the single defined property subschema");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
                                "The value was expected to be of type boolean");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 4,
+      instance, 2,
       "The object properties not covered by other object keywords were "
       "expected to validate against this subschema");
 }
@@ -2724,8 +2715,8 @@ TEST(Evaluator_2019_09, unevaluatedProperties_1_exhaustive) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(2, ControlEvaluate, "/properties", "#/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(3, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/properties", "#/properties", "/foo");
   EVALUATE_TRACE_PRE(4, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/unevaluatedProperties/type",
@@ -2735,9 +2726,9 @@ TEST(Evaluator_2019_09, unevaluatedProperties_1_exhaustive) {
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/properties", "#/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, ControlEvaluate, "/properties", "#/properties",
                               "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(4, AssertionTypeStrict,
                               "/unevaluatedProperties/type",
@@ -2751,10 +2742,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_1_exhaustive) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
                                "The object value was expected to validate "
                                "against the single defined property subschema");
@@ -2787,49 +2778,37 @@ TEST(Evaluator_2019_09, unevaluatedProperties_2) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"baz\", \"bar\": true }")};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 6);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 4);
 
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_PRE(1, LogicalAnd, "/allOf/0/properties",
-                     "#/allOf/0/properties", "");
-  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrictEvaluate,
+                     "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/allOf/0/properties",
-                     "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesUnevaluated, "/unevaluatedProperties",
+  EVALUATE_TRACE_PRE(2, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
-  EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/unevaluatedProperties/type",
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/unevaluatedProperties/type",
                      "#/unevaluatedProperties/type", "/bar");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrictEvaluate,
                               "/allOf/0/properties/foo/type",
                               "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/allOf/0/properties",
-                              "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf/0/properties",
-                              "#/allOf/0/properties", "");
-  EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_POST_SUCCESS(4, AssertionTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/allOf", "#/allOf", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict,
                               "/unevaluatedProperties/type",
                               "#/unevaluatedProperties/type", "/bar");
-  EVALUATE_TRACE_POST_SUCCESS(5, LoopPropertiesUnevaluated,
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesUnevaluated,
                               "/unevaluatedProperties",
                               "#/unevaluatedProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The object value was expected to validate "
-                               "against the single defined property subschema");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 3,
+      instance, 1,
       "The object value was expected to validate against the given subschema");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The value was expected to be of type boolean");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 5,
+      instance, 3,
       "The object properties not covered by other object keywords were "
       "expected to validate against this subschema");
 }
@@ -2858,10 +2837,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_2_exhaustive) {
                      "#/allOf/0/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/allOf/0/properties",
-                     "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(4, "/allOf/0/properties",
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/allOf/0/properties",
                                 "#/allOf/0/properties", "");
+  EVALUATE_TRACE_PRE(4, ControlEvaluate, "/allOf/0/properties",
+                     "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_PRE(5, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(6, AssertionTypeStrict, "/unevaluatedProperties/type",
@@ -2872,10 +2851,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_2_exhaustive) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/allOf/0/properties/foo/type",
                               "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/allOf/0/properties",
-                              "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(2, "/allOf/0/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/allOf/0/properties",
                                  "#/allOf/0/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, ControlEvaluate, "/allOf/0/properties",
+                              "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf/0/properties",
                               "#/allOf/0/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/allOf", "#/allOf", "");
@@ -2891,10 +2870,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_2_exhaustive) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
                                "The object value was expected to validate "
                                "against the single defined property subschema");
@@ -2930,50 +2909,38 @@ TEST(Evaluator_2019_09, unevaluatedProperties_3) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"baz\", \"bar\": 1 }")};
 
-  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 6);
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 4);
 
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_PRE(1, LogicalAnd, "/allOf/0/properties",
-                     "#/allOf/0/properties", "");
-  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrictEvaluate,
+                     "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/allOf/0/properties",
-                     "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesUnevaluated, "/unevaluatedProperties",
+  EVALUATE_TRACE_PRE(2, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
-  EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/unevaluatedProperties/type",
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/unevaluatedProperties/type",
                      "#/unevaluatedProperties/type", "/bar");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrictEvaluate,
                               "/allOf/0/properties/foo/type",
                               "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/allOf/0/properties",
-                              "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf/0/properties",
-                              "#/allOf/0/properties", "");
-  EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_POST_FAILURE(4, AssertionTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/allOf", "#/allOf", "");
+  EVALUATE_TRACE_POST_FAILURE(2, AssertionTypeStrict,
                               "/unevaluatedProperties/type",
                               "#/unevaluatedProperties/type", "/bar");
-  EVALUATE_TRACE_POST_FAILURE(5, LoopPropertiesUnevaluated,
+  EVALUATE_TRACE_POST_FAILURE(3, LoopPropertiesUnevaluated,
                               "/unevaluatedProperties",
                               "#/unevaluatedProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The object value was expected to validate "
-                               "against the single defined property subschema");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 3,
+      instance, 1,
       "The object value was expected to validate against the given subschema");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The value was expected to be of type boolean "
                                "but it was of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 5,
+      instance, 3,
       "The object properties not covered by other object keywords were "
       "expected to validate against this subschema");
 }
@@ -3002,10 +2969,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_3_exhaustive) {
                      "#/allOf/0/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/allOf/0/properties",
-                     "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(4, "/allOf/0/properties",
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/allOf/0/properties",
                                 "#/allOf/0/properties", "");
+  EVALUATE_TRACE_PRE(4, ControlEvaluate, "/allOf/0/properties",
+                     "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_PRE(5, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(6, AssertionTypeStrict, "/unevaluatedProperties/type",
@@ -3014,10 +2981,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_3_exhaustive) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/allOf/0/properties/foo/type",
                               "#/allOf/0/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/allOf/0/properties",
-                              "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(2, "/allOf/0/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/allOf/0/properties",
                                  "#/allOf/0/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, ControlEvaluate, "/allOf/0/properties",
+                              "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf/0/properties",
                               "#/allOf/0/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/allOf", "#/allOf", "");
@@ -3031,10 +2998,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_3_exhaustive) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
                                "The object value was expected to validate "
                                "against the single defined property subschema");
@@ -3063,40 +3030,31 @@ TEST(Evaluator_2019_09, unevaluatedProperties_4) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"baz\", \"bar\": true }")};
 
-  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 5);
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 3);
 
-  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                     "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(2, ControlEvaluate, "/properties", "#/properties", "/foo");
-  EVALUATE_TRACE_PRE(3, LoopPropertiesUnevaluated, "/unevaluatedProperties",
+  EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrictEvaluate,
+                     "/properties/foo/type", "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
-  EVALUATE_TRACE_PRE(4, AssertionFail, "/unevaluatedProperties",
+  EVALUATE_TRACE_PRE(2, AssertionFail, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "/bar");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
-                              "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/properties", "#/properties",
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrictEvaluate,
+                              "/properties/foo/type", "#/properties/foo/type",
                               "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
-  EVALUATE_TRACE_POST_FAILURE(3, AssertionFail, "/unevaluatedProperties",
+  EVALUATE_TRACE_POST_FAILURE(1, AssertionFail, "/unevaluatedProperties",
                               "#/unevaluatedProperties", "/bar");
-  EVALUATE_TRACE_POST_FAILURE(4, LoopPropertiesUnevaluated,
+  EVALUATE_TRACE_POST_FAILURE(2, LoopPropertiesUnevaluated,
                               "/unevaluatedProperties",
                               "#/unevaluatedProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The object value was expected to validate "
-                               "against the single defined property subschema");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 3,
+      instance, 1,
       "The object value was not expected to define the property \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 4,
+      instance, 2,
       "The object value was not expected to define unevaluated properties");
 }
 
@@ -3118,8 +3076,8 @@ TEST(Evaluator_2019_09, unevaluatedProperties_4_exhaustive) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(2, ControlEvaluate, "/properties", "#/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(3, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/properties", "#/properties", "/foo");
   EVALUATE_TRACE_PRE(4, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(5, AssertionFail, "/unevaluatedProperties",
@@ -3127,9 +3085,9 @@ TEST(Evaluator_2019_09, unevaluatedProperties_4_exhaustive) {
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/properties", "#/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, ControlEvaluate, "/properties", "#/properties",
                               "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_FAILURE(4, AssertionFail, "/unevaluatedProperties",
                               "#/unevaluatedProperties", "/bar");
@@ -3140,10 +3098,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_4_exhaustive) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
                                "The object value was expected to validate "
                                "against the single defined property subschema");
@@ -3389,20 +3347,20 @@ TEST(Evaluator_2019_09, unevaluatedProperties_7_exhaustive) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "#/allOf", "");
   EVALUATE_TRACE_PRE(1, LogicalAnd, "/allOf/0/properties",
                      "#/allOf/0/properties", "");
-  EVALUATE_TRACE_PRE(2, ControlEvaluate, "/allOf/0/properties",
-                     "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(3, "/allOf/0/properties",
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/allOf/0/properties",
                                 "#/allOf/0/properties", "");
+  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/allOf/0/properties",
+                     "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_PRE(4, LoopPropertiesUnevaluated,
                      "/allOf/1/unevaluatedProperties",
                      "#/allOf/1/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(5, AssertionFail, "/allOf/1/unevaluatedProperties",
                      "#/allOf/1/unevaluatedProperties", "/foo");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, ControlEvaluate, "/allOf/0/properties",
-                              "#/allOf/0/properties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(1, "/allOf/0/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/allOf/0/properties",
                                  "#/allOf/0/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/allOf/0/properties",
+                              "#/allOf/0/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf/0/properties",
                               "#/allOf/0/properties", "");
   EVALUATE_TRACE_POST_FAILURE(3, AssertionFail,
@@ -3414,10 +3372,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_7_exhaustive) {
   EVALUATE_TRACE_POST_FAILURE(5, LogicalAnd, "/allOf", "#/allOf", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object value was expected to validate "
                                "against the single defined property subschema");
@@ -3508,19 +3466,19 @@ TEST(Evaluator_2019_09, unevaluatedProperties_8_exhaustive) {
   EVALUATE_TRACE_PRE(1, LogicalNot, "/not/not", "#/not/not", "");
   EVALUATE_TRACE_PRE(2, LogicalAnd, "/not/not/properties",
                      "#/not/not/properties", "");
-  EVALUATE_TRACE_PRE(3, ControlEvaluate, "/not/not/properties",
-                     "#/not/not/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION(4, "/not/not/properties",
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/not/not/properties",
                                 "#/not/not/properties", "");
+  EVALUATE_TRACE_PRE(4, ControlEvaluate, "/not/not/properties",
+                     "#/not/not/properties", "/foo");
   EVALUATE_TRACE_PRE(5, LoopPropertiesUnevaluated, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "");
   EVALUATE_TRACE_PRE(6, AssertionFail, "/unevaluatedProperties",
                      "#/unevaluatedProperties", "/foo");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, ControlEvaluate, "/not/not/properties",
-                              "#/not/not/properties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION(1, "/not/not/properties",
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/not/not/properties",
                                  "#/not/not/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, ControlEvaluate, "/not/not/properties",
+                              "#/not/not/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/not/not/properties",
                               "#/not/not/properties", "");
   EVALUATE_TRACE_POST_FAILURE(3, LogicalNot, "/not/not", "#/not/not", "");
@@ -3532,10 +3490,10 @@ TEST(Evaluator_2019_09, unevaluatedProperties_8_exhaustive) {
                               "#/unevaluatedProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The instance location was marked as evaluated");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The object property \"foo\" successfully "
                                "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The instance location was marked as evaluated");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The object value was expected to validate "
                                "against the single defined property subschema");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
