### PR TITLE
Ensure `LoopPropertiesStartsWith` is not emitted with empty children

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -1081,6 +1081,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopPropertiesStartsWith): {
       EVALUATE_BEGIN(loop, LoopPropertiesStartsWith, target.is_object());
+      assert(!loop.children.empty());
       result = true;
       for (const auto &entry : target.as_object()) {
         if (!entry.first.starts_with(loop.value)) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
