### PR TITLE
Ensure `LoopProperties(Evaluate)` is never emitted without children

### DIFF
--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -786,6 +786,11 @@ auto compiler_draft4_applicator_additionalproperties_with_options(
     }
 
   } else if (track_evaluation) {
+    if (children.empty()) {
+      return {make<ControlEvaluate>(context, schema_context, dynamic_context,
+                                    ValuePointer{})};
+    }
+
     return {make<LoopPropertiesEvaluate>(context, schema_context,
                                          dynamic_context, ValueNone{},
                                          std::move(children))};

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -1008,6 +1008,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopProperties): {
       EVALUATE_BEGIN(loop, LoopProperties, target.is_object());
+      assert(!loop.children.empty());
       result = true;
       for (const auto &entry : target.as_object()) {
         context.enter(entry.first, track);
@@ -1030,6 +1031,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopPropertiesEvaluate): {
       EVALUATE_BEGIN(loop, LoopPropertiesEvaluate, target.is_object());
+      assert(!loop.children.empty());
       result = true;
       for (const auto &entry : target.as_object()) {
         context.enter(entry.first, track);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
