### PR TITLE
Ensure `LoopItemsUnevaluated` is never emitted without children

### DIFF
--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -229,6 +229,11 @@ auto compiler_2019_09_applicator_unevaluateditems(
         sourcemeta::jsontoolkit::JSON{true}));
   }
 
+  if (children.empty()) {
+    return {make<ControlEvaluate>(context, schema_context, dynamic_context,
+                                  ValuePointer{})};
+  }
+
   // TODO: Attempt to short-circuit evaluation tracking by looking at sibling
   // and adjacent keywords like we do for `unevaluatedProperties`
 

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -951,6 +951,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopItemsUnevaluated): {
       EVALUATE_BEGIN(loop, LoopItemsUnevaluated, target.is_array());
+      assert(!loop.children.empty());
       assert(track);
       const auto &array{target.as_array()};
       result = true;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
