### PR TITLE
Ensure `LoopPropertiesUnevaluated(Except)` always has children

### DIFF
--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -292,8 +292,11 @@ auto compiler_2019_09_applicator_unevaluatedproperties(
     }
   }
 
-  if (!filter_strings.empty() || !filter_prefixes.empty() ||
-      !filter_regexes.empty()) {
+  if (children.empty()) {
+    return {make<ControlEvaluate>(context, schema_context, dynamic_context,
+                                  ValuePointer{})};
+  } else if (!filter_strings.empty() || !filter_prefixes.empty() ||
+             !filter_regexes.empty()) {
     return {make<LoopPropertiesUnevaluatedExcept>(
         context, schema_context, dynamic_context,
         ValuePropertyFilter{std::move(filter_strings),

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -865,6 +865,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopPropertiesUnevaluated): {
       EVALUATE_BEGIN(loop, LoopPropertiesUnevaluated, target.is_object());
+      assert(!loop.children.empty());
       assert(track);
       result = true;
 
@@ -895,6 +896,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(LoopPropertiesUnevaluatedExcept): {
       EVALUATE_BEGIN(loop, LoopPropertiesUnevaluatedExcept, target.is_object());
+      assert(!loop.children.empty());
       assert(track);
       result = true;
       // Otherwise why emit this instruction?


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
