### PR TITLE
Recursively consider template size when re-ordering `properties`

### DIFF
--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -9,6 +9,7 @@
 #include <iterator>  // std::distance
 #include <regex>     // std::regex, std::regex_match, std::smatch
 #include <utility>   // std::declval, std::move
+#include <variant>   // std::visit
 
 namespace sourcemeta::blaze {
 
@@ -207,6 +208,21 @@ inline auto find_adjacent(const Context &context,
         subschema.type() == type) {
       result.emplace_back(subschema);
     }
+  }
+
+  return result;
+}
+
+inline auto recursive_template_size(const Template &steps) -> std::size_t {
+  std::size_t result{steps.size()};
+  for (const auto &variant : steps) {
+    std::visit(
+        [&result](const auto &step) {
+          if constexpr (requires { step.children; }) {
+            result += recursive_template_size(step.children);
+          }
+        },
+        variant);
   }
 
   return result;

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -531,9 +531,10 @@ auto compiler_draft4_applicator_properties_with_options(
   // earlier without spending a lot of time on other subschemas
   std::sort(properties.begin(), properties.end(),
             [](const auto &left, const auto &right) {
-              return (left.second.size() == right.second.size())
-                         ? (left.first < right.first)
-                         : (left.second.size() < right.second.size());
+              const auto left_size{recursive_template_size(left.second)};
+              const auto right_size{recursive_template_size(right.second)};
+              return (left_size == right_size) ? (left.first < right.first)
+                                               : (left_size < right_size);
             });
 
   assert(schema_context.relative_pointer.back().is_property());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
