### PR TITLE
Implement a smarter `properties` unroll check for `anyOf`/`oneOf`

### DIFF
--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -627,8 +627,7 @@ auto compiler_draft4_applicator_properties_with_options(
       // Always unroll inside `oneOf` or `anyOf`, to have a
       // better chance at quickly short-circuiting
       (!inside_disjunctor ||
-       (!defines_direct_enumeration(properties.front().second).has_value() &&
-        properties.front().second.size() > 1))};
+       (!defines_direct_enumeration(properties.front().second).has_value()))};
 
   if (prefer_loop_over_instance) {
     ValueNamedIndexes indexes;

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -620,15 +620,15 @@ auto compiler_draft4_applicator_properties_with_options(
   const auto prefer_loop_over_instance{
       // This strategy only makes sense if most of the properties are "optional"
       is_required <= (size / 4) &&
-      // If `properties` only defines a relatively small amount of properties,
+      // If `properties` only defines a relatively small amount of
+      // properties,
       // then its probably still faster to unroll
       size > 5 &&
-      // Unless the properties definition has a LOT of optional properties,
-      // we should unroll inside `oneOf` or `anyOf`, to have a better chance at
-      // short-circuiting quickly
-      // TODO: Maybe the proper middle ground here is to ONLY
-      // unroll properties with `const`/`enum`?
-      (!inside_disjunctor || (is_required == 0 && size > 20))};
+      // Always unroll inside `oneOf` or `anyOf`, to have a
+      // better chance at quickly short-circuiting
+      (!inside_disjunctor ||
+       (!defines_direct_enumeration(properties.front().second).has_value() &&
+        properties.front().second.size() > 1))};
 
   if (prefer_loop_over_instance) {
     ValueNamedIndexes indexes;

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -3300,16 +3300,16 @@ TEST(Evaluator_draft4, anyOf_4) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
 
   EVALUATE_TRACE_PRE(0, LogicalOr, "/anyOf", "#/anyOf", "");
-  EVALUATE_TRACE_PRE(1, LogicalAnd, "/anyOf/0/$ref/properties",
+  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/anyOf/0/$ref/properties",
                      "#/definitions/test/properties", "");
-  EVALUATE_TRACE_PRE(2, AssertionPropertyTypeStrict,
-                     "/anyOf/0/$ref/properties/a/type",
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/anyOf/0/$ref/properties/a/type",
                      "#/definitions/test/properties/a/type", "/a");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrict,
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/anyOf/0/$ref/properties/a/type",
                               "#/definitions/test/properties/a/type", "/a");
-  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/anyOf/0/$ref/properties",
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch,
+                              "/anyOf/0/$ref/properties",
                               "#/definitions/test/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalOr, "/anyOf", "#/anyOf", "");
 
@@ -3317,7 +3317,7 @@ TEST(Evaluator_draft4, anyOf_4) {
                                "The value was expected to be of type string");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The object value was expected to validate "
-                               "against the defined properties subschemas");
+                               "against the 11 defined properties subschemas");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 2,
       "The object value was expected to validate against at least one of the 2 "


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
