### PR TITLE
Don't run non-JSON GoogleBenchmark output on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,6 @@ jobs:
           # See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
           UBSAN_OPTIONS: print_stacktrace=1
 
-      - run: cmake --build ./build --config Release --verbose --target benchmark_all
-        if: matrix.platform.benchmark
       - run: cmake --build ./build --config Release --verbose --target benchmark_json
         if: matrix.platform.benchmark
 


### PR DESCRIPTION
We don't really need it, nor read it.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
