### PR TITLE
Rename `ErrorTraceOutput` to `ErrorOutput`

### DIFF
--- a/src/compiler/compile_output.cc
+++ b/src/compiler/compile_output.cc
@@ -9,28 +9,23 @@
 
 namespace sourcemeta::blaze {
 
-ErrorTraceOutput::ErrorTraceOutput(
-    const sourcemeta::jsontoolkit::JSON &instance,
-    const sourcemeta::jsontoolkit::WeakPointer &base)
+ErrorOutput::ErrorOutput(const sourcemeta::jsontoolkit::JSON &instance,
+                         const sourcemeta::jsontoolkit::WeakPointer &base)
     : instance_{instance}, base_{base} {}
 
-auto ErrorTraceOutput::begin() const -> const_iterator {
+auto ErrorOutput::begin() const -> const_iterator {
   return this->output.begin();
 }
 
-auto ErrorTraceOutput::end() const -> const_iterator {
-  return this->output.end();
-}
+auto ErrorOutput::end() const -> const_iterator { return this->output.end(); }
 
-auto ErrorTraceOutput::cbegin() const -> const_iterator {
+auto ErrorOutput::cbegin() const -> const_iterator {
   return this->output.cbegin();
 }
 
-auto ErrorTraceOutput::cend() const -> const_iterator {
-  return this->output.cend();
-}
+auto ErrorOutput::cend() const -> const_iterator { return this->output.cend(); }
 
-auto ErrorTraceOutput::operator()(
+auto ErrorOutput::operator()(
     const EvaluationType type, const bool result,
     const Template::value_type &step,
     const sourcemeta::jsontoolkit::WeakPointer &evaluate_path,

--- a/src/compiler/include/sourcemeta/blaze/compiler_output.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_output.h
@@ -44,7 +44,7 @@ namespace sourcemeta::blaze {
 ///
 /// const sourcemeta::jsontoolkit::JSON instance{5};
 ///
-/// sourcemeta::blaze::ErrorTraceOutput output;
+/// sourcemeta::blaze::ErrorOutput output;
 /// const auto result{sourcemeta::blaze::evaluate(
 ///   schema_template, instance, std::ref(output))};
 ///
@@ -58,15 +58,15 @@ namespace sourcemeta::blaze {
 ///   }
 /// }
 /// ```
-class SOURCEMETA_BLAZE_COMPILER_EXPORT ErrorTraceOutput {
+class SOURCEMETA_BLAZE_COMPILER_EXPORT ErrorOutput {
 public:
-  ErrorTraceOutput(const sourcemeta::jsontoolkit::JSON &instance,
-                   const sourcemeta::jsontoolkit::WeakPointer &base =
-                       sourcemeta::jsontoolkit::empty_weak_pointer);
+  ErrorOutput(const sourcemeta::jsontoolkit::JSON &instance,
+              const sourcemeta::jsontoolkit::WeakPointer &base =
+                  sourcemeta::jsontoolkit::empty_weak_pointer);
 
   // Prevent accidental copies
-  ErrorTraceOutput(const ErrorTraceOutput &) = delete;
-  auto operator=(const ErrorTraceOutput &) -> ErrorTraceOutput & = delete;
+  ErrorOutput(const ErrorOutput &) = delete;
+  auto operator=(const ErrorOutput &) -> ErrorOutput & = delete;
 
   struct Entry {
     const std::string message;

--- a/test/compiler/CMakeLists.txt
+++ b/test/compiler/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(sourcemeta_blaze_compiler_unit
   compiler_json_test.cc
   compiler_template_format_test.cc
-  compiler_output_error_trace_test.cc)
+  compiler_output_error_test.cc)
 noa_add_default_options(PRIVATE sourcemeta_blaze_compiler_unit)
 target_link_libraries(sourcemeta_blaze_compiler_unit
   PRIVATE GTest::gtest)

--- a/test/compiler/compiler_output_error_test.cc
+++ b/test/compiler/compiler_output_error_test.cc
@@ -31,13 +31,13 @@ TEST(Compiler_output_error_trace, success_string_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
@@ -69,13 +69,13 @@ TEST(Compiler_output_error_trace, fail_meaningless_if_1) {
     "bar": { "qux": {} }
   })JSON")};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 2);
 
@@ -107,13 +107,13 @@ TEST(Compiler_output_error_trace, success_dynamic_anchor_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
@@ -134,13 +134,13 @@ TEST(Compiler_output_error_trace, success_oneof_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{"fo"};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
@@ -158,13 +158,13 @@ TEST(Compiler_output_error_trace, fail_string) {
 
   const sourcemeta::jsontoolkit::JSON instance{5};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -191,13 +191,13 @@ TEST(Compiler_output_error_trace, fail_string_over_ref) {
 
   const sourcemeta::jsontoolkit::JSON instance{5};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -226,13 +226,13 @@ TEST(Compiler_output_error_trace, fail_string_with_matching_base) {
 
   const std::string ref = "$ref";
   const sourcemeta::jsontoolkit::WeakPointer pointer{std::cref(ref)};
-  sourcemeta::blaze::ErrorTraceOutput output{instance, pointer};
+  sourcemeta::blaze::ErrorOutput output{instance, pointer};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -260,13 +260,13 @@ TEST(Compiler_output_error_trace, fail_string_with_non_matching_base) {
   const sourcemeta::jsontoolkit::JSON instance{5};
   const std::string foo = "foo";
   const sourcemeta::jsontoolkit::WeakPointer pointer{std::cref(foo)};
-  sourcemeta::blaze::ErrorTraceOutput output{instance, pointer};
+  sourcemeta::blaze::ErrorOutput output{instance, pointer};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -291,13 +291,13 @@ TEST(Compiler_output_error_trace, fail_oneof_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/oneOf",
@@ -321,13 +321,13 @@ TEST(Compiler_output_error_trace, fail_not_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/not",
@@ -353,13 +353,13 @@ TEST(Compiler_output_error_trace, fail_not_not_1) {
 
   const sourcemeta::jsontoolkit::JSON instance{1};
 
-  sourcemeta::blaze::ErrorTraceOutput output{instance};
+  sourcemeta::blaze::ErrorOutput output{instance};
   const auto result{
       sourcemeta::blaze::evaluate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorTraceOutput::Entry> traces{
-      output.cbegin(), output.cend()};
+  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
+                                                            output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/not",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
