### PR TITLE
Fix crash when describing `pattern` inside `propertyNames`

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -1004,6 +1004,20 @@ struct DescribeVisitor {
   }
 
   auto operator()(const AssertionRegex &step) const -> std::string {
+    if (this->evaluate_path.size() > 1 &&
+        this->evaluate_path.at(this->evaluate_path.size() - 2).is_property() &&
+        this->evaluate_path.at(this->evaluate_path.size() - 2).to_property() ==
+            "propertyNames" &&
+        !this->instance_location.empty() &&
+        this->instance_location.back().is_property()) {
+      std::ostringstream message;
+      message << "The property name "
+              << escape_string(this->instance_location.back().to_property())
+              << " was expected to match the regular expression "
+              << escape_string(step_value(step).second);
+      return message.str();
+    }
+
     assert(this->target.is_string());
     std::ostringstream message;
     message << "The string value " << escape_string(this->target.to_string())

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -756,6 +756,34 @@ TEST(Evaluator_draft6, propertyNames_5) {
   }
 }
 
+TEST(Evaluator_draft6, propertyNames_6) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "propertyNames": { "pattern": "^f" }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"bar\": 2 }")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 2);
+
+  EVALUATE_TRACE_PRE(0, LoopKeys, "/propertyNames", "#/propertyNames", "");
+  EVALUATE_TRACE_PRE(1, AssertionRegex, "/propertyNames/pattern",
+                     "#/propertyNames/pattern", "/bar");
+
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionRegex, "/propertyNames/pattern",
+                              "#/propertyNames/pattern", "/bar");
+  EVALUATE_TRACE_POST_FAILURE(1, LoopKeys, "/propertyNames", "#/propertyNames",
+                              "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The property name \"bar\" was expected to "
+                               "match the regular expression \"^f\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object property \"bar\" was expected to "
+                               "validate against the given subschema");
+}
+
 TEST(Evaluator_draft6, invalid_ref_top_level) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
