### PR TITLE
Speed up `enum` checks with `unordered_set` and `fast_hash`

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -1402,9 +1402,12 @@ struct DescribeVisitor {
                 << " declared values";
       } else {
         message << " was expected to equal one of the following values: ";
-        for (auto iterator = value.cbegin(); iterator != value.cend();
+        std::vector<sourcemeta::jsontoolkit::JSON> copy{value.cbegin(),
+                                                        value.cend()};
+        std::sort(copy.begin(), copy.end());
+        for (auto iterator = copy.cbegin(); iterator != copy.cend();
              ++iterator) {
-          if (std::next(iterator) == value.cend()) {
+          if (std::next(iterator) == copy.cend()) {
             message << "and ";
             stringify(*iterator, message);
           } else {

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -60,8 +60,8 @@ auto value_to_json(const T &value) -> sourcemeta::jsontoolkit::JSON {
 
     result.assign("value", std::move(items));
     return result;
-  } else if constexpr (std::is_same_v<ValueArray, T>) {
-    result.assign("type", sourcemeta::jsontoolkit::JSON{"array"});
+  } else if constexpr (std::is_same_v<ValueSet, T>) {
+    result.assign("type", sourcemeta::jsontoolkit::JSON{"set"});
     sourcemeta::jsontoolkit::JSON items{
         sourcemeta::jsontoolkit::JSON::make_array()};
     for (const auto &item : value) {

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -1431,10 +1431,10 @@ auto compiler_draft4_validation_enum(const Context &context,
             schema_context.schema.at(dynamic_context.keyword).front()})};
   }
 
-  std::vector<sourcemeta::jsontoolkit::JSON> options;
+  ValueSet options;
   for (const auto &option :
        schema_context.schema.at(dynamic_context.keyword).as_array()) {
-    options.push_back(option);
+    options.insert(option);
   }
 
   return {make<AssertionEqualsAny>(context, schema_context, dynamic_context,

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -379,8 +379,7 @@ auto evaluate_step(const sourcemeta::blaze::Template::value_type &step,
 
     case IS_STEP(AssertionEqualsAny): {
       EVALUATE_BEGIN_NO_PRECONDITION(assertion, AssertionEqualsAny);
-      result = (std::find(assertion.value.cbegin(), assertion.value.cend(),
-                          context.resolve_target()) != assertion.value.cend());
+      result = assertion.value.contains(context.resolve_target());
       EVALUATE_END(assertion, AssertionEqualsAny);
     }
 

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_template.h
@@ -338,7 +338,7 @@ DEFINE_STEP_WITH_VALUE(Assertion, Equal, ValueJSON)
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks that a JSON document
 /// is equal to at least one of the given elements
-DEFINE_STEP_WITH_VALUE(Assertion, EqualsAny, ValueArray)
+DEFINE_STEP_WITH_VALUE(Assertion, EqualsAny, ValueSet)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks a JSON document is

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
@@ -11,10 +11,21 @@
 #include <string>        // std::string
 #include <tuple>         // std::tuple
 #include <unordered_map> // std::unordered_map
+#include <unordered_set> // std::unordered_set
 #include <utility>       // std::pair
 #include <vector>        // std::vector
 
 namespace sourcemeta::blaze {
+
+// TODO: Elevate this to JSON Toolkit
+/// @ingroup evaluator
+struct HashJSON {
+  inline auto
+  operator()(const sourcemeta::jsontoolkit::JSON &value) const noexcept
+      -> std::size_t {
+    return value.fast_hash();
+  }
+};
 
 /// @ingroup evaluator
 /// @brief Represents a compiler step empty value
@@ -24,13 +35,9 @@ struct ValueNone {};
 /// Represents a compiler step JSON value
 using ValueJSON = sourcemeta::jsontoolkit::JSON;
 
-// Note that for these steps, we prefer vectors over sets as the former performs
-// better for small collections, where we can even guarantee uniqueness when
-// generating the instructions
-
 /// @ingroup evaluator
 /// Represents a set of JSON values
-using ValueArray = std::vector<sourcemeta::jsontoolkit::JSON>;
+using ValueSet = std::unordered_set<sourcemeta::jsontoolkit::JSON, HashJSON>;
 
 /// @ingroup evaluator
 /// Represents a compiler step string values

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -4154,7 +4154,7 @@ TEST(Evaluator_draft4, enum_2) {
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0,
       "The object value {\"foo\":1} was expected to equal one of the following "
-      "values: 1, {}, and \"foo\"");
+      "values: 1, \"foo\", and {}");
 }
 
 TEST(Evaluator_draft4, enum_3) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
