### PR TITLE
Stop requiring `EvaluationContext` resets

### DIFF
--- a/bindings/nodejs/wrapper.cc
+++ b/bindings/nodejs/wrapper.cc
@@ -44,7 +44,6 @@ public:
     assert(schema < this->schemas.size());
     assert(this->schemas[schema].has_value());
     const auto instance{sourcemeta::jsontoolkit::parse(instance_string)};
-    this->context.reset();
     const auto result{sourcemeta::blaze::evaluate(this->schemas[schema].value(),
                                                   instance, context)};
     return emscripten::val(result);

--- a/contrib/perf.cc
+++ b/contrib/perf.cc
@@ -154,7 +154,6 @@ public:
 bool validate_all(auto &context, const auto &instances,
                   const auto &schema_template) {
   for (std::size_t num = 0; num < instances.size(); num++) {
-    context.reset();
     const auto result{
         sourcemeta::blaze::evaluate(schema_template, instances[num], context)};
     if (!result) {

--- a/contrib/validate.cc
+++ b/contrib/validate.cc
@@ -53,7 +53,6 @@ auto main(int argc, char **argv) noexcept -> int {
   sourcemeta::blaze::EvaluationContext context;
   std::size_t cursor{0};
   for (const auto &instance : instances) {
-    context.reset();
     cursor += 1;
     const auto timestamp_start{std::chrono::high_resolution_clock::now()};
     const auto result{

--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -5,17 +5,6 @@
 
 namespace sourcemeta::blaze {
 
-// Do a full reset for the next run
-auto EvaluationContext::reset() -> void {
-  assert(this->evaluate_path.empty());
-  assert(this->evaluate_path_size == 0);
-  assert(this->instance_location.empty());
-  assert(!this->property_target.has_value());
-  assert(this->resources.empty());
-  this->labels.clear();
-  this->evaluated_.clear();
-}
-
 auto EvaluationContext::push(
     const sourcemeta::jsontoolkit::Pointer &relative_schema_location,
     const sourcemeta::jsontoolkit::Pointer &relative_instance_location,

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -237,6 +237,15 @@ auto evaluate(const Instructions &steps,
 auto evaluate(const Instructions &steps,
               const sourcemeta::jsontoolkit::JSON &instance,
               EvaluationContext &context) -> bool {
+  // Do a full reset for the next run
+  assert(context.evaluate_path.empty());
+  assert(context.evaluate_path_size == 0);
+  assert(context.instance_location.empty());
+  assert(!context.property_target.has_value());
+  assert(context.resources.empty());
+  context.labels.clear();
+  context.evaluated_.clear();
+
   return evaluate_internal(instance, context, steps, std::nullopt);
 }
 

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -25,9 +25,6 @@ namespace sourcemeta::blaze {
 /// Represents a stateful schema evaluation context
 class SOURCEMETA_BLAZE_EVALUATOR_EXPORT EvaluationContext {
 public:
-  /// Prepare the schema evaluation context for the next run
-  auto reset() -> void;
-
   // All of these methods are considered internal and no
   // client must depend on them
 #ifndef DOXYGEN

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -95,22 +95,18 @@ TEST(Evaluator, reusable_context) {
   sourcemeta::blaze::EvaluationContext context;
 
   const sourcemeta::jsontoolkit::JSON instance_1{"foo bar"};
-  context.reset();
   EXPECT_TRUE(
       sourcemeta::blaze::evaluate(compiled_schema, instance_1, context));
 
   const sourcemeta::jsontoolkit::JSON instance_2{"baz"};
-  context.reset();
   EXPECT_TRUE(
       sourcemeta::blaze::evaluate(compiled_schema, instance_2, context));
 
   const sourcemeta::jsontoolkit::JSON instance_3{4};
-  context.reset();
   EXPECT_FALSE(
       sourcemeta::blaze::evaluate(compiled_schema, instance_3, context));
 
   const sourcemeta::jsontoolkit::JSON instance_4{"qux"};
-  context.reset();
   EXPECT_TRUE(
       sourcemeta::blaze::evaluate(compiled_schema, instance_4, context));
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
