### PR TITLE
Take target resolution helpers out of the `EvaluationContext`

### DIFF
--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -68,40 +68,6 @@ auto EvaluationContext::hash(
   return resource + this->hasher_(fragment);
 }
 
-auto EvaluationContext::resolve_target(
-    const std::optional<
-        std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
-        &property_target,
-    const sourcemeta::jsontoolkit::JSON &instance)
-    -> const sourcemeta::jsontoolkit::JSON & {
-  if (property_target.has_value()) [[unlikely]] {
-    // In this case, we still need to return a string in order
-    // to cope with non-string keywords inside `propertyNames`
-    // that need to fail validation. But then, the actual string
-    // we return doesn't matter, so we can always return a dummy one.
-    static const sourcemeta::jsontoolkit::JSON empty_string{""};
-    return empty_string;
-  }
-
-  return instance;
-}
-
-auto EvaluationContext::resolve_string_target(
-    const std::optional<
-        std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
-        &property_target,
-    const sourcemeta::jsontoolkit::JSON &instance) const
-    -> std::optional<
-        std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>> {
-  if (property_target.has_value()) [[unlikely]] {
-    return property_target.value();
-  } else if (!instance.is_string()) {
-    return std::nullopt;
-  } else {
-    return instance.to_string();
-  }
-}
-
 auto EvaluationContext::evaluate() -> void {
   this->evaluate(sourcemeta::jsontoolkit::empty_pointer);
 }

--- a/src/evaluator/dispatch.h
+++ b/src/evaluator/dispatch.h
@@ -277,7 +277,7 @@ HANDLER_START {
                               target.is_object());
     // Now here we refer to the actual property
     const auto &effective_target{
-        context.resolve_target(property_target, target_check.value())};
+        resolve_target(property_target, target_check.value())};
     // In non-strict mode, we consider a real number that represents an
     // integer to be an integer
     result = effective_target.type() == assertion.value ||
@@ -294,7 +294,7 @@ HANDLER_START {
                               target.is_object());
     // Now here we refer to the actual property
     const auto &effective_target{
-        context.resolve_target(property_target, target_check.value())};
+        resolve_target(property_target, target_check.value())};
     // In non-strict mode, we consider a real number that represents an
     // integer to be an integer
     result = effective_target.type() == assertion.value ||
@@ -316,9 +316,8 @@ HANDLER_START {
                               // before traversing into the actual property
                               target.is_object());
     // Now here we refer to the actual property
-    result =
-        context.resolve_target(property_target, target_check.value()).type() ==
-        assertion.value;
+    result = resolve_target(property_target, target_check.value()).type() ==
+             assertion.value;
     EVALUATE_END(assertion, AssertionPropertyTypeStrict);
   }
 
@@ -329,9 +328,8 @@ HANDLER_START {
                               // before traversing into the actual property
                               target.is_object());
     // Now here we refer to the actual property
-    result =
-        context.resolve_target(property_target, target_check.value()).type() ==
-        assertion.value;
+    result = resolve_target(property_target, target_check.value()).type() ==
+             assertion.value;
 
     if (result) {
       assert(track);
@@ -349,9 +347,10 @@ HANDLER_START {
                               target.is_object());
     // Now here we refer to the actual property
     result =
-        (std::find(assertion.value.cbegin(), assertion.value.cend(),
-                   context.resolve_target(property_target, target_check.value())
-                       .type()) != assertion.value.cend());
+        (std::find(
+             assertion.value.cbegin(), assertion.value.cend(),
+             resolve_target(property_target, target_check.value()).type()) !=
+         assertion.value.cend());
     EVALUATE_END(assertion, AssertionPropertyTypeStrictAny);
   }
 
@@ -363,9 +362,10 @@ HANDLER_START {
                               target.is_object());
     // Now here we refer to the actual property
     result =
-        (std::find(assertion.value.cbegin(), assertion.value.cend(),
-                   context.resolve_target(property_target, target_check.value())
-                       .type()) != assertion.value.cend());
+        (std::find(
+             assertion.value.cbegin(), assertion.value.cend(),
+             resolve_target(property_target, target_check.value()).type()) !=
+         assertion.value.cend());
 
     if (result) {
       assert(track);

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -10,13 +10,8 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonpointer.h>
 
-#include <cassert>    // assert
-#include <cstdint>    // std::uint8_t
 #include <functional> // std::reference_wrapper
 #include <map>        // std::map
-#include <optional>   // std::optional
-#include <set>        // std::set
-#include <string>     // std::string
 #include <vector>     // std::vector
 
 namespace sourcemeta::blaze {
@@ -40,25 +35,6 @@ public:
   auto pop(const std::size_t relative_schema_location_size,
            const std::size_t relative_instance_location_size,
            const bool dynamic, const bool track) -> void;
-
-  ///////////////////////////////////////////////
-  // Target resolution
-  ///////////////////////////////////////////////
-
-  // TODO: Make these methods plain functions on evaluator.cc
-  auto resolve_target(
-      const std::optional<
-          std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
-          &property_target,
-      const sourcemeta::jsontoolkit::JSON &instance)
-      -> const sourcemeta::jsontoolkit::JSON &;
-  auto resolve_string_target(
-      const std::optional<
-          std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
-          &property_target,
-      const sourcemeta::jsontoolkit::JSON &instance) const
-      -> std::optional<
-          std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>;
 
   ///////////////////////////////////////////////
   // References and anchors


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
