### PR TITLE
Generously allocate space in advance for `EvaluationContext`

### DIFF
--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -7,6 +7,14 @@ namespace sourcemeta::blaze {
 const sourcemeta::jsontoolkit::JSON EvaluationContext::null{nullptr};
 const sourcemeta::jsontoolkit::JSON EvaluationContext::empty_string{""};
 
+EvaluationContext::EvaluationContext() {
+  // Generously allocate plenty of space for demanding runs
+  this->evaluate_path.reserve(1024);
+  this->instance_location.reserve(1024);
+  this->resources.reserve(1024);
+  this->evaluated.reserve(1024);
+}
+
 auto EvaluationContext::hash(
     const std::size_t &resource,
     const sourcemeta::jsontoolkit::JSON::String &fragment) const noexcept
@@ -33,13 +41,13 @@ auto EvaluationContext::evaluate(
   new_instance_location.push_back(relative_instance_location);
   Evaluation entry{std::move(new_instance_location), this->evaluate_path,
                    false};
-  this->evaluated_.emplace_back(std::move(entry));
+  this->evaluated.emplace_back(std::move(entry));
 }
 
 auto EvaluationContext::is_evaluated(
     const sourcemeta::jsontoolkit::WeakPointer::Token &tail) const -> bool {
-  for (auto iterator = this->evaluated_.crbegin();
-       iterator != this->evaluated_.crend(); ++iterator) {
+  for (auto iterator = this->evaluated.crbegin();
+       iterator != this->evaluated.crend(); ++iterator) {
     if (!iterator->skip &&
         this->instance_location.starts_with(iterator->instance_location,
                                             tail) &&
@@ -53,7 +61,7 @@ auto EvaluationContext::is_evaluated(
 }
 
 auto EvaluationContext::unevaluate() -> void {
-  for (auto &entry : this->evaluated_) {
+  for (auto &entry : this->evaluated) {
     if (!entry.skip && entry.evaluate_path.starts_with(this->evaluate_path)) {
       entry.skip = true;
     }

--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -332,7 +332,7 @@ auto evaluate(const Instructions &steps,
   assert(context.instance_location.empty());
   assert(context.resources.empty());
   context.labels.clear();
-  context.evaluated_.clear();
+  context.evaluated.clear();
 
   return evaluate_internal(instance, context, steps, std::nullopt);
 }

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_context.h
@@ -20,6 +20,8 @@ namespace sourcemeta::blaze {
 /// Represents a stateful schema evaluation context
 class SOURCEMETA_BLAZE_EVALUATOR_EXPORT EvaluationContext {
 public:
+  EvaluationContext();
+
   // All of these methods are considered internal and no
   // client must depend on them
 #ifndef DOXYGEN
@@ -74,7 +76,7 @@ public:
     bool skip;
   };
 
-  std::vector<Evaluation> evaluated_;
+  std::vector<Evaluation> evaluated;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
