### PR TITLE
Don't emit `type: object` if the schema also defines `required`

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -862,6 +862,14 @@ struct DescribeVisitor {
     return message.str();
   }
 
+  auto operator()(const AssertionDefinesStrict &step) const -> std::string {
+    std::ostringstream message;
+    message
+        << "The value was expected to be an object that defines the property "
+        << escape_string(step_value(step));
+    return message.str();
+  }
+
   auto operator()(const AssertionDefinesAll &step) const -> std::string {
     const auto &value{step_value(step)};
     assert(value.size() > 1);
@@ -906,11 +914,46 @@ struct DescribeVisitor {
     return message.str();
   }
 
+  auto operator()(const AssertionDefinesAllStrict &step) const -> std::string {
+    const auto &value{step_value(step)};
+    assert(value.size() > 1);
+    std::ostringstream message;
+    message
+        << "The value was expected to be an object that defines properties ";
+    for (auto iterator = value.cbegin(); iterator != value.cend(); ++iterator) {
+      if (std::next(iterator) == value.cend()) {
+        message << "and " << escape_string(*iterator);
+      } else {
+        message << escape_string(*iterator) << ", ";
+      }
+    }
+
+    return message.str();
+  }
+
   auto operator()(const AssertionDefinesExactly &step) const -> std::string {
     const auto &value{step_value(step)};
     assert(value.size() > 1);
     std::ostringstream message;
     message << "The object value was expected to only define properties ";
+    for (auto iterator = value.cbegin(); iterator != value.cend(); ++iterator) {
+      if (std::next(iterator) == value.cend()) {
+        message << "and " << escape_string(*iterator);
+      } else {
+        message << escape_string(*iterator) << ", ";
+      }
+    }
+
+    return message.str();
+  }
+
+  auto operator()(const AssertionDefinesExactlyStrict &step) const
+      -> std::string {
+    const auto &value{step_value(step)};
+    assert(value.size() > 1);
+    std::ostringstream message;
+    message << "The value was expected to be an object that only defines "
+               "properties ";
     for (auto iterator = value.cbegin(); iterator != value.cend(); ++iterator) {
       if (std::next(iterator) == value.cend()) {
         message << "and " << escape_string(*iterator);

--- a/src/compiler/compile_json.cc
+++ b/src/compiler/compile_json.cc
@@ -222,8 +222,12 @@ struct StepVisitor {
 
   HANDLE_STEP("assertion", "fail", AssertionFail)
   HANDLE_STEP("assertion", "defines", AssertionDefines)
+  HANDLE_STEP("assertion", "defines-strict", AssertionDefinesStrict)
   HANDLE_STEP("assertion", "defines-all", AssertionDefinesAll)
+  HANDLE_STEP("assertion", "defines-all-strict", AssertionDefinesAllStrict)
   HANDLE_STEP("assertion", "defines-exactly", AssertionDefinesExactly)
+  HANDLE_STEP("assertion", "defines-exactly-strict",
+              AssertionDefinesExactlyStrict)
   HANDLE_STEP("assertion", "property-dependencies",
               AssertionPropertyDependencies)
   HANDLE_STEP("assertion", "type", AssertionType)

--- a/src/compiler/default_compiler_draft6.h
+++ b/src/compiler/default_compiler_draft6.h
@@ -88,6 +88,11 @@ auto compiler_draft6_validation_type(const Context &context,
         return {};
       }
 
+      if (context.mode == Mode::FastValidation &&
+          schema_context.schema.defines("required")) {
+        return {};
+      }
+
       return {make<AssertionTypeStrict>(
           context, schema_context, dynamic_context,
           sourcemeta::jsontoolkit::JSON::Type::Object)};

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_instruction.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_instruction.h
@@ -16,8 +16,11 @@ namespace sourcemeta::blaze {
 #ifndef DOXYGEN
 struct AssertionFail;
 struct AssertionDefines;
+struct AssertionDefinesStrict;
 struct AssertionDefinesAll;
+struct AssertionDefinesAllStrict;
 struct AssertionDefinesExactly;
+struct AssertionDefinesExactlyStrict;
 struct AssertionPropertyDependencies;
 struct AssertionType;
 struct AssertionTypeAny;
@@ -103,8 +106,9 @@ struct ControlDynamicAnchorJump;
 /// @ingroup evaluator
 /// Represents a schema compilation step that can be evaluated
 using Instruction = std::variant<
-    AssertionFail, AssertionDefines, AssertionDefinesAll,
-    AssertionDefinesExactly, AssertionPropertyDependencies, AssertionType,
+    AssertionFail, AssertionDefines, AssertionDefinesStrict,
+    AssertionDefinesAll, AssertionDefinesAllStrict, AssertionDefinesExactly,
+    AssertionDefinesExactlyStrict, AssertionPropertyDependencies, AssertionType,
     AssertionTypeAny, AssertionTypeStrict, AssertionTypeStrictAny,
     AssertionTypeStringBounded, AssertionTypeStringUpper,
     AssertionTypeArrayBounded, AssertionTypeArrayUpper,
@@ -139,8 +143,11 @@ using Instruction = std::variant<
 enum class InstructionIndex : std::uint8_t {
   AssertionFail = 0,
   AssertionDefines,
+  AssertionDefinesStrict,
   AssertionDefinesAll,
+  AssertionDefinesAllStrict,
   AssertionDefinesExactly,
+  AssertionDefinesExactlyStrict,
   AssertionPropertyDependencies,
   AssertionType,
   AssertionTypeAny,
@@ -265,14 +272,29 @@ DEFINE_STEP_WITH_VALUE(Assertion, Fail, ValueNone)
 DEFINE_STEP_WITH_VALUE(Assertion, Defines, ValueString)
 
 /// @ingroup evaluator_instructions
+/// @brief Represents a compiler assertion step that checks that the instance is
+/// an object and that it defines a given property
+DEFINE_STEP_WITH_VALUE(Assertion, DefinesStrict, ValueString)
+
+/// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks if an object defines
 /// a set of properties
 DEFINE_STEP_WITH_VALUE(Assertion, DefinesAll, ValueStrings)
 
 /// @ingroup evaluator_instructions
+/// @brief Represents a compiler assertion step that checks that the instance is
+/// an object and that it defines a set of properties
+DEFINE_STEP_WITH_VALUE(Assertion, DefinesAllStrict, ValueStrings)
+
+/// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks if an object defines
 /// a set of properties and no other ones
 DEFINE_STEP_WITH_VALUE(Assertion, DefinesExactly, ValueStrings)
+
+/// @ingroup evaluator_instructions
+/// @brief Represents a compiler assertion step that checks if the instance is
+/// an object and defines a set of properties and no other ones
+DEFINE_STEP_WITH_VALUE(Assertion, DefinesExactlyStrict, ValueStrings)
 
 /// @ingroup evaluator_instructions
 /// @brief Represents a compiler assertion step that checks if an object defines

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -273,7 +273,28 @@ TEST(Evaluator_draft4, required_4) {
 
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 2);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesAllStrict, "/required", "#/required",
+                     "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesAllStrict, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be an object that "
+                               "defines properties \"foo\", and \"bar\"");
+}
+
+TEST(Evaluator_draft4, required_4_exhaustive) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": [ "foo", "bar" ]
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(schema, instance, 2);
   EVALUATE_TRACE_PRE(0, AssertionDefinesAll, "/required", "#/required", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/type", "#/type", "");
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesAll, "/required", "#/required",
@@ -1038,34 +1059,31 @@ TEST(Evaluator_draft4, properties_5) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"xxx\", \"bar\": 2 }")};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 4);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
 
-  EVALUATE_TRACE_PRE(0, AssertionDefinesAll, "/required", "#/required", "");
+  EVALUATE_TRACE_PRE(0, AssertionDefinesAllStrict, "/required", "#/required",
+                     "");
   EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict, "/properties/bar/type",
                      "#/properties/bar/type", "/bar");
   EVALUATE_TRACE_PRE(2, AssertionPropertyTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/type", "#/type", "");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesAll, "/required", "#/required",
-                              "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesAllStrict, "/required",
+                              "#/required", "");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
                               "/properties/bar/type", "#/properties/bar/type",
                               "/bar");
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionPropertyTypeStrict,
                               "/properties/foo/type", "#/properties/foo/type",
                               "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/type", "#/type", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The object value was expected to define "
-                               "properties \"foo\", and \"bar\"");
+                               "The value was expected to be an object that "
+                               "defines properties \"foo\", and \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The value was expected to be of type string");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
-                               "The value was expected to be of type object");
 }
 
 TEST(Evaluator_draft4, properties_6) {
@@ -2832,6 +2850,49 @@ TEST(Evaluator_draft4, additionalProperties_13) {
                                "properties \"foo\", and \"bar\"");
 }
 
+TEST(Evaluator_draft4, additionalProperties_14) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": [ "foo", "bar" ],
+    "additionalProperties": false,
+    "properties": {
+      "foo": { "type": "boolean" },
+      "bar": { "type": "boolean" }
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": true, \"bar\": false }")};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesExactlyStrict, "/required",
+                     "#/required", "");
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(2, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesExactlyStrict, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
+                              "/properties/bar/type", "#/properties/bar/type",
+                              "/bar");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be an object that "
+                               "only defines properties \"foo\", and \"bar\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type boolean");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type boolean");
+}
+
 TEST(Evaluator_draft4, not_1) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({
@@ -3267,22 +3328,22 @@ TEST(Evaluator_draft4, items_10) {
 
   EVALUATE_TRACE_PRE(0, LoopItems, "/properties/features/items",
                      "#/properties/features/items", "/features");
-  EVALUATE_TRACE_PRE(1, AssertionTypeStrict,
-                     "/properties/features/items/properties/geometry/type",
-                     "#/properties/features/items/properties/geometry/type",
+  EVALUATE_TRACE_PRE(1, AssertionDefinesStrict,
+                     "/properties/features/items/properties/geometry/required",
+                     "#/properties/features/items/properties/geometry/required",
                      "/features/0/geometry");
 
   EVALUATE_TRACE_POST_FAILURE(
-      0, AssertionTypeStrict,
-      "/properties/features/items/properties/geometry/type",
-      "#/properties/features/items/properties/geometry/type",
+      0, AssertionDefinesStrict,
+      "/properties/features/items/properties/geometry/required",
+      "#/properties/features/items/properties/geometry/required",
       "/features/0/geometry");
   EVALUATE_TRACE_POST_FAILURE(1, LoopItems, "/properties/features/items",
                               "#/properties/features/items", "/features");
 
-  EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 0,
-      "The value was expected to be of type object but it was of type null");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be an object that "
+                               "defines the property \"geometries\"");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "Every item in the array value was expected to "
                                "validate against the given subschema");

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -1574,3 +1574,46 @@ TEST(Evaluator_draft6, enum_14) {
       instance, 0,
       "The number value 3.0 was expected to equal the number constant 3.0");
 }
+
+TEST(Evaluator_draft6, additionalProperties_1) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "required": [ "foo", "bar" ],
+    "additionalProperties": false,
+    "properties": {
+      "foo": { "type": "boolean" },
+      "bar": { "type": "boolean" }
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": true, \"bar\": false }")};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesExactlyStrict, "/required",
+                     "#/required", "");
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(2, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesExactlyStrict, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
+                              "/properties/bar/type", "#/properties/bar/type",
+                              "/bar");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be an object that "
+                               "only defines properties \"foo\", and \"bar\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type boolean");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type boolean");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
