### PR TITLE
Revert "Make `AssertionDefinesExactly(Strict)` loop over the target"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ option(BLAZE_INSTALL "Install the Blaze library" ON)
 option(BLAZE_ADDRESS_SANITIZER "Build Blaze with an address sanitizer" OFF)
 option(BLAZE_UNDEFINED_SANITIZER "Build Blaze with an undefined behavior sanitizer" OFF)
 
-add_compile_definitions(NDEBUG)
-
 if(BLAZE_INSTALL)
   include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)

--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -948,15 +948,12 @@ auto describe(const bool valid, const Instruction &step,
 
   if (step.type ==
       sourcemeta::blaze::InstructionIndex::AssertionDefinesExactly) {
-    const auto &value{instruction_value<ValueStringSet>(step)};
+    const auto &value{instruction_value<ValueStrings>(step)};
     assert(value.size() > 1);
-    ValueStrings value_vector{value.cbegin(), value.cend()};
-    std::sort(value_vector.begin(), value_vector.end());
     std::ostringstream message;
     message << "The object value was expected to only define properties ";
-    for (auto iterator = value_vector.cbegin(); iterator != value_vector.cend();
-         ++iterator) {
-      if (std::next(iterator) == value_vector.cend()) {
+    for (auto iterator = value.cbegin(); iterator != value.cend(); ++iterator) {
+      if (std::next(iterator) == value.cend()) {
         message << "and " << escape_string(*iterator);
       } else {
         message << escape_string(*iterator) << ", ";
@@ -968,16 +965,13 @@ auto describe(const bool valid, const Instruction &step,
 
   if (step.type ==
       sourcemeta::blaze::InstructionIndex::AssertionDefinesExactlyStrict) {
-    const auto &value{instruction_value<ValueStringSet>(step)};
+    const auto &value{instruction_value<ValueStrings>(step)};
     assert(value.size() > 1);
-    ValueStrings value_vector{value.cbegin(), value.cend()};
-    std::sort(value_vector.begin(), value_vector.end());
     std::ostringstream message;
     message << "The value was expected to be an object that only defines "
                "properties ";
-    for (auto iterator = value_vector.cbegin(); iterator != value_vector.cend();
-         ++iterator) {
-      if (std::next(iterator) == value_vector.cend()) {
+    for (auto iterator = value.cbegin(); iterator != value.cend(); ++iterator) {
+      if (std::next(iterator) == value.cend()) {
         message << "and " << escape_string(*iterator);
       } else {
         message << escape_string(*iterator) << ", ";

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -463,17 +463,13 @@ auto compiler_draft4_validation_required(const Context &context,
                                  .defines(property);
                            })) {
       if (context.mode == Mode::FastValidation && assume_object) {
-        ValueStringSet properties_set{properties.cbegin(), properties.cend()};
         return {make(
             sourcemeta::blaze::InstructionIndex::AssertionDefinesExactlyStrict,
-            context, schema_context, dynamic_context,
-            std::move(properties_set))};
+            context, schema_context, dynamic_context, std::move(properties))};
       } else {
-        ValueStringSet properties_set{properties.cbegin(), properties.cend()};
-        return {
-            make(sourcemeta::blaze::InstructionIndex::AssertionDefinesExactly,
-                 context, schema_context, dynamic_context,
-                 std::move(properties_set))};
+        return {make(
+            sourcemeta::blaze::InstructionIndex::AssertionDefinesExactly,
+            context, schema_context, dynamic_context, std::move(properties))};
       }
     } else if (context.mode == Mode::FastValidation && assume_object) {
       return {make(

--- a/src/evaluator/dispatch.inc.h
+++ b/src/evaluator/dispatch.inc.h
@@ -124,13 +124,13 @@ INSTRUCTION_HANDLER(AssertionDefinesExactly) {
   EVALUATE_BEGIN_NON_STRING(AssertionDefinesExactly, target.is_object());
 
   // Otherwise we are we even emitting this instruction?
-  assert(std::get<ValueStringSet>(instruction.value).size() > 1);
+  assert(std::get<ValueStrings>(instruction.value).size() > 1);
 
-  const auto &value{std::get<ValueStringSet>(instruction.value)};
-  if (value.size() == target.object_size()) {
+  if (std::get<ValueStrings>(instruction.value).size() ==
+      target.object_size()) {
     result = true;
-    for (const auto &property : target.as_object()) {
-      if (!value.contains(property.first)) {
+    for (const auto &property : std::get<ValueStrings>(instruction.value)) {
+      if (!target.defines(property)) {
         result = false;
         break;
       }
@@ -151,13 +151,13 @@ INSTRUCTION_HANDLER(AssertionDefinesExactlyStrict) {
   const auto &target{get(instance, instruction.relative_instance_location)};
 
   // Otherwise we are we even emitting this instruction?
-  assert(std::get<ValueStringSet>(instruction.value).size() > 1);
+  assert(std::get<ValueStrings>(instruction.value).size() > 1);
 
-  const auto &value{std::get<ValueStringSet>(instruction.value)};
-  if (target.is_object() && value.size() == target.object_size()) {
+  if (target.is_object() && std::get<ValueStrings>(instruction.value).size() ==
+                                target.object_size()) {
     result = true;
-    for (const auto &property : target.as_object()) {
-      if (!value.contains(property.first)) {
+    for (const auto &property : std::get<ValueStrings>(instruction.value)) {
+      if (!target.defines(property)) {
         result = false;
         break;
       }

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -2811,7 +2811,7 @@ TEST(Evaluator_draft4, additionalProperties_12) {
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The object value was expected to only define "
-                               "properties \"bar\", and \"foo\"");
+                               "properties \"foo\", and \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 1, "The object properties were expected to be of type boolean");
 }
@@ -2838,7 +2838,7 @@ TEST(Evaluator_draft4, additionalProperties_13) {
                               "#/required", "");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The object value was expected to only define "
-                               "properties \"bar\", and \"foo\"");
+                               "properties \"foo\", and \"bar\"");
 }
 
 TEST(Evaluator_draft4, additionalProperties_14) {
@@ -2871,7 +2871,7 @@ TEST(Evaluator_draft4, additionalProperties_14) {
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be an object that "
-                               "only defines properties \"bar\", and \"foo\"");
+                               "only defines properties \"foo\", and \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 1, "The object properties were expected to be of type boolean");
 }

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -1605,7 +1605,7 @@ TEST(Evaluator_draft6, additionalProperties_1) {
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be an object that "
-                               "only defines properties \"bar\", and \"foo\"");
+                               "only defines properties \"foo\", and \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 1, "The object properties were expected to be of type boolean");
 }
@@ -1639,7 +1639,7 @@ TEST(Evaluator_draft6, additionalProperties_2) {
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be an object that "
-                               "only defines properties \"bar\", and \"foo\"");
+                               "only defines properties \"foo\", and \"bar\"");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 1, "The object properties were expected to be of type integer");
 }


### PR DESCRIPTION
This reverts commit 22f4f85778591336c051ec165b091abf1dc608b9.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
