### PR TITLE
Don't construct `std::nullopt` at the start of each evaluation

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -40,6 +40,8 @@ inline auto resolve_string_target(
 
   const auto &target{get(instance, relative_instance_location)};
   if (!target.is_string()) {
+    // TODO: Get rid of this nullopt instance that is created on the fly
+    // Make this function return a pointer
     return std::nullopt;
   } else {
     return target.to_string();
@@ -70,7 +72,7 @@ auto Evaluator::validate(const Template &schema,
 
   if (schema.dynamic || schema.track) {
     this->evaluated_.clear();
-    return complete::evaluate(instance, *this, schema, std::nullopt);
+    return complete::evaluate(instance, *this, schema, DEFAULT_CALLBACK);
   } else {
     return fast::evaluate(instance, *this, schema);
   }

--- a/src/evaluator/evaluator_complete.h
+++ b/src/evaluator/evaluator_complete.h
@@ -224,8 +224,10 @@ inline auto evaluate(const sourcemeta::jsontoolkit::JSON &instance,
     -> bool {
   bool overall{true};
   for (const auto &instruction : schema.instructions) {
-    if (!evaluate_instruction(instruction, schema, callback, instance,
-                              std::nullopt, 0, evaluator)) {
+    if (!evaluate_instruction(
+            instruction, schema, callback, instance,
+            sourcemeta::blaze::Evaluator::DEFAULT_PROPERTY_TARGET, 0,
+            evaluator)) {
       overall = false;
       break;
     }

--- a/src/evaluator/evaluator_fast.h
+++ b/src/evaluator/evaluator_fast.h
@@ -91,8 +91,10 @@ inline auto evaluate(const sourcemeta::jsontoolkit::JSON &instance,
                      sourcemeta::blaze::Evaluator &evaluator,
                      const sourcemeta::blaze::Template &schema) -> bool {
   for (const auto &instruction : schema.instructions) {
-    if (!evaluate_instruction(instruction, schema, std::nullopt, instance,
-                              std::nullopt, 0, evaluator)) {
+    if (!evaluate_instruction(
+            instruction, schema, sourcemeta::blaze::Evaluator::DEFAULT_CALLBACK,
+            instance, sourcemeta::blaze::Evaluator::DEFAULT_PROPERTY_TARGET, 0,
+            evaluator)) {
       return false;
     }
   }

--- a/src/evaluator/include/sourcemeta/blaze/evaluator.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator.h
@@ -152,6 +152,10 @@ public:
 #ifndef DOXYGEN
   static const sourcemeta::jsontoolkit::JSON null;
   static const sourcemeta::jsontoolkit::JSON empty_string;
+  inline static const std::optional<Callback> DEFAULT_CALLBACK;
+  inline static const std::optional<
+      std::reference_wrapper<const sourcemeta::jsontoolkit::JSON::String>>
+      DEFAULT_PROPERTY_TARGET;
 
   auto
   hash(const std::size_t &resource,

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
@@ -9,7 +9,7 @@
 #include <sourcemeta/blaze/evaluator_string_set.h>
 
 #include <cstdint>       // std::uint8_t
-#include <optional>      // std::optional, std::nullopt
+#include <optional>      // std::optional
 #include <string>        // std::string
 #include <tuple>         // std::tuple
 #include <unordered_set> // std::unordered_set


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
