### PR TITLE
Avoid accessing `variant` multiple times for `.defines()`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
 noa https://github.com/sourcemeta/noa caad2e1ceedf9fd1a18686a6a6d1e2b9757ead75
-jsontoolkit https://github.com/sourcemeta/jsontoolkit dea3a52d4b395a774b538ea6683a08ece558b92a
+jsontoolkit https://github.com/sourcemeta/jsontoolkit a219992cbe2aff40e7ca290b5df38247dad824a5
 googletest https://github.com/google/googletest a7f443b80b105f940225332ed3c31f2790092f47
 googlebenchmark https://github.com/google/benchmark 378fe693a1ef51500db21b11ff05a8018c5f0e55
 jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite c2badb1298a8698f86dadf1aea7b44b3a894e5ac

--- a/src/evaluator/dispatch.inc.h
+++ b/src/evaluator/dispatch.inc.h
@@ -71,8 +71,9 @@ INSTRUCTION_HANDLER(AssertionDefinesAll) {
   // Otherwise there is no way the instance can satisfy it anyway
   if (value.size() <= target.object_size()) {
     result = true;
+    const auto &object{target.as_object()};
     for (const auto &property : value) {
-      if (!target.defines(property.first, property.second)) {
+      if (!object.defines(property.first, property.second)) {
         result = false;
         break;
       }
@@ -98,8 +99,9 @@ INSTRUCTION_HANDLER(AssertionDefinesAllStrict) {
   // Otherwise there is no way the instance can satisfy it anyway
   if (target.is_object() && value.size() <= target.object_size()) {
     result = true;
+    const auto &object{target.as_object()};
     for (const auto &property : value) {
-      if (!target.defines(property.first, property.second)) {
+      if (!object.defines(property.first, property.second)) {
         result = false;
         break;
       }
@@ -123,8 +125,9 @@ INSTRUCTION_HANDLER(AssertionDefinesExactly) {
 
   if (value.size() == target.object_size()) {
     result = true;
+    const auto &object{target.as_object()};
     for (const auto &property : value) {
-      if (!target.defines(property.first, property.second)) {
+      if (!object.defines(property.first, property.second)) {
         result = false;
         break;
       }
@@ -149,8 +152,9 @@ INSTRUCTION_HANDLER(AssertionDefinesExactlyStrict) {
 
   if (target.is_object() && value.size() == target.object_size()) {
     result = true;
+    const auto &object{target.as_object()};
     for (const auto &property : value) {
-      if (!target.defines(property.first, property.second)) {
+      if (!object.defines(property.first, property.second)) {
         result = false;
         break;
       }
@@ -172,14 +176,16 @@ INSTRUCTION_HANDLER(AssertionPropertyDependencies) {
   // Otherwise we are we even emitting this instruction?
   assert(!value.empty());
   result = true;
+  const auto &object{target.as_object()};
+  const sourcemeta::jsontoolkit::Hash hasher;
   for (const auto &entry : value) {
-    if (!target.defines(entry.first)) {
+    if (!object.defines(entry.first, entry.hash)) {
       continue;
     }
 
     assert(!entry.second.empty());
     for (const auto &dependency : entry.second) {
-      if (!target.defines(dependency)) {
+      if (!object.defines(dependency, hasher(dependency))) {
         result = false;
         EVALUATE_END(AssertionPropertyDependencies);
       }

--- a/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_object.h
+++ b/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_object.h
@@ -99,6 +99,12 @@ public:
     return this->data.find(key, this->data.hash(key));
   }
 
+  /// Check if an entry with the given key exists
+  inline auto defines(const Key &key,
+                      const typename Container::hash_type hash) const -> bool {
+    return this->data.contains(key, hash);
+  }
+
 private:
   friend Value;
 // Exporting symbols that depends on the standard C++ library is considered

--- a/vendor/jsontoolkit/src/json/json_value.cc
+++ b/vendor/jsontoolkit/src/json/json_value.cc
@@ -538,7 +538,7 @@ JSON::defines(const JSON::String &key,
               const typename JSON::Object::Container::hash_type hash) const
     -> bool {
   assert(this->is_object());
-  return std::get_if<Object>(&this->data)->data.contains(key, hash);
+  return std::get_if<Object>(&this->data)->defines(key, hash);
 }
 
 [[nodiscard]] auto

--- a/vendor/jsontoolkit/src/jsonpointer/jsonpointer.cc
+++ b/vendor/jsontoolkit/src/jsonpointer/jsonpointer.cc
@@ -74,7 +74,7 @@ auto try_traverse(const sourcemeta::jsontoolkit::JSON &document,
       }
 
       const auto &property{token.to_property()};
-      const auto json_value{current->try_at(property, token.property_hash())};
+      const auto *json_value{current->try_at(property, token.property_hash())};
       if (json_value) {
         current = json_value;
       } else {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
