### PR TITLE
Avoid an extra JSON type cast on `DefinesExactly(Strict)` for `.size()`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
 noa https://github.com/sourcemeta/noa caad2e1ceedf9fd1a18686a6a6d1e2b9757ead75
-jsontoolkit https://github.com/sourcemeta/jsontoolkit ffe0b096aad7e77d863deb814f2e31afed3d6b65
+jsontoolkit https://github.com/sourcemeta/jsontoolkit 3a4ddc20da2c8ad0db0c720e7efa8a150389aba9
 googletest https://github.com/google/googletest a7f443b80b105f940225332ed3c31f2790092f47
 googlebenchmark https://github.com/google/benchmark 378fe693a1ef51500db21b11ff05a8018c5f0e55
 jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite c2badb1298a8698f86dadf1aea7b44b3a894e5ac

--- a/src/evaluator/dispatch.inc.h
+++ b/src/evaluator/dispatch.inc.h
@@ -122,10 +122,10 @@ INSTRUCTION_HANDLER(AssertionDefinesExactly) {
   const auto &value{*std::get_if<ValueStringSet>(&instruction.value)};
   // Otherwise we are we even emitting this instruction?
   assert(value.size() > 1);
+  const auto &object{target.as_object()};
 
-  if (value.size() == target.object_size()) {
+  if (value.size() == object.size()) {
     result = true;
-    const auto &object{target.as_object()};
     for (const auto &property : value) {
       if (!object.defines(property.first, property.second)) {
         result = false;
@@ -150,10 +150,10 @@ INSTRUCTION_HANDLER(AssertionDefinesExactlyStrict) {
   // Otherwise we are we even emitting this instruction?
   assert(value.size() > 1);
   assert(target.is_object());
+  const auto &object{target.as_object()};
 
-  if (value.size() == target.object_size()) {
+  if (value.size() == object.size()) {
     result = true;
-    const auto &object{target.as_object()};
     for (const auto &property : value) {
       if (!object.defines(property.first, property.second)) {
         result = false;

--- a/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_flat_map.h
+++ b/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_flat_map.h
@@ -112,8 +112,7 @@ public:
   }
 
   // As a performance optimisation if the hash is known
-  inline auto contains(const key_type &key, const hash_type key_hash) const
-      -> bool {
+  auto contains(const key_type &key, const hash_type key_hash) const -> bool {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance

--- a/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_object.h
+++ b/vendor/jsontoolkit/src/json/include/sourcemeta/jsontoolkit/json_object.h
@@ -105,6 +105,9 @@ public:
     return this->data.contains(key, hash);
   }
 
+  /// Check the size of the object
+  inline auto size() const -> std::size_t { return this->data.size(); }
+
 private:
   friend Value;
 // Exporting symbols that depends on the standard C++ library is considered

--- a/vendor/jsontoolkit/src/json/json_value.cc
+++ b/vendor/jsontoolkit/src/json/json_value.cc
@@ -548,7 +548,7 @@ JSON::at(const String &key,
 
 [[nodiscard]] auto JSON::object_size() const -> std::size_t {
   assert(this->is_object());
-  return this->data_object.data.size();
+  return this->data_object.size();
 }
 
 [[nodiscard]] auto JSON::byte_size() const -> std::size_t {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
