### PR TITLE
Do not apply `LoopPropertiesExactlyTypeStrict` with `patternProperties`

### DIFF
--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -868,7 +868,9 @@ auto compiler_draft4_applicator_properties_with_options(
                                  schema_context.schema.at("type").is_string() &&
                                  schema_context.schema.at("type").to_string() ==
                                      "object"};
-        if (schema_context.schema.defines("required") && assume_object) {
+        if (schema_context.schema.defines("required") &&
+            !schema_context.schema.defines("patternProperties") &&
+            assume_object) {
           ValueStringSet required{
               json_array_to_string_set(schema_context.schema.at("required"))};
           if (is_closed_properties_required(schema_context.schema, required)) {

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -2868,6 +2868,47 @@ TEST(Evaluator_draft4, additionalProperties_14) {
       "The required object properties were expected to be of type boolean");
 }
 
+TEST(Evaluator_draft4, additionalProperties_15) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "required": [ "foo", "bar" ],
+    "additionalProperties": false,
+    "patternProperties": { "^@": true },
+    "properties": {
+      "foo": { "type": "boolean" },
+      "bar": { "type": "boolean" }
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": true, \"bar\": false }")};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesExactly, "/required", "#/required", "");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesTypeStrict, "/properties", "#/properties",
+                     "");
+  EVALUATE_TRACE_PRE(2, LoopPropertiesExcept, "/additionalProperties",
+                     "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesExactly, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesTypeStrict, "/properties",
+                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesExcept, "/additionalProperties",
+                              "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The object value was expected to only define "
+                               "properties \"bar\", and \"foo\"");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1, "The object properties were expected to be of type boolean");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object value was not expected to define additional properties");
+}
+
 TEST(Evaluator_draft4, not_1) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
