### PR TITLE
Remove top-level `NDEBUG` CMake declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ option(BLAZE_INSTALL "Install the Blaze library" ON)
 option(BLAZE_ADDRESS_SANITIZER "Build Blaze with an address sanitizer" OFF)
 option(BLAZE_UNDEFINED_SANITIZER "Build Blaze with an undefined behavior sanitizer" OFF)
 
-add_compile_definitions(NDEBUG)
-
 if(BLAZE_INSTALL)
   include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
