### PR TITLE
Remove unnecessary reference in `Evaluator::hash`

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -94,7 +94,7 @@ auto Evaluator::validate(const Template &schema,
 const sourcemeta::jsontoolkit::JSON Evaluator::null{nullptr};
 const sourcemeta::jsontoolkit::JSON Evaluator::empty_string{""};
 
-auto Evaluator::hash(const std::size_t &resource,
+auto Evaluator::hash(const std::size_t resource,
                      const sourcemeta::jsontoolkit::JSON::String &fragment)
     const noexcept -> std::size_t {
   return resource + this->hasher_(fragment);

--- a/src/evaluator/include/sourcemeta/blaze/evaluator.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator.h
@@ -154,7 +154,7 @@ public:
   static const sourcemeta::jsontoolkit::JSON empty_string;
 
   auto
-  hash(const std::size_t &resource,
+  hash(const std::size_t resource,
        const sourcemeta::jsontoolkit::JSON::String &fragment) const noexcept
       -> std::size_t;
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
