### PR TITLE
Mask `/assets` in `vendorpull`

### DIFF
--- a/vendorpull.mask
+++ b/vendorpull.mask
@@ -11,3 +11,4 @@ Brewfile
 DEPENDENCIES
 Makefile
 README.markdown
+assets


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
