### PR TITLE
Fix zero overflows on `min(Length|Items|Properties)`

### DIFF
--- a/src/compiler/compile_describe.cc
+++ b/src/compiler/compile_describe.cc
@@ -1323,7 +1323,7 @@ auto describe(const bool valid, const Instruction &step,
       std::ostringstream message;
       const auto maximum{instruction_value<ValueUnsignedInteger>(step) - 1};
       message << "The array value was expected to contain at most " << maximum;
-      assert(maximum > 0);
+      assert(maximum >= 0);
       if (maximum == 1) {
         message << " item";
       } else {
@@ -1355,7 +1355,7 @@ auto describe(const bool valid, const Instruction &step,
     std::ostringstream message;
     const auto minimum{instruction_value<ValueUnsignedInteger>(step) + 1};
     message << "The array value was expected to contain at least " << minimum;
-    assert(minimum > 0);
+    assert(minimum >= 0);
     if (minimum == 1) {
       message << " item";
     } else {
@@ -1390,7 +1390,7 @@ auto describe(const bool valid, const Instruction &step,
       std::ostringstream message;
       const auto maximum{instruction_value<ValueUnsignedInteger>(step) - 1};
       message << "The object value was expected to contain at most " << maximum;
-      assert(maximum > 0);
+      assert(maximum >= 0);
       if (maximum == 1) {
         message << " property";
       } else {
@@ -1404,7 +1404,9 @@ auto describe(const bool valid, const Instruction &step,
       }
 
       message << " it contained " << target.size();
-      if (target.size() == 1) {
+      if (target.size() == 0) {
+        message << " properties";
+      } else if (target.size() == 1) {
         message << " property: ";
         message << escape_string(target.as_object().cbegin()->first);
       } else {
@@ -1440,7 +1442,7 @@ auto describe(const bool valid, const Instruction &step,
       const auto minimum{instruction_value<ValueUnsignedInteger>(step) + 1};
       message << "The object value was expected to contain at least "
               << minimum;
-      assert(minimum > 0);
+      assert(minimum >= 0);
       if (minimum == 1) {
         message << " property";
       } else {

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -2006,13 +2006,15 @@ auto compiler_draft4_validation_minlength(const Context &context,
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionStringSizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{static_cast<unsigned long>(
+      schema_context.schema.at(dynamic_context.keyword).as_integer())};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionStringSizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{value - 1})};
 }
 
 auto compiler_draft4_validation_maxitems(const Context &context,
@@ -2068,13 +2070,15 @@ auto compiler_draft4_validation_minitems(const Context &context,
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionArraySizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{
+      schema_context.schema.at(dynamic_context.keyword).as_integer()};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionArraySizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{static_cast<unsigned long>(value - 1)})};
 }
 
 auto compiler_draft4_validation_maxproperties(
@@ -2130,13 +2134,15 @@ auto compiler_draft4_validation_minproperties(
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionObjectSizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{static_cast<unsigned long>(
+      schema_context.schema.at(dynamic_context.keyword).as_integer())};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionObjectSizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{value - 1})};
 }
 
 auto compiler_draft4_validation_maximum(const Context &context,

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -4937,6 +4937,26 @@ TEST(Evaluator_draft4, minLength_5) {
                                "The value was expected to be of type string");
 }
 
+TEST(Evaluator_draft4, minLength_6) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minLength": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{"x"};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
+TEST(Evaluator_draft4, minLength_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minLength": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{""};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
 TEST(Evaluator_draft4, maxLength_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -5068,6 +5088,44 @@ TEST(Evaluator_draft4, maxLength_6) {
       "The value was expected to consist of a string of 1 to 2 characters");
 }
 
+TEST(Evaluator_draft4, maxLength_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxLength": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{"x"};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringSizeLess, "/maxLength", "#/maxLength",
+                     "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionStringSizeLess, "/maxLength",
+                              "#/maxLength", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"x\" was expected to consist of at most 0 characters "
+      "but it consisted of 1 character");
+}
+
+TEST(Evaluator_draft4, maxLength_8) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxLength": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{""};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringSizeLess, "/maxLength", "#/maxLength",
+                     "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionStringSizeLess, "/maxLength",
+                              "#/maxLength", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"\" was expected to consist of at most 0 characters "
+      "and it consisted of 0 characters");
+}
+
 TEST(Evaluator_draft4, minItems_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -5195,6 +5253,85 @@ TEST(Evaluator_draft4, minItems_6) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type array");
+}
+
+TEST(Evaluator_draft4, minItems_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minItems": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[ 1 ]")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
+TEST(Evaluator_draft4, minItems_8) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minItems": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[]")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
+TEST(Evaluator_draft4, minItems_9) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "minItems": 0,
+    "items": {
+      "type": "number"
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[1]")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 2);
+
+  EVALUATE_TRACE_PRE(0, LoopItemsTypeStrictAny, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, LoopItemsTypeStrictAny, "/items", "#/items",
+                              "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The array items were expected to be of type number, or integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type array");
+}
+
+TEST(Evaluator_draft4, minItems_9_exhaustive) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "minItems": 0,
+    "items": {
+      "type": "number"
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[1]")};
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, LoopItems, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrictAny, "/items/type", "#/items/type",
+                     "/0");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrictAny, "/items/type",
+                              "#/items/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopItems, "/items", "#/items", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type number");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "Every item in the array value was expected to "
+                               "validate against the given subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The value was expected to be of type array");
 }
 
@@ -5349,6 +5486,42 @@ TEST(Evaluator_draft4, maxItems_7) {
       "The value was expected to consist of an array of 1 to 2 items");
 }
 
+TEST(Evaluator_draft4, maxItems_8) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxItems": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[ 1 ]")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionArraySizeLess, "/maxItems", "#/maxItems", "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionArraySizeLess, "/maxItems",
+                              "#/maxItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The array value was expected to contain at "
+                               "most 0 items but it contained 1 item");
+}
+
+TEST(Evaluator_draft4, maxItems_9) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxItems": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[]")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionArraySizeLess, "/maxItems", "#/maxItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionArraySizeLess, "/maxItems",
+                              "#/maxItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The array value was expected to contain at "
+                               "most 0 items and it contained 0 items");
+}
+
 TEST(Evaluator_draft4, minProperties_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -5462,6 +5635,27 @@ TEST(Evaluator_draft4, minProperties_5) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type object");
+}
+
+TEST(Evaluator_draft4, minProperties_6) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minProperties": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json("{ \"foo\": 1 }")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
+TEST(Evaluator_draft4, minProperties_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minProperties": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("{}")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
 }
 
 TEST(Evaluator_draft4, maxProperties_1) {
@@ -5604,6 +5798,47 @@ TEST(Evaluator_draft4, maxProperties_6) {
       "The value was expected to consist of an object of 1 to 2 properties");
 }
 
+TEST(Evaluator_draft4, maxProperties_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxProperties": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json("{ \"foo\": 1 }")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionObjectSizeLess, "/maxProperties",
+                     "#/maxProperties", "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionObjectSizeLess, "/maxProperties",
+                              "#/maxProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The object value was expected to contain at most 0 properties but it "
+      "contained 1 property: \"foo\"");
+}
+
+TEST(Evaluator_draft4, maxProperties_8) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maxProperties": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("{}")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionObjectSizeLess, "/maxProperties",
+                     "#/maxProperties", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionObjectSizeLess, "/maxProperties",
+                              "#/maxProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The object value was expected to contain at most 0 properties and it "
+      "contained 0 properties");
+}
+
 TEST(Evaluator_draft4, minimum_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -5668,6 +5903,42 @@ TEST(Evaluator_draft4, minimum_4) {
                                "greater than or equal to the integer 2");
 }
 
+TEST(Evaluator_draft4, minimum_5) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minimum": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{1};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionGreaterEqual, "/minimum", "#/minimum", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionGreaterEqual, "/minimum", "#/minimum",
+                              "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The integer value 1 was expected to be greater "
+                               "than or equal to the integer 0");
+}
+
+TEST(Evaluator_draft4, minimum_6) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minimum": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{0};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionGreaterEqual, "/minimum", "#/minimum", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionGreaterEqual, "/minimum", "#/minimum",
+                              "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The integer value 0 was expected to be greater "
+                               "than or equal to the integer 0");
+}
+
 TEST(Evaluator_draft4, maximum_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -5730,6 +6001,24 @@ TEST(Evaluator_draft4, maximum_4) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The number value 2.1 was expected to be less "
                                "than or equal to the integer 2");
+}
+
+TEST(Evaluator_draft4, maximum_5) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "maximum": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{0};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, AssertionLessEqual, "/maximum", "#/maximum", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionLessEqual, "/maximum", "#/maximum",
+                              "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The integer value 0 was expected to be less "
+                               "than or equal to the integer 0");
 }
 
 TEST(Evaluator_draft4, exclusiveMinimum_1) {

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -341,6 +341,24 @@ TEST(Evaluator_draft6, exclusiveMinimum_2) {
                                "than the integer 2, but they were equal");
 }
 
+TEST(Evaluator_draft6, exclusiveMinimum_3) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "exclusiveMinimum": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{1};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1);
+  EVALUATE_TRACE_PRE(0, AssertionGreater, "/exclusiveMinimum",
+                     "#/exclusiveMinimum", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionGreater, "/exclusiveMinimum",
+                              "#/exclusiveMinimum", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The integer value 1 was expected to be greater "
+                               "than the integer 0");
+}
+
 TEST(Evaluator_draft6, exclusiveMaximum_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
@@ -375,6 +393,24 @@ TEST(Evaluator_draft6, exclusiveMaximum_2) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The integer value 2 was expected to be less "
                                "than the integer 2, but they were equal");
+}
+
+TEST(Evaluator_draft6, exclusiveMaximum_3) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "exclusiveMaximum": 0
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{0};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 1);
+  EVALUATE_TRACE_PRE(0, AssertionLess, "/exclusiveMaximum",
+                     "#/exclusiveMaximum", "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionLess, "/exclusiveMaximum",
+                              "#/exclusiveMaximum", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The integer value 0 was expected to be less "
+                               "than the integer 0, but they were equal");
 }
 
 TEST(Evaluator_draft6, contains_1) {


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/277
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
