### PR TITLE
Fix typo in `ValidDefault` lint rule

### DIFF
--- a/src/linter/valid_default.cc
+++ b/src/linter/valid_default.cc
@@ -5,7 +5,7 @@ namespace sourcemeta::blaze {
 
 ValidDefault::ValidDefault(Compiler compiler)
     : sourcemeta::core::SchemaTransformRule{"blaze/valid_default",
-                                            "Only set a `default` valid that "
+                                            "Only set a `default` value that "
                                             "validates against the schema"},
       compiler_{std::move(compiler)} {};
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
