### PR TITLE
Rename `ErrorOutput` to `SimpleOutput`

### DIFF
--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -3,7 +3,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME compiler
   PRIVATE_HEADERS error.h output.h
   SOURCES
     compile.cc compile_describe.cc
-    compile_output_error.cc compile_output_trace.cc
+    compile_output_simple.cc compile_output_trace.cc
     compile_helpers.h default_compiler.cc
     default_compiler_2020_12.h
     default_compiler_2019_09.h

--- a/src/compiler/compile_output_simple.cc
+++ b/src/compiler/compile_output_simple.cc
@@ -9,23 +9,25 @@
 
 namespace sourcemeta::blaze {
 
-ErrorOutput::ErrorOutput(const sourcemeta::core::JSON &instance,
-                         const sourcemeta::core::WeakPointer &base)
+SimpleOutput::SimpleOutput(const sourcemeta::core::JSON &instance,
+                           const sourcemeta::core::WeakPointer &base)
     : instance_{instance}, base_{base} {}
 
-auto ErrorOutput::begin() const -> const_iterator {
+auto SimpleOutput::begin() const -> const_iterator {
   return this->output.begin();
 }
 
-auto ErrorOutput::end() const -> const_iterator { return this->output.end(); }
+auto SimpleOutput::end() const -> const_iterator { return this->output.end(); }
 
-auto ErrorOutput::cbegin() const -> const_iterator {
+auto SimpleOutput::cbegin() const -> const_iterator {
   return this->output.cbegin();
 }
 
-auto ErrorOutput::cend() const -> const_iterator { return this->output.cend(); }
+auto SimpleOutput::cend() const -> const_iterator {
+  return this->output.cend();
+}
 
-auto ErrorOutput::operator()(
+auto SimpleOutput::operator()(
     const EvaluationType type, const bool result, const Instruction &step,
     const sourcemeta::core::WeakPointer &evaluate_path,
     const sourcemeta::core::WeakPointer &instance_location,

--- a/src/compiler/include/sourcemeta/blaze/compiler_output.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_output.h
@@ -45,7 +45,7 @@ namespace sourcemeta::blaze {
 ///
 /// const sourcemeta::core::JSON instance{5};
 ///
-/// sourcemeta::blaze::ErrorOutput output{instance};
+/// sourcemeta::blaze::SimpleOutput output{instance};
 /// sourcemeta::blaze::Evaluator evaluator;
 /// const auto result{evaluator.validate(
 ///   schema_template, instance, std::ref(output))};
@@ -60,15 +60,15 @@ namespace sourcemeta::blaze {
 ///   }
 /// }
 /// ```
-class SOURCEMETA_BLAZE_COMPILER_EXPORT ErrorOutput {
+class SOURCEMETA_BLAZE_COMPILER_EXPORT SimpleOutput {
 public:
-  ErrorOutput(const sourcemeta::core::JSON &instance,
-              const sourcemeta::core::WeakPointer &base =
-                  sourcemeta::core::empty_weak_pointer);
+  SimpleOutput(const sourcemeta::core::JSON &instance,
+               const sourcemeta::core::WeakPointer &base =
+                   sourcemeta::core::empty_weak_pointer);
 
   // Prevent accidental copies
-  ErrorOutput(const ErrorOutput &) = delete;
-  auto operator=(const ErrorOutput &) -> ErrorOutput & = delete;
+  SimpleOutput(const SimpleOutput &) = delete;
+  auto operator=(const SimpleOutput &) -> SimpleOutput & = delete;
 
   struct Entry {
     const std::string message;
@@ -166,7 +166,7 @@ public:
                   sourcemeta::core::empty_weak_pointer);
 
   // Prevent accidental copies
-  TraceOutput(const ErrorOutput &) = delete;
+  TraceOutput(const TraceOutput &) = delete;
   auto operator=(const TraceOutput &) -> TraceOutput & = delete;
 
   enum class EntryType { Push, Pass, Fail, Annotation };

--- a/test/compiler/CMakeLists.txt
+++ b/test/compiler/CMakeLists.txt
@@ -1,6 +1,6 @@
 sourcemeta_googletest(NAMESPACE sourcemeta PROJECT blaze NAME compiler
   FOLDER "Blaze/Compiler"
-  SOURCES compiler_output_error_test.cc compiler_output_trace_test.cc)
+  SOURCES compiler_output_simple_test.cc compiler_output_trace_test.cc)
 
 target_link_libraries(sourcemeta_blaze_compiler_unit
   PRIVATE sourcemeta::core::json)

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -15,7 +15,7 @@
   EXPECT_EQ(sourcemeta::core::to_string(traces.at((index)).evaluate_path),     \
             expected_evaluate_path);
 
-TEST(Compiler_output_error, success_string_1) {
+TEST(Compiler_output_simple, success_string_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string"
@@ -28,18 +28,18 @@ TEST(Compiler_output_error, success_string_1) {
 
   const sourcemeta::core::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
-TEST(Compiler_output_error, fail_meaningless_if_1) {
+TEST(Compiler_output_simple, fail_meaningless_if_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
@@ -65,14 +65,14 @@ TEST(Compiler_output_error, fail_meaningless_if_1) {
     "bar": { "qux": {} }
   })JSON")};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 2);
 
@@ -84,7 +84,7 @@ TEST(Compiler_output_error, fail_meaningless_if_1) {
       "The object value was not expected to define unevaluated properties");
 }
 
-TEST(Compiler_output_error, success_dynamic_anchor_1) {
+TEST(Compiler_output_simple, success_dynamic_anchor_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$dynamicRef": "#foo",
@@ -103,18 +103,18 @@ TEST(Compiler_output_error, success_dynamic_anchor_1) {
 
   const sourcemeta::core::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
-TEST(Compiler_output_error, success_oneof_1) {
+TEST(Compiler_output_simple, success_oneof_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "oneOf": [
@@ -130,18 +130,18 @@ TEST(Compiler_output_error, success_oneof_1) {
 
   const sourcemeta::core::JSON instance{"fo"};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_TRUE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
   EXPECT_TRUE(traces.empty());
 }
 
-TEST(Compiler_output_error, fail_string) {
+TEST(Compiler_output_simple, fail_string) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string"
@@ -154,14 +154,14 @@ TEST(Compiler_output_error, fail_string) {
 
   const sourcemeta::core::JSON instance{5};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -169,7 +169,7 @@ TEST(Compiler_output_error, fail_string) {
       "The value was expected to be of type string but it was of type integer");
 }
 
-TEST(Compiler_output_error, fail_string_over_ref) {
+TEST(Compiler_output_simple, fail_string_over_ref) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$ref": "#/$defs/string",
@@ -187,14 +187,14 @@ TEST(Compiler_output_error, fail_string_over_ref) {
 
   const sourcemeta::core::JSON instance{5};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -202,7 +202,7 @@ TEST(Compiler_output_error, fail_string_over_ref) {
       "The value was expected to be of type string but it was of type integer");
 }
 
-TEST(Compiler_output_error, fail_string_with_matching_base) {
+TEST(Compiler_output_simple, fail_string_with_matching_base) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$ref": "#/$defs/string",
@@ -222,14 +222,14 @@ TEST(Compiler_output_error, fail_string_with_matching_base) {
 
   const std::string ref = "$ref";
   const sourcemeta::core::WeakPointer pointer{std::cref(ref)};
-  sourcemeta::blaze::ErrorOutput output{instance, pointer};
+  sourcemeta::blaze::SimpleOutput output{instance, pointer};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -237,7 +237,7 @@ TEST(Compiler_output_error, fail_string_with_matching_base) {
       "The value was expected to be of type string but it was of type integer");
 }
 
-TEST(Compiler_output_error, fail_string_with_non_matching_base) {
+TEST(Compiler_output_simple, fail_string_with_non_matching_base) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$ref": "#/$defs/string",
@@ -256,14 +256,14 @@ TEST(Compiler_output_error, fail_string_with_non_matching_base) {
   const sourcemeta::core::JSON instance{5};
   const std::string foo = "foo";
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
-  sourcemeta::blaze::ErrorOutput output{instance, pointer};
+  sourcemeta::blaze::SimpleOutput output{instance, pointer};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -271,7 +271,7 @@ TEST(Compiler_output_error, fail_string_with_non_matching_base) {
       "The value was expected to be of type string but it was of type integer");
 }
 
-TEST(Compiler_output_error, fail_oneof_1) {
+TEST(Compiler_output_simple, fail_oneof_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "oneOf": [
@@ -287,14 +287,14 @@ TEST(Compiler_output_error, fail_oneof_1) {
 
   const sourcemeta::core::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/oneOf",
@@ -302,7 +302,7 @@ TEST(Compiler_output_error, fail_oneof_1) {
                 "only one of the 2 given subschemas");
 }
 
-TEST(Compiler_output_error, fail_not_1) {
+TEST(Compiler_output_simple, fail_not_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "not": {
@@ -317,14 +317,14 @@ TEST(Compiler_output_error, fail_not_1) {
 
   const sourcemeta::core::JSON instance{"foo"};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/not",
@@ -332,7 +332,7 @@ TEST(Compiler_output_error, fail_not_1) {
                 "given subschema, but it did");
 }
 
-TEST(Compiler_output_error, fail_not_not_1) {
+TEST(Compiler_output_simple, fail_not_not_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "not": {
@@ -349,14 +349,14 @@ TEST(Compiler_output_error, fail_not_not_1) {
 
   const sourcemeta::core::JSON instance{1};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/not",
@@ -364,7 +364,7 @@ TEST(Compiler_output_error, fail_not_not_1) {
                 "given subschema, but it did");
 }
 
-TEST(Compiler_output_error, fail_anyof_1) {
+TEST(Compiler_output_simple, fail_anyof_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "allOf": [
@@ -387,14 +387,14 @@ TEST(Compiler_output_error, fail_anyof_1) {
     "bar": 1
   })JSON")};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
@@ -402,7 +402,7 @@ TEST(Compiler_output_error, fail_anyof_1) {
       "The value was expected to be of type integer but it was of type object");
 }
 
-TEST(Compiler_output_error, fail_anyof_2) {
+TEST(Compiler_output_simple, fail_anyof_2) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "anyOf": [
@@ -420,14 +420,14 @@ TEST(Compiler_output_error, fail_anyof_2) {
     "baz": 1
   })JSON")};
 
-  sourcemeta::blaze::ErrorOutput output{instance};
+  sourcemeta::blaze::SimpleOutput output{instance};
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
 
   EXPECT_FALSE(result);
-  std::vector<sourcemeta::blaze::ErrorOutput::Entry> traces{output.cbegin(),
-                                                            output.cend()};
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(traces, 0, "", "/anyOf",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
