### PR TITLE
Add a `compile()` overload that takes an existing schema frame

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,3 +1,3 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
-core https://github.com/sourcemeta/core 89c1394849a488667f03ec5ee1844326570f486d
+core https://github.com/sourcemeta/core 78c8548ce280f2bf88a1f21eb509046ac54f1532
 jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite 4ba013d58e747ecaf48c8bb7cf248cb0d564afbc

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -150,6 +150,24 @@ compile(const sourcemeta::core::JSON &schema,
 
 /// @ingroup compiler
 ///
+/// This function compiles an input JSON Schema into a template that can be
+/// later evaluated, but given an existing schema frame. The schema frame must
+/// contain reference information for the given schema and the input schema must
+/// be bundled. If those pre-conditions are not met, you will hit undefined
+/// behavior.
+///
+/// Don't use this function unless you know what you are doing.
+auto SOURCEMETA_BLAZE_COMPILER_EXPORT
+compile(const sourcemeta::core::JSON &schema,
+        const sourcemeta::core::SchemaWalker &walker,
+        const sourcemeta::core::SchemaResolver &resolver,
+        const Compiler &compiler, const sourcemeta::core::SchemaFrame &frame,
+        const Mode mode = Mode::FastValidation,
+        const std::optional<std::string> &default_dialect = std::nullopt)
+    -> Template;
+
+/// @ingroup compiler
+///
 /// This function compiles a single subschema into a compiler template as
 /// determined by the given pointer. If a URI is given, the compiler will
 /// attempt to jump to that corresponding frame entry. Otherwise, it will

--- a/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
+++ b/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
@@ -110,6 +110,9 @@ public:
 
   SchemaFrame(const Mode mode) : mode_{mode} {}
 
+  // Query the current mode that the schema frame was configured with
+  auto mode() const noexcept -> Mode { return this->mode_; }
+
   /// A single entry in a JSON Schema reference map
   struct ReferencesEntry {
     std::string destination;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
