### PR TITLE
Introduce a `compile` contrib program for fuzzing purposes

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,4 +1,13 @@
 if(BLAZE_COMPILER AND BLAZE_EVALUATOR)
+  sourcemeta_executable(NAMESPACE sourcemeta PROJECT blaze NAME contrib_compile
+    FOLDER "Blaze/Contrib" SOURCES compile.cc)
+  target_link_libraries(sourcemeta_blaze_contrib_compile
+    PRIVATE sourcemeta::core::json)
+  target_link_libraries(sourcemeta_blaze_contrib_compile
+    PRIVATE sourcemeta::core::jsonschema)
+  target_link_libraries(sourcemeta_blaze_contrib_compile
+    PRIVATE sourcemeta::blaze::compiler)
+
   sourcemeta_executable(NAMESPACE sourcemeta PROJECT blaze NAME contrib_validate
     FOLDER "Blaze/Contrib" SOURCES validate.cc)
   target_link_libraries(sourcemeta_blaze_contrib_validate

--- a/contrib/compile.cc
+++ b/contrib/compile.cc
@@ -1,0 +1,42 @@
+#include <sourcemeta/blaze/compiler.h>
+#include <sourcemeta/core/json.h>
+
+#include <chrono>   // std::chrono
+#include <cstdlib>  // EXIT_SUCCESS, EXIT_FAILURE
+#include <iostream> // std::cerr
+
+auto main(int argc, char **argv) noexcept -> int {
+  if (argc < 3) {
+    std::cerr << "Usage: " << argv[0] << " <fast|exhaustive> <schema.json>\n";
+    return EXIT_FAILURE;
+  }
+
+  const std::string mode_string{argv[1]};
+  auto mode{sourcemeta::blaze::Mode::FastValidation};
+  if (mode_string == "fast") {
+    std::cerr << "Choosing fast mode\n";
+  } else if (mode_string == "exhaustive") {
+    std::cerr << "Choosing exhaustive mode\n";
+    mode = sourcemeta::blaze::Mode::Exhaustive;
+  } else {
+    std::cerr << "Invalid mode: " << mode_string << "\n";
+    return EXIT_FAILURE;
+  }
+
+  const auto schema{sourcemeta::core::read_json(argv[2])};
+  std::cerr << "Compiling schema: " << argv[2] << "\n";
+  const auto compile_start{std::chrono::high_resolution_clock::now()};
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver,
+      sourcemeta::blaze::default_schema_compiler, mode)};
+  const auto compile_end{std::chrono::high_resolution_clock::now()};
+  const auto compile_duration{
+      std::chrono::duration_cast<std::chrono::milliseconds>(compile_end -
+                                                            compile_start)};
+  std::cerr << "Took: " << compile_duration.count() << "ms\n";
+  std::cerr << "Number of generated instructions: "
+            << schema_template.instructions.size() << "\n";
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
For example:

```sh
./build/contrib/sourcemeta_blaze_contrib_compile fast path/to/schema.json
./build/contrib/sourcemeta_blaze_contrib_compile exhaustive path/to/schema.json
```

See: https://github.com/sourcemeta/blaze/issues/99
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
