### PR TITLE
Fix Blaze linter rules assuming object schemas

### DIFF
--- a/src/linter/valid_default.cc
+++ b/src/linter/valid_default.cc
@@ -28,7 +28,7 @@ auto ValidDefault::condition(
     return false;
   }
 
-  if (!schema.defines("default")) {
+  if (!schema.is_object() || !schema.defines("default")) {
     return false;
   }
 

--- a/src/linter/valid_examples.cc
+++ b/src/linter/valid_examples.cc
@@ -26,8 +26,8 @@ auto ValidExamples::condition(
     return false;
   }
 
-  if (!schema.defines("examples") || !schema.at("examples").is_array() ||
-      schema.at("examples").empty()) {
+  if (!schema.is_object() || !schema.defines("examples") ||
+      !schema.at("examples").is_array() || schema.at("examples").empty()) {
     return false;
   }
 

--- a/test/linter/linter_valid_default_test.cc
+++ b/test/linter/linter_valid_default_test.cc
@@ -234,3 +234,29 @@ TEST(Linter, valid_default_7) {
 
   EXPECT_EQ(schema, expected);
 }
+
+TEST(Linter, valid_default_8) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "default": {}
+  })JSON")};
+
+  const auto result =
+      bundle.apply(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "default": {}
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}

--- a/test/linter/linter_valid_examples_test.cc
+++ b/test/linter/linter_valid_examples_test.cc
@@ -272,3 +272,29 @@ TEST(Linter, valid_examples_8) {
 
   EXPECT_EQ(schema, expected);
 }
+
+TEST(Linter, valid_examples_9) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "examples": [ {} ]
+  })JSON")};
+
+  const auto result =
+      bundle.apply(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "examples": [ {} ]
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/323
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
