### PR TITLE
Ensure that `items` emits no annotations for empty arrays

### DIFF
--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -542,6 +542,26 @@ TEST(Evaluator_2020_12, items_6_exhaustive) {
       "validate against the given subschema");
 }
 
+TEST(Evaluator_2020_12, items_7) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "items": { "type": "string" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[]")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 0);
+}
+
+TEST(Evaluator_2020_12, items_7_exhaustive) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "items": { "type": "string" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("[]")};
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(schema, instance, 0);
+}
+
 TEST(Evaluator_2020_12, prefixItems_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
