### PR TITLE
Don't emit duplicated `unevaluatedItems` annotations in `SimpleOutput`

### DIFF
--- a/src/compiler/compile_output_simple.cc
+++ b/src/compiler/compile_output_simple.cc
@@ -46,7 +46,15 @@ auto SimpleOutput::operator()(
     if (type == EvaluationType::Post) {
       Location location{instance_location, std::move(effective_evaluate_path),
                         step.keyword_location};
-      this->annotations_[std::move(location)].push_back(annotation);
+      const auto match{this->annotations_.find(location)};
+      if (match == this->annotations_.cend()) {
+        this->annotations_[std::move(location)].push_back(annotation);
+
+        // To avoid emitting the exact same annotation more than once
+        // This is right now mostly because of `unevaluatedItems`
+      } else if (match->second.back() != annotation) {
+        match->second.push_back(annotation);
+      }
     }
 
     return;

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -738,6 +738,35 @@ TEST(Compiler_output_simple, annotations_success_7) {
                           sourcemeta::core::JSON{0});
 }
 
+TEST(Compiler_output_simple, annotations_success_8) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedItems": true
+  })JSON")};
+
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::Exhaustive)};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json("[ 1, 2, 3, 4 ]")};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_TRUE(result);
+
+  EXPECT_ANNOTATION_COUNT(output, 1);
+
+  EXPECT_ANNOTATION_ENTRY(output, "", "/unevaluatedItems", "#/unevaluatedItems",
+                          1);
+  EXPECT_ANNOTATION_VALUE(output, "", "/unevaluatedItems", "#/unevaluatedItems",
+                          0, sourcemeta::core::JSON{true});
+}
+
 TEST(Compiler_output_simple, annotations_failure_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
