### PR TITLE
Fix `SimpleOutput` not reporting `contains` annotations

### DIFF
--- a/src/compiler/compile_output_simple.cc
+++ b/src/compiler/compile_output_simple.cc
@@ -71,7 +71,11 @@ auto SimpleOutput::operator()(
       this->mask.emplace(evaluate_path, false);
     }
   } else if (type == EvaluationType::Post &&
-             this->mask.contains(evaluate_path)) {
+             this->mask.contains(evaluate_path) &&
+
+             // TODO: We only have to do this because "contains" emits this
+             // instructions, when it should not
+             step.type != InstructionIndex::ControlEvaluate) {
     this->mask.erase(evaluate_path);
   }
 

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -767,6 +767,42 @@ TEST(Compiler_output_simple, annotations_success_8) {
                           0, sourcemeta::core::JSON{true});
 }
 
+TEST(Compiler_output_simple, annotations_success_9) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "type": "boolean" },
+    "unevaluatedItems": { "type": "number" }
+  })JSON")};
+
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::Exhaustive)};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json("[ true, 1, false, 2 ]")};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_TRUE(result);
+
+  EXPECT_ANNOTATION_COUNT(output, 2);
+
+  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 2);
+  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
+                          sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 1,
+                          sourcemeta::core::JSON{2});
+
+  EXPECT_ANNOTATION_ENTRY(output, "", "/unevaluatedItems", "#/unevaluatedItems",
+                          1);
+  EXPECT_ANNOTATION_VALUE(output, "", "/unevaluatedItems", "#/unevaluatedItems",
+                          0, sourcemeta::core::JSON{true});
+}
+
 TEST(Compiler_output_simple, annotations_failure_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
