### PR TITLE
Drop annotations from `contains` that were emitted to non-matching items

### DIFF
--- a/src/compiler/include/sourcemeta/blaze/compiler_output.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_output.h
@@ -19,6 +19,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <tuple>       // std::tie
+#include <utility>     // std::pair
 #include <vector>      // std::vector
 
 namespace sourcemeta::blaze {
@@ -126,7 +127,9 @@ private:
   const sourcemeta::core::JSON &instance_;
   const sourcemeta::core::WeakPointer base_;
   container_type output;
-  std::map<sourcemeta::core::WeakPointer, bool> mask;
+  std::set<
+      std::pair<sourcemeta::core::WeakPointer, sourcemeta::core::WeakPointer>>
+      mask;
   std::map<Location, std::vector<sourcemeta::core::JSON>> annotations_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -803,6 +803,36 @@ TEST(Compiler_output_simple, annotations_success_9) {
                           0, sourcemeta::core::JSON{true});
 }
 
+TEST(Compiler_output_simple, annotations_success_10) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "type": "number", "title": "Test" }
+  })JSON")};
+
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::Exhaustive)};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json("[ \"foo\", 42, true ]")};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_TRUE(result);
+
+  EXPECT_ANNOTATION_COUNT(output, 2);
+
+  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 1);
+  EXPECT_ANNOTATION_ENTRY(output, "/1", "/contains/title", "#/contains/title",
+                          1);
+  EXPECT_ANNOTATION_VALUE(output, "/1", "/contains/title", "#/contains/title",
+                          0, sourcemeta::core::JSON{"Test"});
+}
+
 TEST(Compiler_output_simple, annotations_failure_1) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/446
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
