### PR TITLE
Elevate the logic to get an instruction name to `Instruction` itself

### DIFF
--- a/src/compiler/compile_output_trace.cc
+++ b/src/compiler/compile_output_trace.cc
@@ -5,13 +5,6 @@
 #include <utility> // std::move
 #include <variant> // std::visit
 
-static auto step_name(const sourcemeta::blaze::Instruction &instruction)
-    -> std::string_view {
-  return sourcemeta::blaze::InstructionNames
-      [static_cast<std::underlying_type_t<sourcemeta::blaze::InstructionIndex>>(
-          instruction.type)];
-}
-
 static auto try_vocabulary(
     const std::optional<
         std::reference_wrapper<const sourcemeta::core::SchemaFrame>> &frame,
@@ -64,7 +57,7 @@ auto TraceOutput::operator()(
     const sourcemeta::core::WeakPointer &instance_location,
     const sourcemeta::core::JSON &annotation) -> void {
 
-  const auto short_step_name{step_name(step)};
+  const auto short_step_name{step.name()};
   auto effective_evaluate_path{evaluate_path.resolve_from(this->base_)};
 
   // Attempt to get vocabulary information if we can get it

--- a/src/evaluator/CMakeLists.txt
+++ b/src/evaluator/CMakeLists.txt
@@ -2,7 +2,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME evaluator
   FOLDER "Blaze/Evaluator"
   PRIVATE_HEADERS error.h value.h instruction.h string_set.h
   SOURCES evaluator.cc dispatch.inc.h
-          evaluator_string_set.cc
+          evaluator_string_set.cc evaluator_instruction.cc
           evaluator_complete.h evaluator_dynamic.h
           evaluator_track.h evaluator_fast.h)
 

--- a/src/evaluator/evaluator_instruction.cc
+++ b/src/evaluator/evaluator_instruction.cc
@@ -1,0 +1,12 @@
+#include <sourcemeta/blaze/evaluator_instruction.h>
+
+#include <type_traits> // std::underlying_type_t
+
+namespace sourcemeta::blaze {
+
+auto Instruction::name() const -> std::string_view {
+  return InstructionNames[static_cast<std::underlying_type_t<InstructionIndex>>(
+      this->type)];
+}
+
+} // namespace sourcemeta::blaze

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_instruction.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_instruction.h
@@ -1,6 +1,10 @@
 #ifndef SOURCEMETA_BLAZE_EVALUATOR_TEMPLATE_H
 #define SOURCEMETA_BLAZE_EVALUATOR_TEMPLATE_H
 
+#ifndef SOURCEMETA_BLAZE_EVALUATOR_EXPORT
+#include <sourcemeta/blaze/evaluator_export.h>
+#endif
+
 #include <sourcemeta/blaze/evaluator_value.h>
 
 #include <sourcemeta/core/jsonpointer.h>
@@ -245,6 +249,10 @@ struct Instruction {
   const std::size_t schema_resource;
   const Value value;
   const Instructions children;
+
+  /// Get the name of the instruction as a string
+  SOURCEMETA_BLAZE_EVALUATOR_EXPORT
+  auto name() const -> std::string_view;
 };
 
 } // namespace sourcemeta::blaze


### PR DESCRIPTION
As we will use this for other things now, like JSON serialisation.

Fixes: https://github.com/sourcemeta/blaze/issues/451
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
