### PR TITLE
Reuse `ValueIndexPair` in `ValueStringHashes`

### DIFF
--- a/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_value.h
@@ -116,9 +116,8 @@ using ValueTypedProperties = std::pair<ValueType, ValueStringSet>;
 
 /// @ingroup evaluator
 /// Represents a compiler step types property hashes value
-using ValueStringHashes =
-    std::pair<std::vector<ValueStringSet::hash_type>,
-              std::vector<std::pair<std::size_t, std::size_t>>>;
+using ValueStringHashes = std::pair<std::vector<ValueStringSet::hash_type>,
+                                    std::vector<ValueIndexPair>>;
 
 /// @ingroup evaluator
 /// Represents a compiler step types property hashes value


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/456
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
