### PR TITLE
Stop copying `schema_location` in `SimpleOutput::Location` every time

### DIFF
--- a/src/compiler/include/sourcemeta/blaze/compiler_output.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_output.h
@@ -104,14 +104,14 @@ public:
     auto operator<(const Location &other) const noexcept -> bool {
       // Perform a lexicographical comparison
       return std::tie(this->instance_location, this->evaluate_path,
-                      this->schema_location) < std::tie(other.instance_location,
-                                                        other.evaluate_path,
-                                                        other.schema_location);
+                      this->schema_location.get()) <
+             std::tie(other.instance_location, other.evaluate_path,
+                      other.schema_location.get());
     }
 
     const sourcemeta::core::WeakPointer instance_location;
     const sourcemeta::core::WeakPointer evaluate_path;
-    const std::string schema_location;
+    const std::reference_wrapper<const std::string> schema_location;
   };
 
   auto stacktrace(std::ostream &stream,

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -26,15 +26,12 @@
         sourcemeta::core::to_pointer(expected_instance_location)};             \
     const auto evaluate_path{                                                  \
         sourcemeta::core::to_pointer(expected_evaluate_path)};                 \
-    EXPECT_TRUE(output.annotations().contains(                                 \
-        {sourcemeta::core::to_weak_pointer(instance_location),                 \
-         sourcemeta::core::to_weak_pointer(evaluate_path),                     \
-         (expected_schema_location)}));                                        \
-    EXPECT_EQ(output.annotations()                                             \
-                  .at({sourcemeta::core::to_weak_pointer(instance_location),   \
-                       sourcemeta::core::to_weak_pointer(evaluate_path),       \
-                       (expected_schema_location)})                            \
-                  .size(),                                                     \
+    const std::string schema_location{expected_schema_location};               \
+    const sourcemeta::blaze::SimpleOutput::Location location{                  \
+        sourcemeta::core::to_weak_pointer(instance_location),                  \
+        sourcemeta::core::to_weak_pointer(evaluate_path), schema_location};    \
+    EXPECT_TRUE(output.annotations().contains(location));                      \
+    EXPECT_EQ(output.annotations().at(location).size(),                        \
               (expected_entry_count));                                         \
   }
 
@@ -46,11 +43,11 @@
         sourcemeta::core::to_pointer(expected_instance_location)};             \
     const auto evaluate_path{                                                  \
         sourcemeta::core::to_pointer(expected_evaluate_path)};                 \
-    EXPECT_EQ(output.annotations()                                             \
-                  .at({sourcemeta::core::to_weak_pointer(instance_location),   \
-                       sourcemeta::core::to_weak_pointer(evaluate_path),       \
-                       (expected_schema_location)})                            \
-                  .at(expected_entry_index),                                   \
+    const std::string schema_location{expected_schema_location};               \
+    const sourcemeta::blaze::SimpleOutput::Location location{                  \
+        sourcemeta::core::to_weak_pointer(instance_location),                  \
+        sourcemeta::core::to_weak_pointer(evaluate_path), schema_location};    \
+    EXPECT_EQ(output.annotations().at(location).at(expected_entry_index),      \
               (expected_value));                                               \
   }
 

--- a/test/evaluator/annotationsuite.cc
+++ b/test/evaluator/annotationsuite.cc
@@ -38,11 +38,11 @@ has_annotation(const sourcemeta::blaze::SimpleOutput &output,
   for (const auto &annotation : output.annotations()) {
     std::cerr << "Checking against annotations for instance location \""
               << sourcemeta::core::to_string(annotation.first.instance_location)
-              << "\" and schema location \"" << annotation.first.schema_location
-              << "\"" << "\n";
+              << "\" and schema location \""
+              << annotation.first.schema_location.get() << "\"" << "\n";
 
     if (annotation.first.instance_location != instance_location ||
-        annotation.first.schema_location != schema_location) {
+        annotation.first.schema_location.get() != schema_location) {
       continue;
     } else if (std::find(annotation.second.cbegin(), annotation.second.cend(),
                          value) != annotation.second.cend()) {


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/472
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
