### PR TITLE
Extend `SimpleOutput::Entry` with a `schema_location` field

### DIFF
--- a/src/compiler/compile_output_simple.cc
+++ b/src/compiler/compile_output_simple.cc
@@ -99,7 +99,8 @@ auto SimpleOutput::operator()(
   this->output.push_back(
       {describe(result, step, evaluate_path, instance_location, this->instance_,
                 annotation),
-       instance_location, std::move(effective_evaluate_path)});
+       instance_location, std::move(effective_evaluate_path),
+       step.keyword_location});
 }
 
 auto SimpleOutput::stacktrace(std::ostream &stream,

--- a/src/compiler/include/sourcemeta/blaze/compiler_output.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_output.h
@@ -81,6 +81,7 @@ public:
     const std::string message;
     const sourcemeta::core::WeakPointer instance_location;
     const sourcemeta::core::WeakPointer evaluate_path;
+    const std::reference_wrapper<const std::string> schema_location;
   };
 
   auto operator()(const EvaluationType type, const bool result,

--- a/test/compiler/compiler_output_simple_test.cc
+++ b/test/compiler/compiler_output_simple_test.cc
@@ -7,13 +7,16 @@
 #include <sourcemeta/core/jsonschema.h>
 
 #define EXPECT_OUTPUT(traces, index, expected_instance_location,               \
-                      expected_evaluate_path, expected_message)                \
+                      expected_evaluate_path, expected_schema_location,        \
+                      expected_message)                                        \
   EXPECT_TRUE(traces.size() > index);                                          \
   EXPECT_EQ(traces.at((index)).message, (expected_message));                   \
   EXPECT_EQ(sourcemeta::core::to_string(traces.at((index)).instance_location), \
             expected_instance_location);                                       \
   EXPECT_EQ(sourcemeta::core::to_string(traces.at((index)).evaluate_path),     \
-            expected_evaluate_path);
+            expected_evaluate_path);                                           \
+  EXPECT_EQ(traces.at((index)).schema_location.get(),                          \
+            (expected_schema_location));
 
 #define EXPECT_ANNOTATION_COUNT(output, expected_count)                        \
   EXPECT_EQ(output.annotations().size(), (expected_count));
@@ -116,9 +119,11 @@ TEST(Compiler_output_simple, fail_meaningless_if_1) {
 
   EXPECT_OUTPUT(
       traces, 0, "/foo/~1baz", "/properties/foo/unevaluatedProperties",
+      "#/properties/foo/unevaluatedProperties",
       "The object value was not expected to define the property \"/baz\"");
   EXPECT_OUTPUT(
       traces, 1, "/foo", "/properties/foo/unevaluatedProperties",
+      "#/properties/foo/unevaluatedProperties",
       "The object value was not expected to define unevaluated properties");
 
   EXPECT_ANNOTATION_COUNT(output, 0);
@@ -209,7 +214,7 @@ TEST(Compiler_output_simple, fail_string) {
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
-      traces, 0, "", "/type",
+      traces, 0, "", "/type", "#/type",
       "The value was expected to be of type string but it was of type integer");
 
   EXPECT_ANNOTATION_COUNT(output, 0);
@@ -244,7 +249,7 @@ TEST(Compiler_output_simple, fail_string_over_ref) {
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
-      traces, 0, "", "/$ref/type",
+      traces, 0, "", "/$ref/type", "#/$defs/string/type",
       "The value was expected to be of type string but it was of type integer");
   EXPECT_ANNOTATION_COUNT(output, 0);
 }
@@ -280,7 +285,7 @@ TEST(Compiler_output_simple, fail_string_with_matching_base) {
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
-      traces, 0, "", "/type",
+      traces, 0, "", "/type", "#/$defs/string/type",
       "The value was expected to be of type string but it was of type integer");
   EXPECT_ANNOTATION_COUNT(output, 0);
 }
@@ -315,7 +320,7 @@ TEST(Compiler_output_simple, fail_string_with_non_matching_base) {
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
-      traces, 0, "", "/$ref/type",
+      traces, 0, "", "/$ref/type", "#/$defs/string/type",
       "The value was expected to be of type string but it was of type integer");
   EXPECT_ANNOTATION_COUNT(output, 0);
 }
@@ -346,7 +351,7 @@ TEST(Compiler_output_simple, fail_oneof_1) {
                                                              output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
-  EXPECT_OUTPUT(traces, 0, "", "/oneOf",
+  EXPECT_OUTPUT(traces, 0, "", "/oneOf", "#/oneOf",
                 "The string value was expected to validate against one and "
                 "only one of the 2 given subschemas");
   EXPECT_ANNOTATION_COUNT(output, 0);
@@ -377,7 +382,7 @@ TEST(Compiler_output_simple, fail_not_1) {
                                                              output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
-  EXPECT_OUTPUT(traces, 0, "", "/not",
+  EXPECT_OUTPUT(traces, 0, "", "/not", "#/not",
                 "The string value was expected to not validate against the "
                 "given subschema, but it did");
   EXPECT_ANNOTATION_COUNT(output, 0);
@@ -410,7 +415,7 @@ TEST(Compiler_output_simple, fail_not_not_1) {
                                                              output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
-  EXPECT_OUTPUT(traces, 0, "", "/not",
+  EXPECT_OUTPUT(traces, 0, "", "/not", "#/not",
                 "The integer value was expected to not validate against the "
                 "given subschema, but it did");
   EXPECT_ANNOTATION_COUNT(output, 0);
@@ -450,7 +455,7 @@ TEST(Compiler_output_simple, fail_anyof_1) {
 
   EXPECT_EQ(traces.size(), 1);
   EXPECT_OUTPUT(
-      traces, 0, "", "/allOf/1/type",
+      traces, 0, "", "/allOf/1/type", "#/allOf/1/type",
       "The value was expected to be of type integer but it was of type object");
   EXPECT_ANNOTATION_COUNT(output, 0);
 }
@@ -483,7 +488,7 @@ TEST(Compiler_output_simple, fail_anyof_2) {
                                                              output.cend()};
 
   EXPECT_EQ(traces.size(), 1);
-  EXPECT_OUTPUT(traces, 0, "", "/anyOf",
+  EXPECT_OUTPUT(traces, 0, "", "/anyOf", "#/anyOf",
                 "The object value was expected to validate against at least "
                 "one of the 2 given subschemas");
   EXPECT_ANNOTATION_COUNT(output, 0);


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/474
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
