### PR TITLE
Fix `default`/`examples` lint rules on non-anonymous schemas

### DIFF
--- a/src/linter/valid_default.cc
+++ b/src/linter/valid_default.cc
@@ -15,7 +15,7 @@ ValidDefault::ValidDefault(Compiler compiler)
 auto ValidDefault::condition(
     const sourcemeta::core::JSON &schema, const sourcemeta::core::JSON &root,
     const sourcemeta::core::Vocabularies &vocabularies,
-    const sourcemeta::core::SchemaFrame &,
+    const sourcemeta::core::SchemaFrame &frame,
     const sourcemeta::core::SchemaFrame::Location &location,
     const sourcemeta::core::SchemaWalker &walker,
     const sourcemeta::core::SchemaResolver &resolver) const
@@ -36,11 +36,24 @@ auto ValidDefault::condition(
     return false;
   }
 
+  const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
+                                    .value_or(location)
+                                    .get()
+                                    .base_dialect};
+  std::optional<std::string> default_id{location.base};
+  if (sourcemeta::core::identify(root, root_base_dialect).has_value()) {
+    // We want to only set a default identifier if the root schema does not
+    // have an explicit identifier. Otherwise, we can get into corner case
+    // when wrapping the schema
+    default_id = std::nullopt;
+  }
+
   const auto subschema{sourcemeta::core::wrap(root, location.pointer, resolver,
                                               location.dialect)};
   const auto schema_template{compile(subschema, walker, resolver,
                                      this->compiler_, Mode::FastValidation,
-                                     location.dialect, location.base)};
+                                     location.dialect, default_id)};
+
   const auto &instance{schema.at("default")};
   Evaluator evaluator;
   const std::string ref{"$ref"};

--- a/test/linter/linter_valid_default_test.cc
+++ b/test/linter/linter_valid_default_test.cc
@@ -12,7 +12,7 @@ static auto transformer_callback_error(const sourcemeta::core::Pointer &,
   throw std::runtime_error("The transform callback must not be called");
 }
 
-TEST(Linter, valid_default_error_message) {
+TEST(Linter, valid_default_error_message_without_id_nested) {
   sourcemeta::core::SchemaTransformer bundle;
   bundle.add<sourcemeta::blaze::ValidDefault>(
       sourcemeta::blaze::default_schema_compiler);
@@ -43,6 +43,124 @@ TEST(Linter, valid_default_error_message) {
 
   EXPECT_EQ(std::get<0>(entries.at(0)),
             sourcemeta::core::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_default");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only set a `default` value that validates against the schema");
+  EXPECT_EQ(
+      std::get<3>(entries.at(0)),
+      R"TXT(The value was expected to be of type string but it was of type integer
+  at instance location ""
+  at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_default_error_message_without_id_flat) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "default": 1,
+    "type": "string"
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_default");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only set a `default` value that validates against the schema");
+  EXPECT_EQ(
+      std::get<3>(entries.at(0)),
+      R"TXT(The value was expected to be of type string but it was of type integer
+  at instance location ""
+  at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_default_error_message_with_id_nested) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "properties": {
+      "foo": {
+        "default": 1,
+        "type": "string"
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)),
+            sourcemeta::core::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_default");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only set a `default` value that validates against the schema");
+  EXPECT_EQ(
+      std::get<3>(entries.at(0)),
+      R"TXT(The value was expected to be of type string but it was of type integer
+  at instance location ""
+  at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_default_error_message_with_id_flat) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "default": 1,
+    "type": "string"
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
   EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_default");
   EXPECT_EQ(std::get<2>(entries.at(0)),
             "Only set a `default` value that validates against the schema");

--- a/test/linter/linter_valid_examples_test.cc
+++ b/test/linter/linter_valid_examples_test.cc
@@ -12,7 +12,7 @@ static auto transformer_callback_error(const sourcemeta::core::Pointer &,
   throw std::runtime_error("The transform callback must not be called");
 }
 
-TEST(Linter, valid_examples_error_message) {
+TEST(Linter, valid_examples_error_message_without_id_nested) {
   sourcemeta::core::SchemaTransformer bundle;
   bundle.add<sourcemeta::blaze::ValidExamples>(
       sourcemeta::blaze::default_schema_compiler);
@@ -43,6 +43,127 @@ TEST(Linter, valid_examples_error_message) {
 
   EXPECT_EQ(std::get<0>(entries.at(0)),
             sourcemeta::core::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_examples");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only include instances in the `examples` array that validate "
+            "against the schema");
+  EXPECT_EQ(std::get<3>(entries.at(0)),
+            R"TXT(Invalid example instance at index 0
+  The value was expected to be of type string but it was of type integer
+    at instance location ""
+    at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_examples_error_message_without_id_flat) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidExamples>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "examples": [ 1 ],
+    "type": "string"
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_examples");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only include instances in the `examples` array that validate "
+            "against the schema");
+  EXPECT_EQ(std::get<3>(entries.at(0)),
+            R"TXT(Invalid example instance at index 0
+  The value was expected to be of type string but it was of type integer
+    at instance location ""
+    at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_examples_error_message_with_id_nested) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidExamples>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "properties": {
+      "foo": {
+        "examples": [ 1 ],
+        "type": "string"
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)),
+            sourcemeta::core::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_examples");
+  EXPECT_EQ(std::get<2>(entries.at(0)),
+            "Only include instances in the `examples` array that validate "
+            "against the schema");
+  EXPECT_EQ(std::get<3>(entries.at(0)),
+            R"TXT(Invalid example instance at index 0
+  The value was expected to be of type string but it was of type integer
+    at instance location ""
+    at evaluate path "/type"
+)TXT");
+}
+
+TEST(Linter, valid_examples_error_message_with_id_flat) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidExamples>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "examples": [ 1 ],
+    "type": "string"
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         std::string>>
+      entries;
+  const bool result =
+      bundle.check(schema, sourcemeta::core::schema_official_walker,
+                   sourcemeta::core::schema_official_resolver,
+                   [&entries](const auto &pointer, const auto &name,
+                              const auto &message, const auto &description) {
+                     entries.emplace_back(pointer, name, message, description);
+                   });
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
   EXPECT_EQ(std::get<1>(entries.at(0)), "blaze/valid_examples");
   EXPECT_EQ(std::get<2>(entries.at(0)),
             "Only include instances in the `examples` array that validate "


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/pull/390
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
