### PR TITLE
Don't lint `examples` and `default` in Draft 7 and older given `$ref`

### DIFF
--- a/src/linter/valid_default.cc
+++ b/src/linter/valid_default.cc
@@ -36,6 +36,15 @@ auto ValidDefault::condition(
     return false;
   }
 
+  // We have to ignore siblings to `$ref`
+  if (vocabularies.contains("http://json-schema.org/draft-07/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-06/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-04/schema#")) {
+    if (schema.defines("$ref")) {
+      return false;
+    }
+  }
+
   const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
                                     .value_or(location)
                                     .get()

--- a/src/linter/valid_examples.cc
+++ b/src/linter/valid_examples.cc
@@ -44,6 +44,15 @@ auto ValidExamples::condition(
     return false;
   }
 
+  // We have to ignore siblings to `$ref`
+  if (vocabularies.contains("http://json-schema.org/draft-07/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-06/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-04/schema#")) {
+    if (schema.defines("$ref")) {
+      return false;
+    }
+  }
+
   const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
                                     .value_or(location)
                                     .get()

--- a/test/linter/linter_valid_default_test.cc
+++ b/test/linter/linter_valid_default_test.cc
@@ -573,3 +573,71 @@ TEST(Linter, valid_default_12) {
 
   EXPECT_EQ(schema, expected);
 }
+
+TEST(Linter, valid_default_13) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "default": 1 }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  const auto result = bundle.apply(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver, transformer_callback_error);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "default": 1 }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}
+
+TEST(Linter, valid_default_14) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidDefault>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "default": 1 }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  const auto result = bundle.apply(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver, transformer_callback_error);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper" }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}

--- a/test/linter/linter_valid_examples_test.cc
+++ b/test/linter/linter_valid_examples_test.cc
@@ -615,3 +615,71 @@ TEST(Linter, valid_examples_13) {
 
   EXPECT_EQ(schema, expected);
 }
+
+TEST(Linter, valid_examples_14) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidExamples>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "examples": [ 1 ] }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  const auto result = bundle.apply(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver, transformer_callback_error);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "examples": [ 1 ] }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}
+
+TEST(Linter, valid_examples_15) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::ValidExamples>(
+      sourcemeta::blaze::default_schema_compiler);
+
+  auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper", "examples": [ 1 ] }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  const auto result = bundle.apply(
+      schema, sourcemeta::core::schema_official_walker,
+      sourcemeta::core::schema_official_resolver, transformer_callback_error);
+
+  EXPECT_TRUE(result);
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "#/definitions/helper" }
+    },
+    "definitions": {
+      "helper": { "type": "string" }
+    }
+  })JSON")};
+
+  EXPECT_EQ(schema, expected);
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/493
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
