### PR TITLE
Make various compiler optimisations configurable

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -113,8 +113,10 @@ auto compile(const sourcemeta::core::JSON &schema,
              const Compiler &compiler,
              const sourcemeta::core::SchemaFrame &frame, const Mode mode,
              const std::optional<std::string> &default_dialect,
-             const std::optional<std::string> &default_id) -> Template {
+             const std::optional<std::string> &default_id,
+             const std::optional<Tweaks> &tweaks) -> Template {
   assert(is_schema(schema));
+  const auto effective_tweaks{tweaks.value_or(Tweaks{})};
 
   ///////////////////////////////////////////////////////////////////
   // (1) Determine the root frame entry
@@ -173,12 +175,9 @@ auto compile(const sourcemeta::core::JSON &schema,
   // Use string views to avoid copying the actual strings, as we know
   // that the frame survives the entire compilation process
   std::vector<std::tuple<std::string_view, std::size_t, std::size_t>>
-      sorted_references;
+      sorted_precompile_references;
 
-  constexpr auto PRECOMPILED_SCHEMAS_MAXIMUM{10};
-  constexpr auto PRECOMPILED_SCHEMAS_MINIMUM_COUNT{10};
-
-  {
+  if (effective_tweaks.precompile_static_references) {
     std::unordered_map<std::string_view, std::pair<std::size_t, std::size_t>>
         static_reference_destinations;
     for (const auto &reference : frame.references()) {
@@ -187,10 +186,9 @@ auto compile(const sourcemeta::core::JSON &schema,
           frame.locations().contains(
               {sourcemeta::core::SchemaReferenceType::Static,
                reference.second.destination})) {
-        // TODO: Maybe try circular references or non-circular with >100 inbound
-        // locations or something like that?
         std::unordered_set<std::string> visited;
-        if (!is_circular(frame, reference.first.second, reference.second,
+        if (!effective_tweaks.precompile_static_references_non_circular &&
+            !is_circular(frame, reference.first.second, reference.second,
                          visited)) {
           continue;
         }
@@ -204,36 +202,45 @@ auto compile(const sourcemeta::core::JSON &schema,
       }
     }
 
-    sorted_references.reserve(static_reference_destinations.size());
+    sorted_precompile_references.reserve(static_reference_destinations.size());
     for (const auto &reference : static_reference_destinations) {
-      if (reference.second.second >= PRECOMPILED_SCHEMAS_MINIMUM_COUNT) {
-        sorted_references.emplace_back(reference.first, reference.second.first,
-                                       reference.second.second);
+      if (reference.second.second >=
+          effective_tweaks
+              .precompile_static_references_minimum_reference_count) {
+        sorted_precompile_references.emplace_back(
+            reference.first, reference.second.first, reference.second.second);
       }
     }
-    std::ranges::sort(sorted_references,
+    std::ranges::sort(sorted_precompile_references,
                       [](const auto &left, const auto &right) {
                         return std::get<2>(left) > std::get<2>(right);
                       });
 
-    if (sorted_references.size() > PRECOMPILED_SCHEMAS_MAXIMUM) {
-      sorted_references.erase(sorted_references.begin() +
-                                  PRECOMPILED_SCHEMAS_MAXIMUM,
-                              sorted_references.end());
+    if (sorted_precompile_references.size() >
+        effective_tweaks.precompile_static_references_maximum_schemas) {
+      sorted_precompile_references.erase(
+          sorted_precompile_references.begin() +
+              static_cast<std::ptrdiff_t>(
+                  effective_tweaks
+                      .precompile_static_references_maximum_schemas),
+          sorted_precompile_references.end());
     }
 
     // We do not apply this pre-compilation optimisation on meta-schemas
     if (sourcemeta::core::schema_official_resolver(base).has_value() ||
         (uses_dynamic_scopes && schema.is_object() &&
          schema.defines("$vocabulary"))) {
-      sorted_references.clear();
+      sorted_precompile_references.clear();
     }
   }
 
-  assert(sorted_references.size() <= PRECOMPILED_SCHEMAS_MAXIMUM);
+  assert(sorted_precompile_references.size() <=
+         effective_tweaks.precompile_static_references_maximum_schemas);
   std::unordered_set<std::size_t> precompiled_labels;
-  for (const auto &reference : sorted_references) {
-    assert(std::get<2>(reference) >= PRECOMPILED_SCHEMAS_MINIMUM_COUNT);
+  for (const auto &reference : sorted_precompile_references) {
+    assert(
+        std::get<2>(reference) >=
+        effective_tweaks.precompile_static_references_minimum_reference_count);
     precompiled_labels.emplace(std::get<1>(reference));
   }
 
@@ -265,7 +272,8 @@ auto compile(const sourcemeta::core::JSON &schema,
                         .mode = mode,
                         .uses_dynamic_scopes = uses_dynamic_scopes,
                         .unevaluated = std::move(unevaluated),
-                        .precompiled_labels = std::move(precompiled_labels)};
+                        .precompiled_labels = std::move(precompiled_labels),
+                        .tweaks = effective_tweaks};
 
   ///////////////////////////////////////////////////////////////////
   // (7) Build the initial dynamic context
@@ -304,7 +312,7 @@ auto compile(const sourcemeta::core::JSON &schema,
 
   // Attempt to precompile static destinations to avoid explosive compilation
   Instructions static_reference_template;
-  for (const auto &reference : sorted_references) {
+  for (const auto &reference : sorted_precompile_references) {
     const auto entry{context.frame.locations().find(
         {sourcemeta::core::SchemaReferenceType::Static,
          std::string{std::get<0>(reference)}})};
@@ -377,7 +385,8 @@ auto compile(const sourcemeta::core::JSON &schema,
              const sourcemeta::core::SchemaResolver &resolver,
              const Compiler &compiler, const Mode mode,
              const std::optional<std::string> &default_dialect,
-             const std::optional<std::string> &default_id) -> Template {
+             const std::optional<std::string> &default_id,
+             const std::optional<Tweaks> &tweaks) -> Template {
   assert(is_schema(schema));
 
   // Make sure the input schema is bundled, otherwise we won't be able to
@@ -391,7 +400,7 @@ auto compile(const sourcemeta::core::JSON &schema,
   frame.analyse(result, walker, resolver, default_dialect, default_id);
 
   return compile(result, walker, resolver, compiler, frame, mode,
-                 default_dialect, default_id);
+                 default_dialect, default_id, tweaks);
 }
 
 auto compile(const Context &context, const SchemaContext &schema_context,

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -108,36 +108,38 @@ compile_properties(const sourcemeta::blaze::Context &context,
   // and some subschemas that are large. To attempt to improve performance,
   // we prefer to evaluate smaller subschemas first, in the hope of failing
   // earlier without spending a lot of time on other subschemas
-  std::sort(properties.begin(), properties.end(),
-            [](const auto &left, const auto &right) {
-              const auto left_size{recursive_template_size(left.second)};
-              const auto right_size{recursive_template_size(right.second)};
-              if (left_size == right_size) {
-                const auto left_direct_enumeration{
-                    defines_direct_enumeration(left.second)};
-                const auto right_direct_enumeration{
-                    defines_direct_enumeration(right.second)};
+  if (context.tweaks.properties_reorder) {
+    std::sort(properties.begin(), properties.end(),
+              [](const auto &left, const auto &right) {
+                const auto left_size{recursive_template_size(left.second)};
+                const auto right_size{recursive_template_size(right.second)};
+                if (left_size == right_size) {
+                  const auto left_direct_enumeration{
+                      defines_direct_enumeration(left.second)};
+                  const auto right_direct_enumeration{
+                      defines_direct_enumeration(right.second)};
 
-                // Enumerations always take precedence
-                if (left_direct_enumeration.has_value() &&
-                    right_direct_enumeration.has_value()) {
-                  // If both options have a direct enumeration, we choose
-                  // the one with the shorter relative schema location
-                  return relative_schema_location_size(
-                             left.second.at(left_direct_enumeration.value())) <
-                         relative_schema_location_size(
-                             right.second.at(right_direct_enumeration.value()));
-                } else if (left_direct_enumeration.has_value()) {
-                  return true;
-                } else if (right_direct_enumeration.has_value()) {
-                  return false;
+                  // Enumerations always take precedence
+                  if (left_direct_enumeration.has_value() &&
+                      right_direct_enumeration.has_value()) {
+                    // If both options have a direct enumeration, we choose
+                    // the one with the shorter relative schema location
+                    return relative_schema_location_size(left.second.at(
+                               left_direct_enumeration.value())) <
+                           relative_schema_location_size(right.second.at(
+                               right_direct_enumeration.value()));
+                  } else if (left_direct_enumeration.has_value()) {
+                    return true;
+                  } else if (right_direct_enumeration.has_value()) {
+                    return false;
+                  }
+
+                  return left.first < right.first;
+                } else {
+                  return left_size < right_size;
                 }
-
-                return left.first < right.first;
-              } else {
-                return left_size < right_size;
-              }
-            });
+              });
+  }
 
   return properties;
 }
@@ -776,6 +778,10 @@ auto compiler_draft4_applicator_oneof(const Context &context,
 auto properties_as_loop(const Context &context,
                         const SchemaContext &schema_context,
                         const sourcemeta::core::JSON &properties) -> bool {
+  if (context.tweaks.properties_always_unroll) {
+    return false;
+  }
+
   const auto size{properties.size()};
   const auto imports_validation_vocabulary =
       schema_context.vocabularies.contains(

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -82,6 +82,25 @@ enum class Mode : std::uint8_t {
 };
 
 /// @ingroup compiler
+/// Advanced knobs that you can tweak for higher control and optimisations
+struct Tweaks {
+  /// Attempt to precompile static references to speed up compilation
+  const bool precompile_static_references{true};
+  /// Consider static references that are not circular when precompiling static
+  /// references
+  const bool precompile_static_references_non_circular{false};
+  /// The maximum amount of static references to precompile
+  const std::size_t precompile_static_references_maximum_schemas{10};
+  /// The minimum amount of references to a destination before considering it
+  /// for precompilation
+  const std::size_t precompile_static_references_minimum_reference_count{10};
+  /// Always unroll `properties` in a logical AND operation
+  const bool properties_always_unroll{false};
+  /// Attempt to re-order `properties` subschemas to evaluate cheaper ones first
+  const bool properties_reorder{true};
+};
+
+/// @ingroup compiler
 /// The static compiler context is the information you have at your
 /// disposal to implement a keyword that will never change throughout
 /// the compilation process
@@ -106,6 +125,8 @@ struct Context {
   const SchemaUnevaluatedEntries unevaluated;
   /// The set of global labels identifier during precompilation
   std::unordered_set<std::size_t> precompiled_labels;
+  /// The set of global labels identifier during precompilation
+  const Tweaks tweaks;
 };
 
 /// @ingroup compiler
@@ -139,13 +160,14 @@ auto SOURCEMETA_BLAZE_COMPILER_EXPORT default_schema_compiler(
 ///
 /// // Evaluate or encode
 /// ```
-auto SOURCEMETA_BLAZE_COMPILER_EXPORT compile(
-    const sourcemeta::core::JSON &schema,
-    const sourcemeta::core::SchemaWalker &walker,
-    const sourcemeta::core::SchemaResolver &resolver, const Compiler &compiler,
-    const Mode mode = Mode::FastValidation,
-    const std::optional<std::string> &default_dialect = std::nullopt,
-    const std::optional<std::string> &default_id = std::nullopt) -> Template;
+auto SOURCEMETA_BLAZE_COMPILER_EXPORT
+compile(const sourcemeta::core::JSON &schema,
+        const sourcemeta::core::SchemaWalker &walker,
+        const sourcemeta::core::SchemaResolver &resolver,
+        const Compiler &compiler, const Mode mode = Mode::FastValidation,
+        const std::optional<std::string> &default_dialect = std::nullopt,
+        const std::optional<std::string> &default_id = std::nullopt,
+        const std::optional<Tweaks> &tweaks = std::nullopt) -> Template;
 
 /// @ingroup compiler
 ///
@@ -156,14 +178,15 @@ auto SOURCEMETA_BLAZE_COMPILER_EXPORT compile(
 /// behavior.
 ///
 /// Don't use this function unless you know what you are doing.
-auto SOURCEMETA_BLAZE_COMPILER_EXPORT compile(
-    const sourcemeta::core::JSON &schema,
-    const sourcemeta::core::SchemaWalker &walker,
-    const sourcemeta::core::SchemaResolver &resolver, const Compiler &compiler,
-    const sourcemeta::core::SchemaFrame &frame,
-    const Mode mode = Mode::FastValidation,
-    const std::optional<std::string> &default_dialect = std::nullopt,
-    const std::optional<std::string> &default_id = std::nullopt) -> Template;
+auto SOURCEMETA_BLAZE_COMPILER_EXPORT
+compile(const sourcemeta::core::JSON &schema,
+        const sourcemeta::core::SchemaWalker &walker,
+        const sourcemeta::core::SchemaResolver &resolver,
+        const Compiler &compiler, const sourcemeta::core::SchemaFrame &frame,
+        const Mode mode = Mode::FastValidation,
+        const std::optional<std::string> &default_dialect = std::nullopt,
+        const std::optional<std::string> &default_id = std::nullopt,
+        const std::optional<Tweaks> &tweaks = std::nullopt) -> Template;
 
 /// @ingroup compiler
 ///


### PR DESCRIPTION
Mainly for pre-compilation, but inherit some other ones from the linked
branch too.

See: https://github.com/sourcemeta/blaze/pull/374
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
