### PR TITLE
Remove redundant `precompile_static_references` tweak

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -177,7 +177,7 @@ auto compile(const sourcemeta::core::JSON &schema,
   std::vector<std::tuple<std::string_view, std::size_t, std::size_t>>
       sorted_precompile_references;
 
-  if (effective_tweaks.precompile_static_references) {
+  if (effective_tweaks.precompile_static_references_maximum_schemas > 0) {
     std::unordered_map<std::string_view, std::pair<std::size_t, std::size_t>>
         static_reference_destinations;
     for (const auto &reference : frame.references()) {

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -84,8 +84,6 @@ enum class Mode : std::uint8_t {
 /// @ingroup compiler
 /// Advanced knobs that you can tweak for higher control and optimisations
 struct Tweaks {
-  /// Attempt to precompile static references to speed up compilation
-  bool precompile_static_references{true};
   /// Consider static references that are not circular when precompiling static
   /// references
   bool precompile_static_references_non_circular{false};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
