### PR TITLE
Avoid copying `DynamicContext::keyword` every time

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -31,7 +31,7 @@ auto compile_subschema(const sourcemeta::blaze::Context &context,
       return {make(
           sourcemeta::blaze::InstructionIndex::AssertionFail, context,
           schema_context,
-          {.keyword = "",
+          {.keyword = KEYWORD_EMPTY,
            .base_schema_location = dynamic_context.base_schema_location,
            .base_instance_location = dynamic_context.base_instance_location,
            .property_as_target = dynamic_context.property_as_target},

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -13,6 +13,12 @@
 
 namespace sourcemeta::blaze {
 
+// Static keyword strings for use in DynamicContext references
+static const sourcemeta::core::JSON::String KEYWORD_EMPTY{};
+static const sourcemeta::core::JSON::String KEYWORD_PROPERTIES{"properties"};
+static const sourcemeta::core::JSON::String KEYWORD_THEN{"then"};
+static const sourcemeta::core::JSON::String KEYWORD_ELSE{"else"};
+
 // Helper to create a single-element WeakPointer from a property name reference
 inline auto make_weak_pointer(const std::string &property)
     -> sourcemeta::core::WeakPointer {
@@ -42,7 +48,7 @@ inline auto make_weak_pointer(const std::string &property1,
 }
 
 inline auto relative_dynamic_context() -> DynamicContext {
-  return {.keyword = "",
+  return {.keyword = KEYWORD_EMPTY,
           .base_schema_location = sourcemeta::core::empty_weak_pointer,
           .base_instance_location = sourcemeta::core::empty_weak_pointer,
           .property_as_target = false};
@@ -50,14 +56,14 @@ inline auto relative_dynamic_context() -> DynamicContext {
 
 inline auto relative_dynamic_context(const DynamicContext &dynamic_context)
     -> DynamicContext {
-  return {.keyword = "",
+  return {.keyword = KEYWORD_EMPTY,
           .base_schema_location = sourcemeta::core::empty_weak_pointer,
           .base_instance_location = sourcemeta::core::empty_weak_pointer,
           .property_as_target = dynamic_context.property_as_target};
 }
 
 inline auto property_relative_dynamic_context() -> DynamicContext {
-  return {.keyword = "",
+  return {.keyword = KEYWORD_EMPTY,
           .base_schema_location = sourcemeta::core::empty_weak_pointer,
           .base_instance_location = sourcemeta::core::empty_weak_pointer,
           .property_as_target = true};

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -505,7 +505,7 @@ auto compiler_draft4_validation_required(const Context &context,
             .base = schema_context.base,
             .is_property_name = schema_context.is_property_name};
         const DynamicContext new_dynamic_context{
-            .keyword = "properties",
+            .keyword = KEYWORD_PROPERTIES,
             .base_schema_location = sourcemeta::core::empty_weak_pointer,
             .base_instance_location = sourcemeta::core::empty_weak_pointer,
             .property_as_target = false};

--- a/src/compiler/default_compiler_draft7.h
+++ b/src/compiler/default_compiler_draft7.h
@@ -20,18 +20,17 @@ auto compiler_draft7_applicator_if(const Context &context,
                                 sourcemeta::core::empty_weak_pointer)};
 
   // `then`
-  static const std::string then_keyword{"then"};
   std::size_t then_cursor{children.size()};
   if (schema_context.schema.defines("then")) {
     const auto destination{
         to_uri(schema_context.relative_pointer.initial().concat(
-                   make_weak_pointer(then_keyword)),
+                   make_weak_pointer(KEYWORD_THEN)),
                schema_context.base)
             .recompose()};
     assert(context.frame.locations().contains(
         {sourcemeta::core::SchemaReferenceType::Static, destination}));
     DynamicContext new_dynamic_context{
-        .keyword = "then",
+        .keyword = KEYWORD_THEN,
         .base_schema_location = dynamic_context.base_schema_location,
         .base_instance_location = sourcemeta::core::empty_weak_pointer,
         .property_as_target = dynamic_context.property_as_target};
@@ -49,19 +48,18 @@ auto compiler_draft7_applicator_if(const Context &context,
   }
 
   // `else`
-  static const std::string else_keyword{"else"};
   std::size_t else_cursor{0};
   if (schema_context.schema.defines("else")) {
     else_cursor = children.size();
     const auto destination{
         to_uri(schema_context.relative_pointer.initial().concat(
-                   make_weak_pointer(else_keyword)),
+                   make_weak_pointer(KEYWORD_ELSE)),
                schema_context.base)
             .recompose()};
     assert(context.frame.locations().contains(
         {sourcemeta::core::SchemaReferenceType::Static, destination}));
     DynamicContext new_dynamic_context{
-        .keyword = "else",
+        .keyword = KEYWORD_ELSE,
         .base_schema_location = dynamic_context.base_schema_location,
         .base_instance_location = sourcemeta::core::empty_weak_pointer,
         .property_as_target = dynamic_context.property_as_target};

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -56,7 +56,7 @@ struct SchemaContext {
 struct DynamicContext {
   // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   /// The schema keyword
-  const std::string keyword;
+  const sourcemeta::core::JSON::String &keyword;
   /// The schema base keyword path
   const sourcemeta::core::WeakPointer &base_schema_location;
   /// The base instance location that the keyword must be evaluated to


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
