### PR TITLE
Preserve certain errors when linting `default`/`examples`

### DIFF
--- a/src/alterschema/linter/valid_default.h
+++ b/src/alterschema/linter/valid_default.h
@@ -41,6 +41,10 @@ public:
       try {
         schema_template = compile(root, walker, resolver, this->compiler_,
                                   frame, base.value().get(), Mode::Exhaustive);
+      } catch (const CompilerReferenceTargetNotSchemaError &) {
+        throw;
+      } catch (const sourcemeta::core::SchemaVocabularyError &) {
+        throw;
       } catch (...) {
         return false;
       }
@@ -81,6 +85,10 @@ public:
     try {
       schema_template = compile(subschema, walker, resolver, this->compiler_,
                                 Mode::Exhaustive, location.dialect, default_id);
+    } catch (const CompilerReferenceTargetNotSchemaError &) {
+      throw;
+    } catch (const sourcemeta::core::SchemaVocabularyError &) {
+      throw;
     } catch (...) {
       return false;
     }

--- a/src/alterschema/linter/valid_examples.h
+++ b/src/alterschema/linter/valid_examples.h
@@ -42,6 +42,10 @@ public:
       try {
         schema_template = compile(root, walker, resolver, this->compiler_,
                                   frame, base.value().get(), Mode::Exhaustive);
+      } catch (const CompilerReferenceTargetNotSchemaError &) {
+        throw;
+      } catch (const sourcemeta::core::SchemaVocabularyError &) {
+        throw;
       } catch (...) {
         return false;
       }
@@ -90,6 +94,10 @@ public:
     try {
       schema_template = compile(subschema, walker, resolver, this->compiler_,
                                 Mode::Exhaustive, location.dialect, default_id);
+    } catch (const CompilerReferenceTargetNotSchemaError &) {
+      throw;
+    } catch (const sourcemeta::core::SchemaVocabularyError &) {
+      throw;
     } catch (...) {
       return false;
     }

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -11729,3 +11729,38 @@ TEST(AlterSchema_lint_2020_12,
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2020_12, valid_default_throws_on_unsupported_vocabulary) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/unsupported-vocabulary-metaschema",
+    "type": "string",
+    "default": "hello"
+  })JSON");
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
+  EXPECT_THROW(static_cast<void>(
+                   bundle.check(document, sourcemeta::core::schema_walker,
+                                alterschema_test_resolver,
+                                [](const auto &, const auto &, const auto &,
+                                   const auto &, const auto &) {})),
+               sourcemeta::core::SchemaVocabularyError);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     valid_examples_throws_on_unsupported_vocabulary) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/unsupported-vocabulary-metaschema",
+    "type": "string",
+    "examples": [ "hello" ]
+  })JSON");
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
+  EXPECT_THROW(static_cast<void>(
+                   bundle.check(document, sourcemeta::core::schema_walker,
+                                alterschema_test_resolver,
+                                [](const auto &, const auto &, const auto &,
+                                   const auto &, const auto &) {})),
+               sourcemeta::core::SchemaVocabularyError);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <sourcemeta/blaze/compiler_error.h>
 #include <sourcemeta/core/json.h>
 
 #include "alterschema_test_utils.h"
@@ -4455,4 +4456,48 @@ TEST(AlterSchema_lint_draft7, quintuple_negation_to_single) {
   })JSON");
 
   EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft7, valid_default_throws_on_invalid_ref_target) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "#/$defs/foo" }
+    ],
+    "$defs": {
+      "foo": { "type": "string" }
+    },
+    "default": "test"
+  })JSON");
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
+  EXPECT_THROW(static_cast<void>(
+                   bundle.check(document, sourcemeta::core::schema_walker,
+                                alterschema_test_resolver,
+                                [](const auto &, const auto &, const auto &,
+                                   const auto &, const auto &) {})),
+               sourcemeta::blaze::CompilerReferenceTargetNotSchemaError);
+}
+
+TEST(AlterSchema_lint_draft7, valid_examples_throws_on_invalid_ref_target) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "#/$defs/foo" }
+    ],
+    "$defs": {
+      "foo": { "type": "string" }
+    },
+    "examples": [ "test" ]
+  })JSON");
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
+  EXPECT_THROW(static_cast<void>(
+                   bundle.check(document, sourcemeta::core::schema_walker,
+                                alterschema_test_resolver,
+                                [](const auto &, const auto &, const auto &,
+                                   const auto &, const auto &) {})),
+               sourcemeta::blaze::CompilerReferenceTargetNotSchemaError);
 }

--- a/test/alterschema/alterschema_test_utils.h
+++ b/test/alterschema/alterschema_test_utils.h
@@ -50,6 +50,19 @@ static auto alterschema_test_resolver(std::string_view identifier)
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "integer"
     })JSON");
+  } else if (identifier ==
+             "https://example.com/unsupported-vocabulary-metaschema") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$id": "https://example.com/unsupported-vocabulary-metaschema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+      }
+    })JSON");
   } else {
     return sourcemeta::core::schema_resolver(identifier);
   }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
