### PR TITLE
Property support the empty `enum` in 2019-09 and 2020-12

### DIFF
--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -2059,6 +2059,11 @@ auto compiler_draft4_validation_enum(const Context &context,
     return {};
   }
 
+  if (schema_context.schema.at(dynamic_context.keyword).empty()) {
+    return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
+                 schema_context, dynamic_context, ValueNone{})};
+  }
+
   if (schema_context.schema.at(dynamic_context.keyword).size() == 1) {
     return {
         make(sourcemeta::blaze::InstructionIndex::AssertionEqual, context,

--- a/src/evaluator/evaluator_describe.cc
+++ b/src/evaluator/evaluator_describe.cc
@@ -216,6 +216,14 @@ auto describe(const bool valid, const Instruction &step,
   const sourcemeta::core::JSON &target{get(instance, instance_location)};
 
   if (step.type == sourcemeta::blaze::InstructionIndex::AssertionFail) {
+    if (keyword == "enum") {
+      std::ostringstream message;
+      message << "The " << type_name(target.type())
+              << " value was not expected to validate against the empty "
+                 "enumeration";
+      return message.str();
+    }
+
     if (keyword == "contains") {
       return "The constraints declared for this keyword were not satisfiable";
     }

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -4819,5 +4819,61 @@
         "The object value was not expected to define unevaluated properties"
       ]
     }
+  },
+  {
+    "description": "empty_enum_string",
+    "schema": { "$schema": "https://json-schema.org/draft/2019-09/schema", "enum": [] },
+    "instance": "foo",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The string value was not expected to validate against the empty enumeration"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The string value was not expected to validate against the empty enumeration"
+      ]
+    }
+  },
+  {
+    "description": "empty_enum_integer",
+    "schema": { "$schema": "https://json-schema.org/draft/2019-09/schema", "enum": [] },
+    "instance": 42,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The integer value was not expected to validate against the empty enumeration"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The integer value was not expected to validate against the empty enumeration"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -4338,5 +4338,61 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "empty_enum_string",
+    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "enum": [] },
+    "instance": "foo",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The string value was not expected to validate against the empty enumeration"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The string value was not expected to validate against the empty enumeration"
+      ]
+    }
+  },
+  {
+    "description": "empty_enum_integer",
+    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "enum": [] },
+    "instance": 42,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The integer value was not expected to validate against the empty enumeration"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+      ],
+      "descriptions": [
+        "The integer value was not expected to validate against the empty enumeration"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
