### PR TITLE
Introduce a new `portable_anchor_names` linter rule

### DIFF
--- a/src/alterschema/CMakeLists.txt
+++ b/src/alterschema/CMakeLists.txt
@@ -133,6 +133,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME alterschema
     linter/items_schema_default.h
     linter/multiple_of_default.h
     linter/pattern_properties_default.h
+    linter/portable_anchor_names.h
     linter/properties_default.h
     linter/property_names_default.h
     linter/property_names_type_default.h

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -243,6 +243,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "linter/items_schema_default.h"
 #include "linter/multiple_of_default.h"
 #include "linter/pattern_properties_default.h"
+#include "linter/portable_anchor_names.h"
 #include "linter/properties_default.h"
 #include "linter/property_names_default.h"
 #include "linter/property_names_type_default.h"
@@ -435,6 +436,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<CommentTrim>();
     bundle.add<DuplicateExamples>();
     bundle.add<SimplePropertiesIdentifiers>();
+    bundle.add<PortableAnchorNames>();
     bundle.add<InvalidExternalRef>();
     bundle.add<ValidDefault>();
     bundle.add<ValidExamples>();

--- a/src/alterschema/linter/portable_anchor_names.h
+++ b/src/alterschema/linter/portable_anchor_names.h
@@ -58,11 +58,8 @@ private:
       "$dynamicAnchor"};
   static inline const sourcemeta::core::JSON::String ID_MODERN{"$id"};
   static inline const sourcemeta::core::JSON::String ID_DRAFT_4{"id"};
-
-  static auto safe_anchor_pattern() -> const Regex & {
-    static const Regex pattern{to_regex("^[A-Za-z][A-Za-z0-9_.-]*$").value()};
-    return pattern;
-  }
+  static inline const Regex SAFE_ANCHOR_PATTERN{
+      to_regex("^[A-Za-z][A-Za-z0-9_.-]*$").value()};
 
   static auto
   check_anchor_keyword(const sourcemeta::core::JSON &schema,
@@ -79,7 +76,7 @@ private:
       return;
     }
 
-    if (!matches(safe_anchor_pattern(),
+    if (!matches(SAFE_ANCHOR_PATTERN,
                  sourcemeta::core::JSON::String{fragment.value()})) {
       offenders.push_back(Pointer{keyword});
     }
@@ -103,7 +100,7 @@ private:
       return;
     }
 
-    if (!matches(safe_anchor_pattern(),
+    if (!matches(SAFE_ANCHOR_PATTERN,
                  sourcemeta::core::JSON::String{fragment.value()})) {
       offenders.push_back(Pointer{keyword});
     }

--- a/src/alterschema/linter/portable_anchor_names.h
+++ b/src/alterschema/linter/portable_anchor_names.h
@@ -1,0 +1,111 @@
+class PortableAnchorNames final : public SchemaTransformRule {
+public:
+  using mutates = std::false_type;
+  using reframe_after_transform = std::false_type;
+  PortableAnchorNames()
+      : SchemaTransformRule{
+            "portable_anchor_names",
+            "Keep anchors within the safe allowed character set across JSON "
+            "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+        {Vocabularies::Known::JSON_Schema_2020_12_Core,
+         Vocabularies::Known::JSON_Schema_2019_09_Core,
+         Vocabularies::Known::JSON_Schema_Draft_7,
+         Vocabularies::Known::JSON_Schema_Draft_6,
+         Vocabularies::Known::JSON_Schema_Draft_4}));
+    ONLY_CONTINUE_IF(schema.is_object());
+
+    std::vector<Pointer> offenders;
+
+    if (vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2020_12_Core,
+             Vocabularies::Known::JSON_Schema_2019_09_Core})) {
+      this->check_anchor_keyword(schema, ANCHOR, offenders);
+    }
+
+    if (vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2020_12_Core})) {
+      this->check_anchor_keyword(schema, DYNAMIC_ANCHOR, offenders);
+    }
+
+    if (vocabularies.contains_any({Vocabularies::Known::JSON_Schema_Draft_7,
+                                   Vocabularies::Known::JSON_Schema_Draft_6,
+                                   Vocabularies::Known::JSON_Schema_Draft_4})) {
+      const auto &id_keyword{
+          vocabularies.contains_any({Vocabularies::Known::JSON_Schema_Draft_4})
+              ? ID_DRAFT_4
+              : ID_MODERN};
+      this->check_id_fragment(schema, id_keyword, offenders);
+    }
+
+    ONLY_CONTINUE_IF(!offenders.empty());
+    return APPLIES_TO_POINTERS(std::move(offenders));
+  }
+
+private:
+  static inline const sourcemeta::core::JSON::String ANCHOR{"$anchor"};
+  static inline const sourcemeta::core::JSON::String DYNAMIC_ANCHOR{
+      "$dynamicAnchor"};
+  static inline const sourcemeta::core::JSON::String ID_MODERN{"$id"};
+  static inline const sourcemeta::core::JSON::String ID_DRAFT_4{"id"};
+
+  static auto safe_anchor_pattern() -> const Regex & {
+    static const Regex pattern{to_regex("^[A-Za-z][A-Za-z0-9_.-]*$").value()};
+    return pattern;
+  }
+
+  static auto
+  check_anchor_keyword(const sourcemeta::core::JSON &schema,
+                       const sourcemeta::core::JSON::String &keyword,
+                       std::vector<Pointer> &offenders) -> void {
+    if (!schema.defines(keyword) || !schema.at(keyword).is_string()) {
+      return;
+    }
+
+    const auto fragment{
+        sourcemeta::core::URI::from_fragment(schema.at(keyword).to_string())
+            .fragment()};
+    if (!fragment.has_value() || fragment.value().empty()) {
+      return;
+    }
+
+    if (!matches(safe_anchor_pattern(),
+                 sourcemeta::core::JSON::String{fragment.value()})) {
+      offenders.push_back(Pointer{keyword});
+    }
+  }
+
+  static auto check_id_fragment(const sourcemeta::core::JSON &schema,
+                                const sourcemeta::core::JSON::String &keyword,
+                                std::vector<Pointer> &offenders) -> void {
+    if (!schema.defines(keyword) || !schema.at(keyword).is_string()) {
+      return;
+    }
+
+    const auto &value{schema.at(keyword).to_string()};
+    if (value.find('#') == sourcemeta::core::JSON::String::npos) {
+      return;
+    }
+
+    const sourcemeta::core::URI uri{value};
+    const auto fragment{uri.fragment()};
+    if (!fragment.has_value() || fragment.value().empty()) {
+      return;
+    }
+
+    if (!matches(safe_anchor_pattern(),
+                 sourcemeta::core::JSON::String{fragment.value()})) {
+      offenders.push_back(Pointer{keyword});
+    }
+  }
+};

--- a/src/alterschema/linter/portable_anchor_names.h
+++ b/src/alterschema/linter/portable_anchor_names.h
@@ -69,15 +69,12 @@ private:
       return;
     }
 
-    const auto fragment{
-        sourcemeta::core::URI::from_fragment(schema.at(keyword).to_string())
-            .fragment()};
-    if (!fragment.has_value() || fragment.value().empty()) {
+    const auto &value{schema.at(keyword).to_string()};
+    if (value.empty()) {
       return;
     }
 
-    if (!matches(SAFE_ANCHOR_PATTERN,
-                 sourcemeta::core::JSON::String{fragment.value()})) {
+    if (!matches(SAFE_ANCHOR_PATTERN, value)) {
       offenders.push_back(Pointer{keyword});
     }
   }

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -5243,3 +5243,75 @@ TEST(AlterSchema_lint_2019_09, recursive_ref_stays_dynamic_with_anchor) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2019_09, portable_anchor_names_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$anchor": "Foo.bar-baz"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, portable_anchor_names_anchor_colon) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$anchor": "foo:bar"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, portable_anchor_names_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "$anchor": "inner:bad" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, portable_anchor_names_id_no_fragment_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com/my-schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -11764,3 +11764,120 @@ TEST(AlterSchema_lint_2020_12,
                                    const auto &, const auto &) {})),
                sourcemeta::core::SchemaVocabularyError);
 }
+
+TEST(AlterSchema_lint_2020_12, portable_anchor_names_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$anchor": "foo",
+    "$dynamicAnchor": "Bar.baz-qux"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     portable_anchor_names_anchor_leading_underscore) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$anchor": "_foo"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     portable_anchor_names_dynamic_anchor_leading_underscore) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$dynamicAnchor": "_foo"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     portable_anchor_names_anchor_and_dynamic_anchor) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "$anchor": "_foo",
+    "$dynamicAnchor": "_bar"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, portable_anchor_names_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "$anchor": "_inner" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, portable_anchor_names_id_no_fragment_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/my-schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -2846,3 +2846,137 @@ TEST(AlterSchema_lint_draft4, valid_default_7) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#Foo.bar-baz",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_fragment_colon) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#foo:bar",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_fragment_slash) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#foo/bar",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_fragment_leading_digit) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#1foo",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_bare_hash_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_empty_string_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_id_no_fragment_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com/my-schema",
+    "title": "Test",
+    "description": "A test schema"
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, portable_anchor_names_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "id": "#inner:bad" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -3222,3 +3222,105 @@ TEST(AlterSchema_lint_draft6, valid_default_6) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "#Foo.bar-baz",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_id_fragment_colon) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "#foo:bar",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_id_bare_hash_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_id_empty_string_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_id_no_fragment_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/my-schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, portable_anchor_names_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "$id": "#inner:bad" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -4501,3 +4501,105 @@ TEST(AlterSchema_lint_draft7, valid_examples_throws_on_invalid_ref_target) {
                                    const auto &, const auto &) {})),
                sourcemeta::blaze::CompilerReferenceTargetNotSchemaError);
 }
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "#Foo.bar-baz",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_id_fragment_colon) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "#foo:bar",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_id_bare_hash_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_id_empty_string_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_id_no_fragment_skipped) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/my-schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ]
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, portable_anchor_names_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "$id": "#inner:bad" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "portable_anchor_names",
+      "Keep anchors within the safe allowed character set across JSON "
+      "Schema dialects (`^[A-Za-z][A-Za-z0-9_.-]*$`)",
+      false);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
