### PR TITLE
Fix `multipleOf` / `divisibleBy` invalid linter suggestions

### DIFF
--- a/src/alterschema/linter/divisible_by_default.h
+++ b/src/alterschema/linter/divisible_by_default.h
@@ -22,6 +22,10 @@ public:
                           Vocabularies::Known::JSON_Schema_Draft_3_Hyper}) &&
                      schema.is_object());
 
+    const auto *type{schema.try_at("type")};
+    ONLY_CONTINUE_IF(type && type->is_string() &&
+                     type->to_string() == "integer");
+
     const auto *divisible_by{schema.try_at("divisibleBy")};
     ONLY_CONTINUE_IF(
         divisible_by &&

--- a/src/alterschema/linter/multiple_of_default.h
+++ b/src/alterschema/linter/multiple_of_default.h
@@ -24,6 +24,10 @@ public:
                           Vocabularies::Known::JSON_Schema_Draft_4}) &&
                      schema.is_object());
 
+    const auto *type{schema.try_at("type")};
+    ONLY_CONTINUE_IF(type && type->is_string() &&
+                     type->to_string() == "integer");
+
     const auto *multiple_of{schema.try_at("multipleOf")};
     ONLY_CONTINUE_IF(
         multiple_of &&

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -2648,6 +2648,7 @@ TEST(AlterSchema_lint_2019_09, multiple_of_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "multipleOf": 1.0,
     "contains": { "type": "string" }
   })JSON");
 

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -3033,6 +3033,7 @@ TEST(AlterSchema_lint_2020_12, multiple_of_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "multipleOf": 1.0,
     "unevaluatedProperties": false
   })JSON");
 

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -1969,7 +1969,7 @@ TEST(AlterSchema_lint_draft3, divisible_by_default_1) {
 TEST(AlterSchema_lint_draft3, divisible_by_default_2) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "type": "number",
+    "type": "integer",
     "divisibleBy": 1.0
   })JSON");
 
@@ -1979,7 +1979,45 @@ TEST(AlterSchema_lint_draft3, divisible_by_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "type": "number"
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft3, divisible_by_default_no_change_number_type) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "number",
+    "divisibleBy": 1
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "number",
+    "divisibleBy": 1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft3, divisible_by_default_no_change_no_type) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "divisibleBy": 1
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "divisibleBy": 1
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -1176,7 +1176,7 @@ TEST(AlterSchema_lint_draft4, multiple_of_default_1) {
 TEST(AlterSchema_lint_draft4, multiple_of_default_2) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "number",
+    "type": "integer",
     "multipleOf": 1.0
   })JSON");
 
@@ -1186,7 +1186,7 @@ TEST(AlterSchema_lint_draft4, multiple_of_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "number"
+    "type": "integer"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1205,6 +1205,7 @@ TEST(AlterSchema_lint_draft4, multiple_of_default_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "multipleOf": 1,
     "minimum": 0
   })JSON");
 
@@ -3089,6 +3090,26 @@ TEST(AlterSchema_lint_draft4, exclusive_bounds_false_drop_5) {
     "type": "integer",
     "minimum": 0,
     "exclusiveMinimum": true
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_no_change_number_type) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 1
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1448,6 +1448,7 @@ TEST(AlterSchema_lint_draft6, multiple_of_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "multipleOf": 1.0,
     "maximum": 100
   })JSON");
 

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1622,6 +1622,7 @@ TEST(AlterSchema_lint_draft7, multiple_of_default_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "multipleOf": 1,
     "properties": {
       "age": { "type": "number" }
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
