### PR TITLE
lint: add conflicting_readonly_writeonly rule

### DIFF
--- a/src/alterschema/CMakeLists.txt
+++ b/src/alterschema/CMakeLists.txt
@@ -121,6 +121,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME alterschema
 
     # Linter
     linter/comment_trim.h
+    linter/conflicting_readonly_writeonly.h
     linter/const_not_in_enum.h
     linter/content_schema_default.h
     linter/definitions_to_defs.h

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -233,6 +233,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 
 // Linter
 #include "linter/comment_trim.h"
+#include "linter/conflicting_readonly_writeonly.h"
 #include "linter/const_not_in_enum.h"
 #include "linter/content_schema_default.h"
 #include "linter/definitions_to_defs.h"
@@ -476,6 +477,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<TitleTrim>();
     bundle.add<DescriptionTrim>();
     bundle.add<CommentTrim>();
+    bundle.add<ConflictingReadOnlyWriteOnly>();
     bundle.add<DuplicateExamples>();
     bundle.add<SimplePropertiesIdentifiers>();
     bundle.add<PortableAnchorNames>();

--- a/src/alterschema/linter/conflicting_readonly_writeonly.h
+++ b/src/alterschema/linter/conflicting_readonly_writeonly.h
@@ -1,0 +1,31 @@
+class ConflictingReadOnlyWriteOnly final : public SchemaTransformRule {
+public:
+  using mutates = std::false_type;
+  using reframe_after_transform = std::false_type;
+  ConflictingReadOnlyWriteOnly()
+      : SchemaTransformRule{"conflicting_readonly_writeonly",
+                            "The `readOnly` and `writeOnly` keywords are "
+                            "mutually exclusive"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+        {Vocabularies::Known::JSON_Schema_2020_12_Meta_Data,
+         Vocabularies::Known::JSON_Schema_2019_09_Meta_Data,
+         Vocabularies::Known::JSON_Schema_Draft_7}));
+    ONLY_CONTINUE_IF(schema.is_object());
+    const auto *read_only{schema.try_at("readOnly")};
+    const auto *write_only{schema.try_at("writeOnly")};
+    ONLY_CONTINUE_IF(read_only && write_only);
+    ONLY_CONTINUE_IF(read_only->is_boolean() && write_only->is_boolean());
+    ONLY_CONTINUE_IF(read_only->to_boolean() && write_only->to_boolean());
+    return APPLIES_TO_KEYWORDS("readOnly", "writeOnly");
+  }
+};

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -4173,6 +4173,72 @@ TEST(AlterSchema_lint_2019_09, top_level_examples_2) {
   EXPECT_EQ(traces.size(), 0);
 }
 
+TEST(AlterSchema_lint_2019_09, conflicting_readonly_writeonly_1) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, conflicting_readonly_writeonly_2) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, conflicting_readonly_writeonly_3) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": false,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, conflicting_readonly_writeonly_4) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(traces, 0, "", "conflicting_readonly_writeonly",
+                    "The `readOnly` and `writeOnly` keywords are mutually "
+                    "exclusive",
+                    false);
+}
+
 TEST(AlterSchema_lint_2019_09, duplicate_examples_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -6433,6 +6433,72 @@ TEST(AlterSchema_lint_2020_12, top_level_examples_6) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(AlterSchema_lint_2020_12, conflicting_readonly_writeonly_1) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, conflicting_readonly_writeonly_2) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, conflicting_readonly_writeonly_3) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": false,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, conflicting_readonly_writeonly_4) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(traces, 0, "", "conflicting_readonly_writeonly",
+                    "The `readOnly` and `writeOnly` keywords are mutually "
+                    "exclusive",
+                    false);
+}
+
 TEST(AlterSchema_lint_2020_12, duplicate_examples_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -2975,6 +2975,72 @@ TEST(AlterSchema_lint_draft7, top_level_examples_2) {
   EXPECT_EQ(traces.size(), 0);
 }
 
+TEST(AlterSchema_lint_draft7, conflicting_readonly_writeonly_1) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, conflicting_readonly_writeonly_2) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, conflicting_readonly_writeonly_3) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": false,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, conflicting_readonly_writeonly_4) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "My schema",
+    "description": "A description",
+    "examples": [ 1 ],
+    "readOnly": true,
+    "writeOnly": true
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(traces, 0, "", "conflicting_readonly_writeonly",
+                    "The `readOnly` and `writeOnly` keywords are mutually "
+                    "exclusive",
+                    false);
+}
+
 TEST(AlterSchema_lint_draft7, duplicate_examples_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
## Summary

Adds a new lint rule `conflicting_readonly_writeonly` that fires when a schema
has both `readOnly: true` and `writeOnly: true` set. These keywords are
mutually exclusive.

Applies to Draft 7, 2019-09, and 2020-12.

## Changes

- `src/alterschema/linter/conflicting_readonly_writeonly.h` - new rule
- `src/alterschema/alterschema.cc` - rule registered for all three dialects
- `src/alterschema/CMakeLists.txt` - header added
- `test/alterschema/alterschema_lint_draft7_test.cc` - tests added
- `test/alterschema/alterschema_lint_2019_09_test.cc` - tests added
- `test/alterschema/alterschema_lint_2020_12_test.cc` - tests added

Part of sourcemeta/core#1975.