### PR TITLE
Add a linter rule to check for ECMA-262 in `pattern`

### DIFF
--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -253,6 +253,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "linter/items_array_default.h"
 #include "linter/items_schema_default.h"
 #include "linter/multiple_of_default.h"
+#include "linter/pattern_non_ecma_regex.h"
 #include "linter/pattern_properties_default.h"
 #include "linter/portable_anchor_names.h"
 #include "linter/properties_default.h"
@@ -459,6 +460,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<DivisibleByDefault>();
     bundle.add<MultipleOfDefault>();
     bundle.add<PatternPropertiesDefault>();
+    bundle.add<PatternNonEcmaRegex>();
     bundle.add<PropertiesDefault>();
     bundle.add<PropertyNamesDefault>();
     bundle.add<PropertyNamesTypeDefault>();

--- a/src/alterschema/linter/pattern_non_ecma_regex.h
+++ b/src/alterschema/linter/pattern_non_ecma_regex.h
@@ -1,0 +1,46 @@
+class PatternNonEcmaRegex final : public SchemaTransformRule {
+public:
+  using mutates = std::false_type;
+  using reframe_after_transform = std::false_type;
+  PatternNonEcmaRegex()
+      : SchemaTransformRule{
+            "pattern_non_ecma_regex",
+            "For interoperability reasons, only set this keyword to a regular "
+            "expression that strictly adheres to the ECMA-262 dialect"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+        {Vocabularies::Known::JSON_Schema_2020_12_Validation,
+         Vocabularies::Known::JSON_Schema_2019_09_Validation,
+         Vocabularies::Known::JSON_Schema_Draft_7,
+         Vocabularies::Known::JSON_Schema_Draft_7_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_6,
+         Vocabularies::Known::JSON_Schema_Draft_6_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_4,
+         Vocabularies::Known::JSON_Schema_Draft_4_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_3,
+         Vocabularies::Known::JSON_Schema_Draft_3_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_2,
+         Vocabularies::Known::JSON_Schema_Draft_2_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_1,
+         Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
+         Vocabularies::Known::JSON_Schema_Draft_0,
+         Vocabularies::Known::JSON_Schema_Draft_0_Hyper}));
+    ONLY_CONTINUE_IF(schema.is_object());
+
+    const auto *pattern_value{schema.try_at("pattern")};
+    ONLY_CONTINUE_IF(pattern_value && pattern_value->is_string());
+
+    ONLY_CONTINUE_IF(
+        !sourcemeta::core::is_regex_ecma(pattern_value->to_string()));
+    return APPLIES_TO_KEYWORDS("pattern");
+  }
+};

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -5604,3 +5604,170 @@ TEST(AlterSchema_lint_2019_09, unknown_format_prefix_demote_custom) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -12681,6 +12681,173 @@ TEST(AlterSchema_lint_2020_12, unknown_format_prefix_collision_iterates) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
 TEST(AlterSchema_lint_2020_12, unnecessary_allof_wrapper_parallel_three_gates) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_lint_draft0_test.cc
+++ b/test/alterschema/alterschema_lint_draft0_test.cc
@@ -540,3 +540,36 @@ TEST(AlterSchema_lint_draft0, draft_official_dialect_with_https_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft0, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft0, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -1113,3 +1113,40 @@ TEST(AlterSchema_lint_draft1, draft_official_dialect_with_https_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft1, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft1, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -1113,3 +1113,40 @@ TEST(AlterSchema_lint_draft2, draft_official_dialect_with_https_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft2, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft2, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -3075,3 +3075,162 @@ TEST(AlterSchema_lint_draft3, unknown_format_prefix_non_string_left_unchanged) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -3343,3 +3343,162 @@ TEST(AlterSchema_lint_draft4, unnecessary_allof_wrapper_parallel_pattern) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -3434,3 +3434,170 @@ TEST(AlterSchema_lint_draft6, unknown_format_prefix_demote_custom) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -4974,3 +4974,170 @@ TEST(AlterSchema_lint_draft7, unnecessary_allof_wrapper_parallel_gates) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_valid_empty) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_non_string_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "pattern": 42 }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^(abc]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "[[:alpha:]]+" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "(?P<name>[a-z]+)" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_multiple_offenders) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" },
+      "bar": { "type": "string", "pattern": "[[:digit:]]" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/bar", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+  EXPECT_LINT_TRACE(
+      traces, 1, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_openapi_test.cc
+++ b/test/alterschema/alterschema_lint_openapi_test.cc
@@ -282,3 +282,42 @@ TEST(AlterSchema_lint_openapi_3_1, pattern_non_ecma_regex_valid) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(traces.size(), 0);
 }
+
+TEST(AlterSchema_lint_openapi_3_2, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_openapi_3_2, pattern_non_ecma_regex_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^foo$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}

--- a/test/alterschema/alterschema_lint_openapi_test.cc
+++ b/test/alterschema/alterschema_lint_openapi_test.cc
@@ -243,3 +243,42 @@ TEST(AlterSchema_lint_openapi, example_unknown_without_vocabulary) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_openapi_3_1, pattern_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.1/dialect/base",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "\\a" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_non_ecma_regex",
+      "For interoperability reasons, only set this keyword to a regular "
+      "expression that strictly adheres to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_openapi_3_1, pattern_non_ecma_regex_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.1/dialect/base",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": { "type": "string", "pattern": "^foo$" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
