### PR TITLE
Lint non-ECMA regexes in `patternProperties`

### DIFF
--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -255,6 +255,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "linter/multiple_of_default.h"
 #include "linter/pattern_non_ecma_regex.h"
 #include "linter/pattern_properties_default.h"
+#include "linter/pattern_properties_non_ecma_regex.h"
 #include "linter/portable_anchor_names.h"
 #include "linter/properties_default.h"
 #include "linter/property_names_default.h"
@@ -461,6 +462,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<MultipleOfDefault>();
     bundle.add<PatternPropertiesDefault>();
     bundle.add<PatternNonEcmaRegex>();
+    bundle.add<PatternPropertiesNonEcmaRegex>();
     bundle.add<PropertiesDefault>();
     bundle.add<PropertyNamesDefault>();
     bundle.add<PropertyNamesTypeDefault>();

--- a/src/alterschema/linter/pattern_properties_non_ecma_regex.h
+++ b/src/alterschema/linter/pattern_properties_non_ecma_regex.h
@@ -1,0 +1,45 @@
+class PatternPropertiesNonEcmaRegex final : public SchemaTransformRule {
+public:
+  using mutates = std::false_type;
+  using reframe_after_transform = std::false_type;
+  PatternPropertiesNonEcmaRegex()
+      : SchemaTransformRule{
+            "pattern_properties_non_ecma_regex",
+            "For interoperability reasons, only set the keys of this keyword "
+            "to regular expressions that strictly adhere to the ECMA-262 "
+            "dialect"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+        {Vocabularies::Known::JSON_Schema_2020_12_Applicator,
+         Vocabularies::Known::JSON_Schema_2019_09_Applicator,
+         Vocabularies::Known::JSON_Schema_Draft_7,
+         Vocabularies::Known::JSON_Schema_Draft_6,
+         Vocabularies::Known::JSON_Schema_Draft_4,
+         Vocabularies::Known::JSON_Schema_Draft_3,
+         Vocabularies::Known::JSON_Schema_Draft_3_Hyper}));
+    ONLY_CONTINUE_IF(schema.is_object());
+
+    const auto *pattern_properties{schema.try_at("patternProperties")};
+    ONLY_CONTINUE_IF(pattern_properties && pattern_properties->is_object() &&
+                     !pattern_properties->empty());
+
+    std::vector<Pointer> offenders;
+    for (const auto &entry : pattern_properties->as_object()) {
+      if (!sourcemeta::core::is_regex_ecma(entry.first)) {
+        offenders.push_back(Pointer{"patternProperties", entry.first});
+      }
+    }
+
+    ONLY_CONTINUE_IF(!offenders.empty());
+    return APPLIES_TO_POINTERS(std::move(offenders));
+  }
+};

--- a/src/alterschema/linter/pattern_properties_non_ecma_regex.h
+++ b/src/alterschema/linter/pattern_properties_non_ecma_regex.h
@@ -22,8 +22,11 @@ public:
         {Vocabularies::Known::JSON_Schema_2020_12_Applicator,
          Vocabularies::Known::JSON_Schema_2019_09_Applicator,
          Vocabularies::Known::JSON_Schema_Draft_7,
+         Vocabularies::Known::JSON_Schema_Draft_7_Hyper,
          Vocabularies::Known::JSON_Schema_Draft_6,
+         Vocabularies::Known::JSON_Schema_Draft_6_Hyper,
          Vocabularies::Known::JSON_Schema_Draft_4,
+         Vocabularies::Known::JSON_Schema_Draft_4_Hyper,
          Vocabularies::Known::JSON_Schema_Draft_3,
          Vocabularies::Known::JSON_Schema_Draft_3_Hyper}));
     ONLY_CONTINUE_IF(schema.is_object());

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -5974,4 +5974,11 @@ TEST(AlterSchema_lint_2019_09,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -5771,3 +5771,207 @@ TEST(AlterSchema_lint_2019_09, pattern_non_ecma_regex_multiple_offenders) {
       "expression that strictly adheres to the ECMA-262 dialect",
       false);
 }
+
+TEST(AlterSchema_lint_2019_09,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2019_09,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_2019_09,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2019_09,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -12848,6 +12848,210 @@ TEST(AlterSchema_lint_2020_12, pattern_non_ecma_regex_multiple_offenders) {
       false);
 }
 
+TEST(AlterSchema_lint_2020_12,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
 TEST(AlterSchema_lint_2020_12, unnecessary_allof_wrapper_parallel_three_gates) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -13050,6 +13050,13 @@ TEST(AlterSchema_lint_2020_12,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }
 
 TEST(AlterSchema_lint_2020_12, unnecessary_allof_wrapper_parallel_three_gates) {

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -3234,3 +3234,198 @@ TEST(AlterSchema_lint_draft3, pattern_non_ecma_regex_multiple_offenders) {
       "expression that strictly adheres to the ECMA-262 dialect",
       false);
 }
+
+TEST(AlterSchema_lint_draft3,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft3,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_draft3,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft3,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -3428,4 +3428,11 @@ TEST(AlterSchema_lint_draft3,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -3502,3 +3502,198 @@ TEST(AlterSchema_lint_draft4, pattern_non_ecma_regex_multiple_offenders) {
       "expression that strictly adheres to the ECMA-262 dialect",
       false);
 }
+
+TEST(AlterSchema_lint_draft4,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft4,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_draft4,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft4,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -3696,4 +3696,11 @@ TEST(AlterSchema_lint_draft4,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -3601,3 +3601,207 @@ TEST(AlterSchema_lint_draft6, pattern_non_ecma_regex_multiple_offenders) {
       "expression that strictly adheres to the ECMA-262 dialect",
       false);
 }
+
+TEST(AlterSchema_lint_draft6,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft6,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_draft6,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft6,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -3804,4 +3804,11 @@ TEST(AlterSchema_lint_draft6,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -5141,3 +5141,207 @@ TEST(AlterSchema_lint_draft7, pattern_non_ecma_regex_multiple_offenders) {
       "expression that strictly adheres to the ECMA-262 dialect",
       false);
 }
+
+TEST(AlterSchema_lint_draft7,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_properties_non_ecma_regex_valid_simple) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "[0-9]{2}": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_draft7,
+     pattern_properties_non_ecma_regex_empty_object_ignored) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {}
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_default",
+      "Setting the `patternProperties` keyword to the empty object "
+      "does not add any further constraint",
+      true);
+}
+
+TEST(AlterSchema_lint_draft7,
+     pattern_properties_non_ecma_regex_unbalanced_bracket) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^(abc]": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_properties_non_ecma_regex_posix_class) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "[[:alpha:]]+": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7,
+     pattern_properties_non_ecma_regex_python_named_group) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "(?P<name>[a-z]+)": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_properties_non_ecma_regex_nested) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "properties": {
+      "foo": {
+        "type": "object",
+        "patternProperties": {
+          "\\a": { "type": "string" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "/properties/foo", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7, pattern_properties_non_ecma_regex_mixed_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^[a-z]+$": { "type": "string" },
+      "\\a": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_draft7,
+     pattern_properties_non_ecma_regex_multiple_bad_keys) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" },
+      "[[:digit:]]": { "type": "integer" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -5344,4 +5344,11 @@ TEST(AlterSchema_lint_draft7,
       "For interoperability reasons, only set the keys of this keyword to "
       "regular expressions that strictly adhere to the ECMA-262 dialect",
       false);
+
+  const auto &outcome{std::get<3>(traces.at(0))};
+  EXPECT_EQ(outcome.locations.size(), 2);
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(0)),
+            "/patternProperties/\\a");
+  EXPECT_EQ(sourcemeta::core::to_string(outcome.locations.at(1)),
+            "/patternProperties/[[:digit:]]");
 }

--- a/test/alterschema/alterschema_lint_openapi_test.cc
+++ b/test/alterschema/alterschema_lint_openapi_test.cc
@@ -321,3 +321,83 @@ TEST(AlterSchema_lint_openapi_3_2, pattern_non_ecma_regex_valid) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(traces.size(), 0);
 }
+
+TEST(AlterSchema_lint_openapi_3_1,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.1/dialect/base",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_openapi_3_1, pattern_properties_non_ecma_regex_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.1/dialect/base",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^foo$": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}
+
+TEST(AlterSchema_lint_openapi_3_2,
+     pattern_properties_non_ecma_regex_invalid_escape) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "\\a": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(traces.size(), 1);
+  EXPECT_LINT_TRACE(
+      traces, 0, "", "pattern_properties_non_ecma_regex",
+      "For interoperability reasons, only set the keys of this keyword to "
+      "regular expressions that strictly adhere to the ECMA-262 dialect",
+      false);
+}
+
+TEST(AlterSchema_lint_openapi_3_2, pattern_properties_non_ecma_regex_valid) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://spec.openapis.org/oas/3.2/dialect/2025-09-17",
+    "title": "Test",
+    "description": "A test schema",
+    "examples": [ {} ],
+    "patternProperties": {
+      "^foo$": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_WITHOUT_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(traces.size(), 0);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
