### PR TITLE
Properly support upgrading `$vocabulary` from 2019-09 to 2020-12

### DIFF
--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -156,6 +156,8 @@ public:
       }
     }
 
+    rewrite_vocabulary(schema);
+
     if (schema.defines("$schema") && schema.at("$schema").is_string() &&
         schema.at("$schema").to_string() == DRAFT_2019_09_URL) {
       schema.assign("$schema", sourcemeta::core::JSON{DRAFT_2020_12_URL});
@@ -186,6 +188,70 @@ private:
       "https://json-schema.org/draft/2019-09/schema"};
   static constexpr std::string_view DRAFT_2020_12_URL{
       "https://json-schema.org/draft/2020-12/schema"};
+  static constexpr std::string_view APPLICATOR_2019_09_URI{
+      "https://json-schema.org/draft/2019-09/vocab/applicator"};
+  static constexpr std::string_view UNEVALUATED_2020_12_URI{
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated"};
+
+  static inline const std::unordered_map<std::string, std::string>
+      VOCAB_URI_MAP_2019_09_TO_2020_12{
+          {"https://json-schema.org/draft/2019-09/vocab/core",
+           "https://json-schema.org/draft/2020-12/vocab/core"},
+          {"https://json-schema.org/draft/2019-09/vocab/applicator",
+           "https://json-schema.org/draft/2020-12/vocab/applicator"},
+          {"https://json-schema.org/draft/2019-09/vocab/validation",
+           "https://json-schema.org/draft/2020-12/vocab/validation"},
+          {"https://json-schema.org/draft/2019-09/vocab/meta-data",
+           "https://json-schema.org/draft/2020-12/vocab/meta-data"},
+          {"https://json-schema.org/draft/2019-09/vocab/format",
+           "https://json-schema.org/draft/2020-12/vocab/format-annotation"},
+          {"https://json-schema.org/draft/2019-09/vocab/content",
+           "https://json-schema.org/draft/2020-12/vocab/content"}};
+
+  static auto
+  vocabulary_has_mappable_uri(const sourcemeta::core::JSON &subschema) -> bool {
+    if (!subschema.is_object() || !subschema.defines("$vocabulary") ||
+        !subschema.at("$vocabulary").is_object()) {
+      return false;
+    }
+    for (const auto &entry : subschema.at("$vocabulary").as_object()) {
+      if (VOCAB_URI_MAP_2019_09_TO_2020_12.contains(entry.first)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static auto rewrite_vocabulary(sourcemeta::core::JSON &schema) -> void {
+    if (!schema.is_object() || !schema.defines("$vocabulary") ||
+        !schema.at("$vocabulary").is_object()) {
+      return;
+    }
+
+    auto fresh{sourcemeta::core::JSON::make_object()};
+    bool unevaluated_already_present{false};
+
+    for (const auto &entry : schema.at("$vocabulary").as_object()) {
+      if (entry.first == UNEVALUATED_2020_12_URI) {
+        unevaluated_already_present = true;
+      }
+
+      const auto iter{VOCAB_URI_MAP_2019_09_TO_2020_12.find(entry.first)};
+      if (iter == VOCAB_URI_MAP_2019_09_TO_2020_12.cend()) {
+        fresh.assign(entry.first, entry.second);
+        continue;
+      }
+
+      fresh.assign(iter->second, entry.second);
+
+      if (entry.first == APPLICATOR_2019_09_URI &&
+          !unevaluated_already_present) {
+        fresh.assign(std::string{UNEVALUATED_2020_12_URI}, entry.second);
+      }
+    }
+
+    schema.at("$vocabulary").into(std::move(fresh));
+  }
 
   struct AnchorRename {
     sourcemeta::core::Pointer subschema_pointer;
@@ -311,7 +377,8 @@ private:
       return false;
     }
     if (!subschema.defines_any({"$schema", "$recursiveAnchor", "$recursiveRef",
-                                "items", "additionalItems", "contains"})) {
+                                "items", "additionalItems", "contains",
+                                "$vocabulary"})) {
       return false;
     }
     if (subschema.defines("$schema") && subschema.at("$schema").is_string() &&
@@ -327,6 +394,9 @@ private:
     }
     if (subschema.defines("contains") &&
         !location_inside_contains_wrapper(location)) {
+      return true;
+    }
+    if (vocabulary_has_mappable_uri(subschema)) {
       return true;
     }
     return false;

--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -190,6 +190,8 @@ private:
       "https://json-schema.org/draft/2020-12/schema"};
   static constexpr std::string_view APPLICATOR_2019_09_URI{
       "https://json-schema.org/draft/2019-09/vocab/applicator"};
+  static constexpr std::string_view APPLICATOR_2020_12_URI{
+      "https://json-schema.org/draft/2020-12/vocab/applicator"};
   static constexpr std::string_view UNEVALUATED_2020_12_URI{
       "https://json-schema.org/draft/2020-12/vocab/unevaluated"};
 
@@ -229,12 +231,18 @@ private:
     }
 
     std::unordered_set<std::string> source_keys;
+    std::optional<sourcemeta::core::JSON> applicator_2019_09_value;
     for (const auto &entry : schema.at("$vocabulary").as_object()) {
       source_keys.insert(entry.first);
+      if (entry.first == APPLICATOR_2019_09_URI) {
+        applicator_2019_09_value = entry.second;
+      }
     }
 
     const bool unevaluated_already_present{
         source_keys.contains(std::string{UNEVALUATED_2020_12_URI})};
+    const bool should_inline_unevaluated{applicator_2019_09_value.has_value() &&
+                                         !unevaluated_already_present};
 
     auto fresh{sourcemeta::core::JSON::make_object()};
 
@@ -242,6 +250,11 @@ private:
       const auto iter{VOCAB_URI_MAP_2019_09_TO_2020_12.find(entry.first)};
       if (iter == VOCAB_URI_MAP_2019_09_TO_2020_12.cend()) {
         fresh.assign(entry.first, entry.second);
+        if (entry.first == APPLICATOR_2020_12_URI &&
+            should_inline_unevaluated) {
+          fresh.assign(std::string{UNEVALUATED_2020_12_URI},
+                       applicator_2019_09_value.value());
+        }
         continue;
       }
 
@@ -251,8 +264,7 @@ private:
 
       fresh.assign(iter->second, entry.second);
 
-      if (entry.first == APPLICATOR_2019_09_URI &&
-          !unevaluated_already_present) {
+      if (entry.first == APPLICATOR_2019_09_URI && should_inline_unevaluated) {
         fresh.assign(std::string{UNEVALUATED_2020_12_URI}, entry.second);
       }
     }

--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -228,17 +228,24 @@ private:
       return;
     }
 
+    std::unordered_set<std::string> source_keys;
+    for (const auto &entry : schema.at("$vocabulary").as_object()) {
+      source_keys.insert(entry.first);
+    }
+
+    const bool unevaluated_already_present{
+        source_keys.contains(std::string{UNEVALUATED_2020_12_URI})};
+
     auto fresh{sourcemeta::core::JSON::make_object()};
-    bool unevaluated_already_present{false};
 
     for (const auto &entry : schema.at("$vocabulary").as_object()) {
-      if (entry.first == UNEVALUATED_2020_12_URI) {
-        unevaluated_already_present = true;
-      }
-
       const auto iter{VOCAB_URI_MAP_2019_09_TO_2020_12.find(entry.first)};
       if (iter == VOCAB_URI_MAP_2019_09_TO_2020_12.cend()) {
         fresh.assign(entry.first, entry.second);
+        continue;
+      }
+
+      if (source_keys.contains(iter->second)) {
         continue;
       }
 

--- a/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
+++ b/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
@@ -1070,6 +1070,86 @@ TEST(AlterSchema_upgrade_2019_09_to_2020_12,
 }
 
 TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_wins_over_2019_09_equivalent) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": false,
+      "https://json-schema.org/draft/2020-12/vocab/core": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_wins_over_2019_09_equivalent_reversed_order) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/core": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_applicator_wins_no_inline_unevaluated) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/applicator": false,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_format_annotation_wins_over_2019_09_format) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/format": true,
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
      vocabulary_inside_embedded_meta_schema_rewritten) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/outer",

--- a/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
+++ b/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
@@ -1110,7 +1110,7 @@ TEST(AlterSchema_upgrade_2019_09_to_2020_12,
 }
 
 TEST(AlterSchema_upgrade_2019_09_to_2020_12,
-     vocabulary_explicit_2020_12_applicator_wins_no_inline_unevaluated) {
+     vocabulary_explicit_2020_12_applicator_wins_unevaluated_from_2019_09) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$vocabulary": {
@@ -1122,7 +1122,70 @@ TEST(AlterSchema_upgrade_2019_09_to_2020_12,
   const auto expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_applicator_wins_unevaluated_reversed_order) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_explicit_2020_12_applicator_alone_does_not_emit_unevaluated) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
       "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_both_applicators_with_explicit_unevaluated_keeps_unevaluated) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/applicator": false,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
     }
   })JSON");
 

--- a/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
+++ b/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
@@ -1247,3 +1247,333 @@ TEST(AlterSchema_upgrade_2019_09_to_2020_12,
 
   UPGRADE_2020_12(document, expected);
 }
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_outer_and_embedded_meta_schema_both_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer-meta",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/validation": true
+    },
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/applicator": true
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer-meta",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true
+    },
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+          "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_format_mapped) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/format": false
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/format-annotation": false
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_custom_uri_passes_through) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://example.com/vocab/custom": false
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://example.com/vocab/custom": false
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_hyper_uri_left_intact) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_explicit_2020_12_wins) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": false,
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_multiple_sibling_embedded_meta_schemas_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "alpha": {
+        "$id": "https://example.com/alpha-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/applicator": true
+        }
+      },
+      "beta": {
+        "$id": "https://example.com/beta-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/format": true
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "alpha": {
+        "$id": "https://example.com/alpha-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+          "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+        }
+      },
+      "beta": {
+        "$id": "https://example.com/beta-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_deeply_nested_embedded_meta_schema_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "middle": {
+        "$id": "https://example.com/middle-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/validation": false
+        },
+        "$defs": {
+          "inner": {
+            "$id": "https://example.com/inner-meta",
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "$vocabulary": {
+              "https://json-schema.org/draft/2019-09/vocab/core": true,
+              "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+              "https://json-schema.org/draft/2019-09/vocab/format": false
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "middle": {
+        "$id": "https://example.com/middle-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": false
+        },
+        "$defs": {
+          "inner": {
+            "$id": "https://example.com/inner-meta",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$vocabulary": {
+              "https://json-schema.org/draft/2020-12/vocab/core": true,
+              "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+              "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+              "https://json-schema.org/draft/2020-12/vocab/format-annotation": false
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_keeps_existing_unevaluated) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+          "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+          "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}

--- a/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
+++ b/test/alterschema/alterschema_upgrade_2019_09_to_2020_12_test.cc
@@ -764,3 +764,343 @@ TEST(AlterSchema_upgrade_2019_09_to_2020_12, format_values_preserved) {
 
   UPGRADE_2020_12(document, expected);
 }
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12, vocabulary_core_uri_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_direct_rename_uris_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/validation": true,
+      "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+      "https://json-schema.org/draft/2019-09/vocab/content": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+      "https://json-schema.org/draft/2020-12/vocab/content": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_format_maps_to_format_annotation_required) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/format": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_format_maps_to_format_annotation_optional) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/format": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_applicator_emits_applicator_and_unevaluated_required) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_applicator_emits_applicator_and_unevaluated_optional) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": false,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_applicator_keeps_existing_unevaluated_value) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_applicator_after_existing_unevaluated_preserves_order) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": false,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_custom_uri_passes_through_intact) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://example.com/vocab/custom-required": true,
+      "https://example.com/vocab/custom-optional": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://example.com/vocab/custom-required": true,
+      "https://example.com/vocab/custom-optional": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_hyper_schema_uri_left_intact) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_full_official_set_and_custom) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/my-meta",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2019-09/vocab/core": true,
+      "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+      "https://json-schema.org/draft/2019-09/vocab/validation": true,
+      "https://json-schema.org/draft/2019-09/vocab/meta-data": false,
+      "https://json-schema.org/draft/2019-09/vocab/format": false,
+      "https://json-schema.org/draft/2019-09/vocab/content": false,
+      "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false,
+      "https://example.com/vocab/extra": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/my-meta",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      "https://json-schema.org/draft/2020-12/vocab/meta-data": false,
+      "https://json-schema.org/draft/2020-12/vocab/format-annotation": false,
+      "https://json-schema.org/draft/2020-12/vocab/content": false,
+      "https://json-schema.org/draft/2019-09/vocab/hyper-schema": false,
+      "https://example.com/vocab/extra": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_already_2020_12_uris_unchanged) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/applicator": true
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_empty_object_unchanged) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {}
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {}
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_non_object_left_untouched) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": "not-an-object"
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": "not-an-object"
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}
+
+TEST(AlterSchema_upgrade_2019_09_to_2020_12,
+     vocabulary_inside_embedded_meta_schema_rewritten) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/applicator": true
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/outer",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "inner": {
+        "$id": "https://example.com/inner-meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+          "https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+        }
+      }
+    }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}

--- a/test/alterschema/alterschema_upgrade_draft7_to_2020_12_test.cc
+++ b/test/alterschema/alterschema_upgrade_draft7_to_2020_12_test.cc
@@ -210,3 +210,18 @@ TEST(AlterSchema_upgrade_Draft7_to_2020_12,
   UPGRADE_2020_12_WITH_DIALECT(document, expected,
                                "http://json-schema.org/draft-07/schema#");
 }
+
+TEST(AlterSchema_upgrade_Draft7_to_2020_12,
+     custom_dollar_vocabulary_remains_prefixed) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$vocabulary": { "https://example.com/vocab": true }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "x-$vocabulary": { "https://example.com/vocab": true }
+  })JSON");
+
+  UPGRADE_2020_12(document, expected);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
