### PR TITLE
Use the frame for accessing vocabularies during compilation

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -380,8 +380,8 @@ auto compile(const sourcemeta::core::JSON &schema,
     }
 
     auto subschema{sourcemeta::core::get(context.root, entry.pointer)};
-    auto nested_vocabularies{sourcemeta::blaze::vocabularies(
-        subschema, context.resolver, entry.dialect)};
+    auto nested_vocabularies{
+        context.frame.vocabularies(entry, context.resolver)};
     const auto nested_relative_pointer{
         entry.pointer.slice(entry.relative_pointer)};
     const sourcemeta::core::URI nested_base{entry.base};
@@ -495,8 +495,7 @@ auto compile(const Context &context, const SchemaContext &schema_context,
       context,
       {.relative_pointer = new_relative_pointer,
        .schema = new_schema,
-       .vocabularies =
-           vocabularies(new_schema, context.resolver, entry.dialect),
+       .vocabularies = context.frame.vocabularies(entry, context.resolver),
        .base = new_base,
        .is_property_name = schema_context.is_property_name},
       {.keyword = dynamic_context.keyword,

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -9,6 +9,7 @@
 #include <cassert>    // assert
 #include <functional> // std::cref
 #include <iterator>   // std::distance
+#include <optional>   // std::optional
 #include <regex>      // std::regex, std::regex_match, std::smatch
 #include <utility>    // std::declval, std::move
 
@@ -186,13 +187,25 @@ inline auto static_frame_entry(const Context &context,
   return context.frame.locations().at({type, current});
 }
 
-inline auto walk_subschemas(const Context &context,
-                            const SchemaContext &schema_context,
-                            const DynamicContext &dynamic_context) -> auto {
+// Whether the current keyword value, as a schema, contains any nested
+// subschema. Note that the schema context of a keyword compiler already
+// points at the keyword value
+inline auto defines_nested_subschemas(const Context &context,
+                                      const SchemaContext &schema_context)
+    -> bool {
   const auto &entry{static_frame_entry(context, schema_context)};
-  return sourcemeta::blaze::SchemaIterator{
-      schema_context.schema.at(dynamic_context.keyword), context.walker,
-      context.resolver, entry.dialect};
+  for (const auto &location : context.frame.locations()) {
+    if ((location.second.type ==
+             sourcemeta::blaze::SchemaFrame::LocationType::Subschema ||
+         location.second.type ==
+             sourcemeta::blaze::SchemaFrame::LocationType::Resource) &&
+        location.second.pointer.starts_with(entry.pointer) &&
+        location.second.pointer.size() > entry.pointer.size()) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 // TODO: Get rid of this given the new Core regex optimisations
@@ -266,8 +279,8 @@ inline auto find_adjacent(const Context &context,
          possible_keyword_uri})};
     const auto &subschema{
         sourcemeta::core::get(context.root, frame_entry.pointer)};
-    const auto &subschema_vocabularies{sourcemeta::blaze::vocabularies(
-        subschema, context.resolver, frame_entry.dialect)};
+    const auto subschema_vocabularies{
+        context.frame.vocabularies(frame_entry, context.resolver)};
 
     if (std::ranges::any_of(vocabularies,
                             [&subschema_vocabularies](const auto &vocabulary) {

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -188,8 +188,10 @@ inline auto static_frame_entry(const Context &context,
 }
 
 // Whether the current keyword value, as a schema, contains any nested
-// subschema. Note that the schema context of a keyword compiler already
-// points at the keyword value
+// subschema. Note that while the schema of the schema context of a keyword
+// compiler is the parent subschema, its relative pointer already targets
+// the keyword value, so the frame entry we look up corresponds to the
+// keyword value and not to the parent subschema
 inline auto defines_nested_subschemas(const Context &context,
                                       const SchemaContext &schema_context)
     -> bool {

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -182,15 +182,7 @@ auto compiler_draft4_applicator_not(const Context &context,
                                     const SchemaContext &schema_context,
                                     const DynamicContext &dynamic_context,
                                     const Instructions &) -> Instructions {
-  std::size_t subschemas{0};
-  for (const auto &subschema :
-       walk_subschemas(context, schema_context, dynamic_context)) {
-    if (subschema.pointer.empty()) {
-      continue;
-    }
-
-    subschemas += 1;
-  }
+  const auto subschemas{defines_nested_subschemas(context, schema_context)};
 
   Instructions children{compile(context, schema_context,
                                 relative_dynamic_context(),
@@ -208,7 +200,7 @@ auto compiler_draft4_applicator_not(const Context &context,
   // evaluation if we really need it. If the "not" subschema
   // does not define applicators, then that's an easy case
   // we can skip
-  if (subschemas > 0 &&
+  if (subschemas &&
       (requires_evaluation(context, schema_context) || track_items)) {
     return {make(sourcemeta::blaze::InstructionIndex::LogicalNotEvaluate,
                  context, schema_context, dynamic_context, ValueNone{},

--- a/src/compiler/unevaluated.cc
+++ b/src/compiler/unevaluated.cc
@@ -22,8 +22,7 @@ auto find_adjacent_dependencies(
     return;
   }
 
-  const auto subschema_vocabularies{
-      vocabularies(subschema, resolver, entry.dialect)};
+  const auto subschema_vocabularies{frame.vocabularies(entry, resolver)};
 
   for (const auto &property : subschema.as_object()) {
     if (property.first == current && entry.pointer == root.pointer) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

