### PR TITLE
Extend `base_dialect` to support embedded meta-schemas

### DIFF
--- a/src/foundation/foundation.cc
+++ b/src/foundation/foundation.cc
@@ -277,8 +277,7 @@ auto sourcemeta::blaze::metaschema(
 
   const auto maybe_metaschema{resolver(effective_dialect)};
   if (!maybe_metaschema.has_value()) {
-    // The meta-schema may still be embedded in the schema itself,
-    // as `bundle()` does for custom meta-schemas
+    // The meta-schema may still be embedded in the schema itself
     const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
         schema, effective_dialect, resolver)};
     if (embedded) {
@@ -333,8 +332,7 @@ base_dialect_with_visited(const sourcemeta::core::JSON &schema,
   const std::optional<sourcemeta::core::JSON> metaschema{
       resolver(effective_dialect)};
   if (!metaschema.has_value()) {
-    // The meta-schema may still be embedded in the original document
-    // itself, as `bundle()` does for custom meta-schemas
+    // The meta-schema may still be embedded in the original document itself
     const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
         document, effective_dialect, resolver)};
     if (embedded) {
@@ -588,7 +586,7 @@ auto sourcemeta::blaze::vocabularies(
   }
 
   // The meta-schema may not be known to the resolver but still be embedded
-  // in the schema itself, as `bundle()` does for custom meta-schemas
+  // in the schema itself
   return vocabularies(
       [&schema, &resolver](const std::string_view identifier)
           -> std::optional<sourcemeta::core::JSON> {

--- a/src/foundation/foundation.cc
+++ b/src/foundation/foundation.cc
@@ -277,6 +277,14 @@ auto sourcemeta::blaze::metaschema(
 
   const auto maybe_metaschema{resolver(effective_dialect)};
   if (!maybe_metaschema.has_value()) {
+    // The meta-schema may still be embedded in the schema itself,
+    // as `bundle()` does for custom meta-schemas
+    const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+        schema, effective_dialect, resolver)};
+    if (embedded) {
+      return *embedded;
+    }
+
     // Relative meta-schema references are invalid according to the
     // JSON Schema specifications. They must be absolute ones
     const sourcemeta::core::URI effective_dialect_uri{effective_dialect};
@@ -297,7 +305,8 @@ base_dialect_with_visited(const sourcemeta::core::JSON &schema,
                           const sourcemeta::blaze::SchemaResolver &resolver,
                           std::string_view default_dialect,
                           std::unordered_set<std::string_view> &visited,
-                          const bool allow_dialect_override)
+                          const bool allow_dialect_override,
+                          const sourcemeta::core::JSON &document)
     -> std::optional<sourcemeta::blaze::SchemaBaseDialect> {
   assert(sourcemeta::blaze::is_schema(schema));
   const std::string_view effective_dialect{sourcemeta::blaze::dialect(
@@ -324,6 +333,22 @@ base_dialect_with_visited(const sourcemeta::core::JSON &schema,
   const std::optional<sourcemeta::core::JSON> metaschema{
       resolver(effective_dialect)};
   if (!metaschema.has_value()) {
+    // The meta-schema may still be embedded in the original document
+    // itself, as `bundle()` does for custom meta-schemas
+    const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+        document, effective_dialect, resolver)};
+    if (embedded) {
+      const std::string_view embedded_dialect{sourcemeta::blaze::dialect(
+          *embedded, effective_dialect, allow_dialect_override)};
+      if (embedded_dialect == effective_dialect) {
+        throw sourcemeta::blaze::SchemaUnknownBaseDialectError();
+      }
+
+      return base_dialect_with_visited(*embedded, resolver, effective_dialect,
+                                       visited, allow_dialect_override,
+                                       document);
+    }
+
     sourcemeta::core::URI effective_dialect_uri;
     try {
       effective_dialect_uri = sourcemeta::core::URI{effective_dialect};
@@ -353,7 +378,7 @@ base_dialect_with_visited(const sourcemeta::core::JSON &schema,
 
   return base_dialect_with_visited(metaschema.value(), resolver,
                                    effective_dialect, visited,
-                                   allow_dialect_override);
+                                   allow_dialect_override, document);
 }
 
 auto sourcemeta::blaze::base_dialect(
@@ -363,7 +388,7 @@ auto sourcemeta::blaze::base_dialect(
     -> std::optional<SchemaBaseDialect> {
   std::unordered_set<std::string_view> visited;
   return base_dialect_with_visited(schema, resolver, default_dialect, visited,
-                                   allow_dialect_override);
+                                   allow_dialect_override, schema);
 }
 
 namespace {
@@ -562,8 +587,25 @@ auto sourcemeta::blaze::vocabularies(
     throw sourcemeta::blaze::SchemaUnknownDialectError();
   }
 
-  return vocabularies(resolver, resolved_base_dialect.value(),
-                      resolved_dialect);
+  // The meta-schema may not be known to the resolver but still be embedded
+  // in the schema itself, as `bundle()` does for custom meta-schemas
+  return vocabularies(
+      [&schema, &resolver](const std::string_view identifier)
+          -> std::optional<sourcemeta::core::JSON> {
+        auto result{resolver(identifier)};
+        if (result.has_value()) {
+          return result;
+        }
+
+        const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+            schema, identifier, resolver)};
+        if (embedded) {
+          return *embedded;
+        }
+
+        return std::nullopt;
+      },
+      resolved_base_dialect.value(), resolved_dialect);
 }
 
 auto sourcemeta::blaze::vocabularies(const SchemaResolver &resolver,

--- a/src/foundation/foundation.cc
+++ b/src/foundation/foundation.cc
@@ -278,7 +278,7 @@ auto sourcemeta::blaze::metaschema(
   const auto maybe_metaschema{resolver(effective_dialect)};
   if (!maybe_metaschema.has_value()) {
     // The meta-schema may still be embedded in the schema itself
-    const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+    const auto *embedded{sourcemeta::blaze::try_embedded_metaschema(
         schema, effective_dialect, resolver)};
     if (embedded) {
       return *embedded;
@@ -333,7 +333,7 @@ base_dialect_with_visited(const sourcemeta::core::JSON &schema,
       resolver(effective_dialect)};
   if (!metaschema.has_value()) {
     // The meta-schema may still be embedded in the original document itself
-    const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+    const auto *embedded{sourcemeta::blaze::try_embedded_metaschema(
         document, effective_dialect, resolver)};
     if (embedded) {
       const std::string_view embedded_dialect{sourcemeta::blaze::dialect(
@@ -595,7 +595,7 @@ auto sourcemeta::blaze::vocabularies(
           return result;
         }
 
-        const auto *embedded{sourcemeta::blaze::find_embedded_metaschema(
+        const auto *embedded{sourcemeta::blaze::try_embedded_metaschema(
             schema, identifier, resolver)};
         if (embedded) {
           return *embedded;

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -6,6 +6,7 @@
 #include <sourcemeta/core/uri.h>
 
 #include <cassert>          // assert
+#include <deque>            // std::deque
 #include <initializer_list> // std::initializer_list
 #include <optional>         // std::optional
 #include <string_view>      // std::string_view
@@ -95,7 +96,8 @@ inline auto embedded_metaschema_identifier_matches(
     const sourcemeta::core::JSON &candidate, const std::string_view keyword,
     const std::string_view identifier,
     const std::optional<sourcemeta::core::JSON::String> &canonical) -> bool {
-  const auto *value{candidate.try_at(sourcemeta::core::JSON::String{keyword})};
+  const auto *value{
+      candidate.try_at(sourcemeta::core::JSON::StringView{keyword})};
   if (!value || !value->is_string()) {
     return false;
   }
@@ -155,7 +157,7 @@ embedded_metaschema_candidate(const sourcemeta::core::JSON &document,
     }
 
     const auto *direct{
-        entries->try_at(sourcemeta::core::JSON::String{identifier})};
+        entries->try_at(sourcemeta::core::JSON::StringView{identifier})};
     if (direct && embedded_metaschema_matches(*direct, identifier, canonical)) {
       return {direct, container};
     }
@@ -206,7 +208,7 @@ inline auto embedded_metaschema_link_valid(const sourcemeta::core::JSON &link,
 
 struct EmbeddedMetaschemaLink {
   const sourcemeta::core::JSON *schema;
-  sourcemeta::core::JSON::String identifier;
+  sourcemeta::core::JSON::StringView identifier;
   std::string_view container;
 };
 
@@ -217,25 +219,25 @@ struct EmbeddedMetaschemaLink {
 // entire meta-schema chain terminates at an official base dialect and every
 // embedded link declares its identifier and sits in a container in a way
 // that is valid for such base dialect
-inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
-                                     const std::string_view identifier,
-                                     const SchemaResolver &resolver)
+inline auto try_embedded_metaschema(const sourcemeta::core::JSON &document,
+                                    const std::string_view identifier,
+                                    const SchemaResolver &resolver)
     -> const sourcemeta::core::JSON * {
   const auto candidate{embedded_metaschema_candidate(document, identifier)};
   if (!candidate.first) {
     return nullptr;
   }
 
-  std::unordered_set<sourcemeta::core::JSON::String> visited;
-  std::vector<EmbeddedMetaschemaLink> links{
-      {.schema = candidate.first,
-       .identifier = sourcemeta::core::JSON::String{identifier},
-       .container = candidate.second}};
+  std::unordered_set<std::string_view> visited;
+  std::vector<EmbeddedMetaschemaLink> links{{.schema = candidate.first,
+                                             .identifier = identifier,
+                                             .container = candidate.second}};
   // Chain links that the resolver knows about are returned by value, so we
-  // need to keep them alive while we keep walking the chain
-  std::vector<sourcemeta::core::JSON> resolved;
+  // keep them alive while we walk the chain, in a container that never
+  // relocates its elements, as we hold views into them
+  std::deque<sourcemeta::core::JSON> resolved;
   const auto *current{candidate.first};
-  sourcemeta::core::JSON::String current_identifier{identifier};
+  std::string_view current_identifier{identifier};
   std::optional<SchemaBaseDialect> terminal;
 
   while (true) {

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -161,17 +161,12 @@ embedded_metaschema_candidate(const sourcemeta::core::JSON &document,
 }
 
 // A meta-schema that is not known to the resolver may still be embedded in
-// the document itself, as `bundle()` does for custom meta-schemas. Across
-// every official base dialect, the only containers that can hold embedded
-// resources are `$defs` (2019-09 and 2020-12, where it belongs to the
-// mandatory core vocabulary) and `definitions` (Draft 7 and older, which
-// have no vocabulary mechanism), so no custom dialect can redefine them away.
-// A candidate only counts if its entire meta-schema chain terminates at an
-// official base dialect and every embedded link of the chain sits in the
-// exact container that such base dialect prescribes, which is the container
-// `bundle()` would have used. For example, a chain that terminates in Draft 7
-// but whose links are embedded in `$defs` (which means nothing in Draft 7)
-// is rejected
+// the document itself. Across every official base dialect, the only
+// containers that can hold embedded resources are `$defs` and `definitions`,
+// which no custom dialect can redefine away. A candidate only counts if its
+// entire meta-schema chain terminates at an official base dialect and every
+// embedded link sits in the exact container that such base dialect
+// prescribes
 inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
                                      const std::string_view identifier,
                                      const SchemaResolver &resolver)

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -223,6 +223,12 @@ inline auto try_embedded_metaschema(const sourcemeta::core::JSON &document,
                                     const std::string_view identifier,
                                     const SchemaResolver &resolver)
     -> const sourcemeta::core::JSON * {
+  // Relative or invalid meta-schema references are not acceptable
+  // according to the JSON Schema specifications
+  if (!sourcemeta::core::URI::is_uri(identifier)) {
+    return nullptr;
+  }
+
   const auto candidate{embedded_metaschema_candidate(document, identifier)};
   if (!candidate.first) {
     return nullptr;
@@ -270,6 +276,10 @@ inline auto try_embedded_metaschema(const sourcemeta::core::JSON &document,
       current = &resolved.back();
       current_identifier = dialect_uri;
       continue;
+    }
+
+    if (!sourcemeta::core::URI::is_uri(dialect_uri)) {
+      return nullptr;
     }
 
     const auto next{embedded_metaschema_candidate(document, dialect_uri)};

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -3,8 +3,15 @@
 
 #include <sourcemeta/blaze/foundation.h>
 
-#include <cassert>     // assert
-#include <string_view> // std::string_view
+#include <sourcemeta/core/uri.h>
+
+#include <cassert>          // assert
+#include <initializer_list> // std::initializer_list
+#include <optional>         // std::optional
+#include <string_view>      // std::string_view
+#include <unordered_set>    // std::unordered_set
+#include <utility>          // std::pair, std::move
+#include <vector>           // std::vector
 
 namespace sourcemeta::blaze {
 
@@ -82,6 +89,155 @@ ref_overrides_adjacent_keywords(const SchemaBaseDialect base_dialect) -> bool {
     default:
       return false;
   }
+}
+
+inline auto embedded_metaschema_matches(
+    const sourcemeta::core::JSON &candidate, const std::string_view identifier,
+    const std::optional<sourcemeta::core::JSON::String> &canonical) -> bool {
+  if (!candidate.is_object()) {
+    return false;
+  }
+
+  for (const auto *const keyword : {"$id", "id"}) {
+    const auto *value{candidate.try_at(keyword)};
+    if (!value || !value->is_string()) {
+      continue;
+    }
+
+    const auto &current{value->to_string()};
+    if (current == identifier) {
+      return true;
+    }
+
+    if (canonical.has_value()) {
+      try {
+        if (sourcemeta::core::URI::canonicalize(current) == canonical.value()) {
+          return true;
+        }
+      } catch (const sourcemeta::core::URIParseError &) {
+        continue;
+      }
+    }
+  }
+
+  return false;
+}
+
+inline auto
+embedded_metaschema_candidate(const sourcemeta::core::JSON &document,
+                              const std::string_view identifier)
+    -> std::pair<const sourcemeta::core::JSON *, std::string_view> {
+  if (!document.is_object()) {
+    return {nullptr, ""};
+  }
+
+  std::optional<sourcemeta::core::JSON::String> canonical;
+  try {
+    canonical = sourcemeta::core::URI::canonicalize(identifier);
+  } catch (const sourcemeta::core::URIParseError &) {
+    canonical = std::nullopt;
+  }
+
+  for (const auto *const container : {"$defs", "definitions"}) {
+    const auto *entries{document.try_at(container)};
+    if (!entries || !entries->is_object()) {
+      continue;
+    }
+
+    const auto *direct{
+        entries->try_at(sourcemeta::core::JSON::String{identifier})};
+    if (direct && embedded_metaschema_matches(*direct, identifier, canonical)) {
+      return {direct, container};
+    }
+
+    for (const auto &entry : entries->as_object()) {
+      if (embedded_metaschema_matches(entry.second, identifier, canonical)) {
+        return {&entry.second, container};
+      }
+    }
+  }
+
+  return {nullptr, ""};
+}
+
+// A meta-schema that is not known to the resolver may still be embedded in
+// the document itself, as `bundle()` does for custom meta-schemas. Across
+// every official base dialect, the only containers that can hold embedded
+// resources are `$defs` (2019-09 and 2020-12, where it belongs to the
+// mandatory core vocabulary) and `definitions` (Draft 7 and older, which
+// have no vocabulary mechanism), so no custom dialect can redefine them away.
+// A candidate only counts if its entire meta-schema chain terminates at an
+// official base dialect and every embedded link of the chain sits in the
+// exact container that such base dialect prescribes, which is the container
+// `bundle()` would have used. For example, a chain that terminates in Draft 7
+// but whose links are embedded in `$defs` (which means nothing in Draft 7)
+// is rejected
+inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
+                                     const std::string_view identifier,
+                                     const SchemaResolver &resolver)
+    -> const sourcemeta::core::JSON * {
+  const auto candidate{embedded_metaschema_candidate(document, identifier)};
+  if (!candidate.first) {
+    return nullptr;
+  }
+
+  std::unordered_set<sourcemeta::core::JSON::String> visited;
+  std::vector<std::string_view> containers{candidate.second};
+  // Chain links that the resolver knows about are returned by value, so we
+  // need to keep them alive while we keep walking the chain
+  std::vector<sourcemeta::core::JSON> resolved;
+  const auto *current{candidate.first};
+  sourcemeta::core::JSON::String current_identifier{identifier};
+  std::optional<SchemaBaseDialect> terminal;
+
+  while (true) {
+    if (!visited.emplace(current_identifier).second) {
+      return nullptr;
+    }
+
+    if (!current->is_object()) {
+      return nullptr;
+    }
+
+    const auto *metaschema_dialect{current->try_at("$schema")};
+    if (!metaschema_dialect || !metaschema_dialect->is_string()) {
+      return nullptr;
+    }
+
+    const auto &dialect_uri{metaschema_dialect->to_string()};
+    const auto known{to_base_dialect(dialect_uri)};
+    if (known.has_value()) {
+      terminal = known;
+      break;
+    }
+
+    auto remote{resolver(dialect_uri)};
+    if (remote.has_value()) {
+      resolved.push_back(std::move(remote).value());
+      current = &resolved.back();
+      current_identifier = dialect_uri;
+      continue;
+    }
+
+    const auto next{embedded_metaschema_candidate(document, dialect_uri)};
+    if (!next.first) {
+      return nullptr;
+    }
+
+    containers.push_back(next.second);
+    current = next.first;
+    current_identifier = dialect_uri;
+  }
+
+  assert(terminal.has_value());
+  const auto expected{definitions_keyword(terminal.value())};
+  for (const auto container : containers) {
+    if (container != expected) {
+      return nullptr;
+    }
+  }
+
+  return candidate.first;
 }
 
 } // namespace sourcemeta::blaze

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -91,6 +91,31 @@ ref_overrides_adjacent_keywords(const SchemaBaseDialect base_dialect) -> bool {
   }
 }
 
+inline auto embedded_metaschema_identifier_matches(
+    const sourcemeta::core::JSON &candidate, const std::string_view keyword,
+    const std::string_view identifier,
+    const std::optional<sourcemeta::core::JSON::String> &canonical) -> bool {
+  const auto *value{candidate.try_at(sourcemeta::core::JSON::String{keyword})};
+  if (!value || !value->is_string()) {
+    return false;
+  }
+
+  const auto &current{value->to_string()};
+  if (current == identifier) {
+    return true;
+  }
+
+  if (canonical.has_value()) {
+    try {
+      return sourcemeta::core::URI::canonicalize(current) == canonical.value();
+    } catch (const sourcemeta::core::URIParseError &) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 inline auto embedded_metaschema_matches(
     const sourcemeta::core::JSON &candidate, const std::string_view identifier,
     const std::optional<sourcemeta::core::JSON::String> &canonical) -> bool {
@@ -99,24 +124,9 @@ inline auto embedded_metaschema_matches(
   }
 
   for (const auto *const keyword : {"$id", "id"}) {
-    const auto *value{candidate.try_at(keyword)};
-    if (!value || !value->is_string()) {
-      continue;
-    }
-
-    const auto &current{value->to_string()};
-    if (current == identifier) {
+    if (embedded_metaschema_identifier_matches(candidate, keyword, identifier,
+                                               canonical)) {
       return true;
-    }
-
-    if (canonical.has_value()) {
-      try {
-        if (sourcemeta::core::URI::canonicalize(current) == canonical.value()) {
-          return true;
-        }
-      } catch (const sourcemeta::core::URIParseError &) {
-        continue;
-      }
     }
   }
 
@@ -160,13 +170,53 @@ embedded_metaschema_candidate(const sourcemeta::core::JSON &document,
   return {nullptr, ""};
 }
 
+inline auto embedded_metaschema_link_valid(const sourcemeta::core::JSON &link,
+                                           const std::string_view identifier,
+                                           const std::string_view container,
+                                           const SchemaBaseDialect base_dialect)
+    -> bool {
+  // In 2019-09 and 2020-12, `definitions` is still supported
+  // for backwards compatibility
+  switch (base_dialect) {
+    case SchemaBaseDialect::JSON_Schema_2020_12:
+    case SchemaBaseDialect::JSON_Schema_2020_12_Hyper:
+    case SchemaBaseDialect::JSON_Schema_2019_09:
+    case SchemaBaseDialect::JSON_Schema_2019_09_Hyper:
+      if (container != "$defs" && container != "definitions") {
+        return false;
+      }
+
+      break;
+    default:
+      if (container != definitions_keyword(base_dialect)) {
+        return false;
+      }
+  }
+
+  std::optional<sourcemeta::core::JSON::String> canonical;
+  try {
+    canonical = sourcemeta::core::URI::canonicalize(identifier);
+  } catch (const sourcemeta::core::URIParseError &) {
+    canonical = std::nullopt;
+  }
+
+  return embedded_metaschema_identifier_matches(link, id_keyword(base_dialect),
+                                                identifier, canonical);
+}
+
+struct EmbeddedMetaschemaLink {
+  const sourcemeta::core::JSON *schema;
+  sourcemeta::core::JSON::String identifier;
+  std::string_view container;
+};
+
 // A meta-schema that is not known to the resolver may still be embedded in
 // the document itself. Across every official base dialect, the only
 // containers that can hold embedded resources are `$defs` and `definitions`,
 // which no custom dialect can redefine away. A candidate only counts if its
 // entire meta-schema chain terminates at an official base dialect and every
-// embedded link sits in the exact container that such base dialect
-// prescribes
+// embedded link declares its identifier and sits in a container in a way
+// that is valid for such base dialect
 inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
                                      const std::string_view identifier,
                                      const SchemaResolver &resolver)
@@ -177,7 +227,10 @@ inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
   }
 
   std::unordered_set<sourcemeta::core::JSON::String> visited;
-  std::vector<std::string_view> containers{candidate.second};
+  std::vector<EmbeddedMetaschemaLink> links{
+      {.schema = candidate.first,
+       .identifier = sourcemeta::core::JSON::String{identifier},
+       .container = candidate.second}};
   // Chain links that the resolver knows about are returned by value, so we
   // need to keep them alive while we keep walking the chain
   std::vector<sourcemeta::core::JSON> resolved;
@@ -186,17 +239,20 @@ inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
   std::optional<SchemaBaseDialect> terminal;
 
   while (true) {
+    // The meta-schema is present, but its chain can never terminate at an
+    // official base dialect, just like a self-descriptive or cyclic
+    // meta-schema that the resolver knows about
     if (!visited.emplace(current_identifier).second) {
-      return nullptr;
+      throw SchemaUnknownBaseDialectError();
     }
 
     if (!current->is_object()) {
-      return nullptr;
+      throw SchemaUnknownBaseDialectError();
     }
 
     const auto *metaschema_dialect{current->try_at("$schema")};
     if (!metaschema_dialect || !metaschema_dialect->is_string()) {
-      return nullptr;
+      throw SchemaUnknownBaseDialectError();
     }
 
     const auto &dialect_uri{metaschema_dialect->to_string()};
@@ -219,15 +275,17 @@ inline auto find_embedded_metaschema(const sourcemeta::core::JSON &document,
       return nullptr;
     }
 
-    containers.push_back(next.second);
+    links.push_back({.schema = next.first,
+                     .identifier = dialect_uri,
+                     .container = next.second});
     current = next.first;
     current_identifier = dialect_uri;
   }
 
   assert(terminal.has_value());
-  const auto expected{definitions_keyword(terminal.value())};
-  for (const auto container : containers) {
-    if (container != expected) {
+  for (const auto &link : links) {
+    if (!embedded_metaschema_link_valid(*(link.schema), link.identifier,
+                                        link.container, terminal.value())) {
       return nullptr;
     }
   }

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -679,6 +679,72 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema) {
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
 }
 
+TEST(Foundation_base_dialect, embedded_custom_metaschema_2019_09) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2019_09);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_draft7) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_draft4) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "id": "https://example.com/schema",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta": {
+        "id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_4);
+}
+
 TEST(Foundation_base_dialect, embedded_custom_metaschema_chain) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta-a",
@@ -691,6 +757,55 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema_chain) {
       },
       "https://example.com/meta-b": {
         "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_chain_draft7) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "definitions": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+}
+
+TEST(Foundation_base_dialect,
+     embedded_custom_metaschema_non_canonical_dialect_uri) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta#",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$vocabulary": {
           "https://json-schema.org/draft/2020-12/vocab/core": true
@@ -720,6 +835,85 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema_wrong_container) {
     }
   })JSON");
 
-  EXPECT_THROW(sourcemeta::blaze::base_dialect(document, test_resolver),
-               sourcemeta::blaze::SchemaResolutionError);
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(Foundation_base_dialect,
+     embedded_custom_metaschema_wrong_container_2020_12) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_self_descriptive) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://example.com/meta",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_not_found) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/other": {
+        "$id": "https://example.com/other",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
 }

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -654,3 +654,72 @@ TEST(Foundation_base_dialect, override_disallowed_with_default_dialect) {
   EXPECT_EQ(base_dialect.value(),
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
 }
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_chain) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_wrong_container) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::blaze::base_dialect(document, test_resolver),
+               sourcemeta::blaze::SchemaResolutionError);
+}

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -981,3 +981,30 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema_not_found) {
     FAIL();
   }
 }
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_relative_dialect) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "meta": {
+        "$id": "meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::SchemaRelativeMetaschemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "meta");
+  } catch (...) {
+    FAIL();
+  }
+}

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -845,8 +845,7 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema_wrong_container) {
   }
 }
 
-TEST(Foundation_base_dialect,
-     embedded_custom_metaschema_wrong_container_2020_12) {
+TEST(Foundation_base_dialect, embedded_custom_metaschema_definitions_2020_12) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta",
     "$id": "https://example.com/schema",
@@ -857,6 +856,55 @@ TEST(Foundation_base_dialect,
         "$vocabulary": {
           "https://json-schema.org/draft/2020-12/vocab/core": true
         },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  // In 2019-09 and 2020-12, `definitions` is still supported
+  // for backwards compatibility
+  const auto base_dialect{
+      sourcemeta::blaze::base_dialect(document, test_resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_wrong_id_keyword) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta": {
+        "id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::base_dialect(document, test_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(Foundation_base_dialect,
+     embedded_custom_metaschema_draft4_wrong_id_keyword) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "id": "https://example.com/schema",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object"
       }
     }
@@ -885,14 +933,30 @@ TEST(Foundation_base_dialect, embedded_custom_metaschema_self_descriptive) {
     }
   })JSON");
 
-  try {
-    sourcemeta::blaze::base_dialect(document, test_resolver);
-    FAIL();
-  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
-    EXPECT_EQ(error.identifier(), "https://example.com/meta");
-  } catch (...) {
-    FAIL();
-  }
+  EXPECT_THROW(sourcemeta::blaze::base_dialect(document, test_resolver),
+               sourcemeta::blaze::SchemaUnknownBaseDialectError);
+}
+
+TEST(Foundation_base_dialect, embedded_custom_metaschema_cyclic) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://example.com/meta-a",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::blaze::base_dialect(document, test_resolver),
+               sourcemeta::blaze::SchemaUnknownBaseDialectError);
 }
 
 TEST(Foundation_base_dialect, embedded_custom_metaschema_not_found) {

--- a/test/foundation/foundation_metaschema_test.cc
+++ b/test/foundation/foundation_metaschema_test.cc
@@ -100,3 +100,26 @@ TEST(Foundation_metaschema, override_unresolvable) {
       sourcemeta::blaze::metaschema(schema, sourcemeta::blaze::schema_resolver),
       sourcemeta::blaze::SchemaResolutionError);
 }
+
+TEST(Foundation_metaschema, embedded_custom_metaschema) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto metaschema{sourcemeta::blaze::metaschema(
+      schema, sourcemeta::blaze::schema_resolver)};
+  EXPECT_TRUE(metaschema.is_object());
+  EXPECT_EQ(metaschema, schema.at("$defs").at("https://example.com/meta"));
+}

--- a/test/foundation/foundation_metaschema_test.cc
+++ b/test/foundation/foundation_metaschema_test.cc
@@ -120,6 +120,74 @@ TEST(Foundation_metaschema, embedded_custom_metaschema) {
 
   const auto metaschema{sourcemeta::blaze::metaschema(
       schema, sourcemeta::blaze::schema_resolver)};
-  EXPECT_TRUE(metaschema.is_object());
-  EXPECT_EQ(metaschema, schema.at("$defs").at("https://example.com/meta"));
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true
+    },
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(metaschema, expected);
+}
+
+TEST(Foundation_metaschema, embedded_custom_metaschema_draft7) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto metaschema{sourcemeta::blaze::metaschema(
+      schema, sourcemeta::blaze::schema_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(metaschema, expected);
+}
+
+TEST(Foundation_metaschema, embedded_custom_metaschema_chain) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto metaschema{sourcemeta::blaze::metaschema(
+      schema, sourcemeta::blaze::schema_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta-a",
+    "$schema": "https://example.com/meta-b",
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(metaschema, expected);
 }

--- a/test/foundation/foundation_metaschema_test.cc
+++ b/test/foundation/foundation_metaschema_test.cc
@@ -191,3 +191,30 @@ TEST(Foundation_metaschema, embedded_custom_metaschema_chain) {
 
   EXPECT_EQ(metaschema, expected);
 }
+
+TEST(Foundation_metaschema, embedded_custom_metaschema_relative_dialect) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "meta": {
+        "$id": "meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::metaschema(schema, sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::SchemaRelativeMetaschemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "meta");
+  } catch (...) {
+    FAIL();
+  }
+}

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -808,7 +808,7 @@ TEST(Foundation_vocabulary, embedded_custom_metaschema_without_vocabulary) {
   EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
 }
 
-TEST(Foundation_vocabulary, embedded_custom_metaschema_wrong_container) {
+TEST(Foundation_vocabulary, embedded_custom_metaschema_definitions_2020_12) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta",
     "$id": "https://example.com/schema",
@@ -819,6 +819,28 @@ TEST(Foundation_vocabulary, embedded_custom_metaschema_wrong_container) {
         "$vocabulary": {
           "https://json-schema.org/draft/2020-12/vocab/core": true
         },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  // In 2019-09 and 2020-12, `definitions` is still supported
+  // for backwards compatibility
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 1);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_wrong_container) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object"
       }
     }

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -659,3 +659,29 @@ TEST(Foundation_vocabulary, has_unknown_with_openapi_vocabularies) {
 
   EXPECT_FALSE(vocabularies.has_unknown());
 }
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Validation);
+}

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -685,3 +685,152 @@ TEST(Foundation_vocabulary, embedded_custom_metaschema) {
   EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
   EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Validation);
 }
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_2019_09) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2019-09/vocab/core": true,
+          "https://json-schema.org/draft/2019-09/vocab/validation": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2019_09_Core);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2019_09_Validation);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_draft7) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 1);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_Draft_7);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_draft4) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "id": "https://example.com/schema",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta": {
+        "id": "https://example.com/meta",
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 1);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_Draft_4);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_chain) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Validation);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_without_vocabulary) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document,
+                                      sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(vocabularies.size(), 1);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
+}
+
+TEST(Foundation_vocabulary, embedded_custom_metaschema_wrong_container) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "definitions": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::vocabularies(document,
+                                    sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
+    EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

