### PR TITLE
Do not emit `not` when canonicalising `dependentSchemas` and `dependentRequired`

### DIFF
--- a/src/alterschema/canonicalizer/dependent_required_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_required_to_any_of.h
@@ -45,19 +45,16 @@ public:
         required_all.push_back(dependent);
       }
 
-      auto not_required{JSON::make_object()};
-      not_required.assign("type", JSON{"object"});
-      not_required.assign("required", JSON::make_array());
-      not_required.at("required").push_back(JSON{entry.first});
-      auto not_branch{JSON::make_object()};
-      not_branch.assign("not", std::move(not_required));
+      auto absence_branch{JSON::make_object()};
+      absence_branch.assign("properties", JSON::make_object());
+      absence_branch.at("properties").assign(entry.first, JSON{false});
 
       auto required_branch{JSON::make_object()};
       required_branch.assign("type", JSON{"object"});
       required_branch.assign("required", std::move(required_all));
 
       auto pair{JSON::make_array()};
-      pair.push_back(std::move(not_branch));
+      pair.push_back(std::move(absence_branch));
       pair.push_back(std::move(required_branch));
 
       auto wrapper{JSON::make_object()};

--- a/src/alterschema/canonicalizer/dependent_required_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_required_to_any_of.h
@@ -18,6 +18,9 @@ public:
         vocabularies.contains_any(
             {Vocabularies::Known::JSON_Schema_2019_09_Validation,
              Vocabularies::Known::JSON_Schema_2020_12_Validation}) &&
+        vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2019_09_Applicator,
+             Vocabularies::Known::JSON_Schema_2020_12_Applicator}) &&
         schema.is_object());
 
     const auto *dependent_required{schema.try_at("dependentRequired")};

--- a/src/alterschema/canonicalizer/dependent_required_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_required_to_any_of.h
@@ -18,9 +18,6 @@ public:
         vocabularies.contains_any(
             {Vocabularies::Known::JSON_Schema_2019_09_Validation,
              Vocabularies::Known::JSON_Schema_2020_12_Validation}) &&
-        vocabularies.contains_any(
-            {Vocabularies::Known::JSON_Schema_2019_09_Applicator,
-             Vocabularies::Known::JSON_Schema_2020_12_Applicator}) &&
         schema.is_object());
 
     const auto *dependent_required{schema.try_at("dependentRequired")};
@@ -30,6 +27,15 @@ public:
     ONLY_CONTINUE_IF(std::ranges::any_of(
         dependent_required->as_object(),
         [](const auto &entry) { return entry.second.is_array(); }));
+
+    if (!vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2019_09_Applicator,
+             Vocabularies::Known::JSON_Schema_2020_12_Applicator})) {
+      throw SchemaError(
+          "Cannot canonicalise `dependentRequired` without the Applicator "
+          "vocabulary");
+    }
+
     return true;
   }
 

--- a/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
@@ -18,6 +18,9 @@ public:
         vocabularies.contains_any(
             {Vocabularies::Known::JSON_Schema_2019_09_Applicator,
              Vocabularies::Known::JSON_Schema_2020_12_Applicator}) &&
+        vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2019_09_Validation,
+             Vocabularies::Known::JSON_Schema_2020_12_Validation}) &&
         schema.is_object());
 
     const auto *dependent_schemas{schema.try_at("dependentSchemas")};

--- a/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
@@ -30,12 +30,9 @@ public:
     auto result_branches{JSON::make_array()};
 
     for (const auto &entry : schema.at("dependentSchemas").as_object()) {
-      auto not_required{JSON::make_object()};
-      not_required.assign("type", JSON{"object"});
-      not_required.assign("required", JSON::make_array());
-      not_required.at("required").push_back(JSON{entry.first});
-      auto not_branch{JSON::make_object()};
-      not_branch.assign("not", std::move(not_required));
+      auto absence_branch{JSON::make_object()};
+      absence_branch.assign("properties", JSON::make_object());
+      absence_branch.at("properties").assign(entry.first, JSON{false});
 
       auto required_obj{JSON::make_object()};
       required_obj.assign("type", JSON{"object"});
@@ -50,7 +47,7 @@ public:
       allof_branch.assign("allOf", std::move(all_of));
 
       auto pair{JSON::make_array()};
-      pair.push_back(std::move(not_branch));
+      pair.push_back(std::move(absence_branch));
       pair.push_back(std::move(allof_branch));
 
       auto wrapper{JSON::make_object()};

--- a/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
+++ b/src/alterschema/canonicalizer/dependent_schemas_to_any_of.h
@@ -18,14 +18,20 @@ public:
         vocabularies.contains_any(
             {Vocabularies::Known::JSON_Schema_2019_09_Applicator,
              Vocabularies::Known::JSON_Schema_2020_12_Applicator}) &&
-        vocabularies.contains_any(
-            {Vocabularies::Known::JSON_Schema_2019_09_Validation,
-             Vocabularies::Known::JSON_Schema_2020_12_Validation}) &&
         schema.is_object());
 
     const auto *dependent_schemas{schema.try_at("dependentSchemas")};
     ONLY_CONTINUE_IF(dependent_schemas && dependent_schemas->is_object() &&
                      !dependent_schemas->empty());
+
+    if (!vocabularies.contains_any(
+            {Vocabularies::Known::JSON_Schema_2019_09_Validation,
+             Vocabularies::Known::JSON_Schema_2020_12_Validation})) {
+      throw SchemaError(
+          "Cannot canonicalise `dependentSchemas` without the Validation "
+          "vocabulary");
+    }
+
     return true;
   }
 

--- a/src/alterschema/canonicalizer/type_array_to_any_of.h
+++ b/src/alterschema/canonicalizer/type_array_to_any_of.h
@@ -18,15 +18,20 @@ public:
             const sourcemeta::blaze::SchemaResolver &, const bool) const
       -> SchemaTransformRule::Result override {
 
-    ONLY_CONTINUE_IF(vocabularies.contains_any(
-                         {Vocabularies::Known::JSON_Schema_2020_12_Validation,
-                          Vocabularies::Known::JSON_Schema_2020_12_Applicator,
-                          Vocabularies::Known::JSON_Schema_2019_09_Validation,
-                          Vocabularies::Known::JSON_Schema_2019_09_Applicator,
-                          Vocabularies::Known::JSON_Schema_Draft_7,
-                          Vocabularies::Known::JSON_Schema_Draft_6,
-                          Vocabularies::Known::JSON_Schema_Draft_4}) &&
-                     schema.is_object());
+    ONLY_CONTINUE_IF(
+        ((vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2020_12_Validation) &&
+          vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2020_12_Applicator)) ||
+         (vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2019_09_Validation) &&
+          vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2019_09_Applicator)) ||
+         vocabularies.contains_any(
+             {Vocabularies::Known::JSON_Schema_Draft_7,
+              Vocabularies::Known::JSON_Schema_Draft_6,
+              Vocabularies::Known::JSON_Schema_Draft_4})) &&
+        schema.is_object());
 
     const auto *type{schema.try_at("type")};
     ONLY_CONTINUE_IF(type && type->is_array());

--- a/test/alterschema/alterschema_canonicalize_2019_09_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2019_09_test.cc
@@ -1118,16 +1118,34 @@ TEST_F(Canonicalizer201909Test, dependent_schemas_to_any_of) {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "anyOf": [
       {
-        "not": {
-          "type": "object",
-          "required": [ "foo" ],
-          "patternProperties": {},
-          "propertyNames": true,
-          "minProperties": 1,
-          "properties": {
-            "foo": true
-          }
-        }
+        "enum": [ null ]
+      },
+      {
+        "enum": [ false, true ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "foo": false
+        },
+        "patternProperties": {},
+        "propertyNames": true,
+        "minProperties": 0
+      },
+      {
+        "type": "array",
+        "uniqueItems": false,
+        "minItems": 0,
+        "contains": true,
+        "minContains": 0,
+        "items": true
+      },
+      {
+        "type": "string",
+        "minLength": 0
+      },
+      {
+        "type": "number"
       },
       {
         "allOf": [
@@ -1175,16 +1193,13 @@ TEST_F(Canonicalizer201909Test, dependent_required_to_any_of) {
           {
             "anyOf": [
               {
-                "not": {
-                  "type": "object",
-                  "required": [ "foo" ],
-                  "patternProperties": {},
-                  "propertyNames": true,
-                  "minProperties": 1,
-                  "properties": {
-                    "foo": true
-                  }
-                }
+                "type": "object",
+                "properties": {
+                  "foo": false
+                },
+                "patternProperties": {},
+                "propertyNames": true,
+                "minProperties": 0
               },
               {
                 "type": "object",

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -2620,16 +2620,34 @@ TEST_F(Canonicalizer202012Test, dependent_schemas_to_any_of) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "anyOf": [
       {
-        "not": {
-          "type": "object",
-          "required": [ "foo" ],
-          "patternProperties": {},
-          "propertyNames": true,
-          "minProperties": 1,
-          "properties": {
-            "foo": true
-          }
-        }
+        "enum": [ null ]
+      },
+      {
+        "enum": [ false, true ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "foo": false
+        },
+        "patternProperties": {},
+        "propertyNames": true,
+        "minProperties": 0
+      },
+      {
+        "type": "array",
+        "uniqueItems": false,
+        "minItems": 0,
+        "contains": true,
+        "minContains": 0,
+        "items": true
+      },
+      {
+        "type": "string",
+        "minLength": 0
+      },
+      {
+        "type": "number"
       },
       {
         "allOf": [
@@ -2677,16 +2695,13 @@ TEST_F(Canonicalizer202012Test, dependent_required_to_any_of) {
           {
             "anyOf": [
               {
-                "not": {
-                  "type": "object",
-                  "required": [ "foo" ],
-                  "patternProperties": {},
-                  "propertyNames": true,
-                  "minProperties": 1,
-                  "properties": {
-                    "foo": true
-                  }
-                }
+                "type": "object",
+                "properties": {
+                  "foo": false
+                },
+                "patternProperties": {},
+                "propertyNames": true,
+                "minProperties": 0
               },
               {
                 "type": "object",

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -2746,6 +2746,44 @@ TEST_F(Canonicalizer202012Test, dependent_required_to_any_of) {
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
 
+TEST_F(Canonicalizer202012Test,
+       dependent_required_to_any_of_without_applicator) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://sourcemeta.com/2020-12-validation-without-applicator",
+    "dependentRequired": {
+      "foo": [ "bar" ]
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://sourcemeta.com/2020-12-validation-without-applicator",
+    "dependentRequired": {
+      "foo": [ "bar" ]
+    }
+  })JSON");
+
+  CANONICALIZE_WITHOUT_VALIDATE(document, expected);
+}
+
+TEST_F(Canonicalizer202012Test,
+       dependent_schemas_to_any_of_without_validation) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://sourcemeta.com/2020-12-applicator-without-validation",
+    "dependentSchemas": {
+      "foo": { "type": "string", "minLength": 0 }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://sourcemeta.com/2020-12-applicator-without-validation",
+    "dependentSchemas": {
+      "foo": { "type": "string", "minLength": 0 }
+    }
+  })JSON");
+
+  CANONICALIZE_WITHOUT_VALIDATE(document, expected);
+}
+
 TEST_F(Canonicalizer202012Test, empty_defs_drop) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -2755,14 +2755,23 @@ TEST_F(Canonicalizer202012Test,
     }
   })JSON");
 
-  const auto expected = sourcemeta::core::parse_json(R"JSON({
-    "$schema": "https://sourcemeta.com/2020-12-validation-without-applicator",
-    "dependentRequired": {
-      "foo": [ "bar" ]
-    }
-  })JSON");
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle,
+                         sourcemeta::blaze::AlterSchemaMode::Canonicalizer);
 
-  CANONICALIZE_WITHOUT_VALIDATE(document, expected);
+  try {
+    [[maybe_unused]] const auto result{bundle.apply(
+        document, sourcemeta::blaze::schema_walker, alterschema_test_resolver,
+        [](const auto &, const auto &, const auto &, const auto &,
+           const auto &) {})};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Cannot canonicalise `dependentRequired` without the "
+                 "Applicator vocabulary");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST_F(Canonicalizer202012Test,
@@ -2774,14 +2783,23 @@ TEST_F(Canonicalizer202012Test,
     }
   })JSON");
 
-  const auto expected = sourcemeta::core::parse_json(R"JSON({
-    "$schema": "https://sourcemeta.com/2020-12-applicator-without-validation",
-    "dependentSchemas": {
-      "foo": { "type": "string", "minLength": 0 }
-    }
-  })JSON");
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle,
+                         sourcemeta::blaze::AlterSchemaMode::Canonicalizer);
 
-  CANONICALIZE_WITHOUT_VALIDATE(document, expected);
+  try {
+    [[maybe_unused]] const auto result{bundle.apply(
+        document, sourcemeta::blaze::schema_walker, alterschema_test_resolver,
+        [](const auto &, const auto &, const auto &, const auto &,
+           const auto &) {})};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Cannot canonicalise `dependentSchemas` without the "
+                 "Validation vocabulary");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST_F(Canonicalizer202012Test, empty_defs_drop) {

--- a/test/alterschema/alterschema_test_utils.h
+++ b/test/alterschema/alterschema_test_utils.h
@@ -53,6 +53,26 @@ static auto alterschema_test_resolver(std::string_view identifier)
       "type": "integer"
     })JSON");
   } else if (identifier ==
+             "https://sourcemeta.com/2020-12-validation-without-applicator") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$id": "https://sourcemeta.com/2020-12-validation-without-applicator",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true
+      }
+    })JSON");
+  } else if (identifier ==
+             "https://sourcemeta.com/2020-12-applicator-without-validation") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$id": "https://sourcemeta.com/2020-12-applicator-without-validation",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true
+      }
+    })JSON");
+  } else if (identifier ==
              "https://example.com/unsupported-vocabulary-metaschema") {
     return sourcemeta::core::parse_json(R"JSON({
       "$id": "https://example.com/unsupported-vocabulary-metaschema",
@@ -118,6 +138,19 @@ static auto alterschema_test_resolver(std::string_view identifier)
     EXPECT_EQ(document, expected);                                             \
     sourcemeta::blaze::Evaluator _evaluator;                                   \
     EXPECT_TRUE(_evaluator.validate(compiled_template, document));             \
+  }
+
+#define CANONICALIZE_WITHOUT_VALIDATE(document, expected)                      \
+  {                                                                            \
+    sourcemeta::blaze::SchemaTransformer _bundle;                              \
+    sourcemeta::blaze::add(_bundle,                                            \
+                           sourcemeta::blaze::AlterSchemaMode::Canonicalizer); \
+    const auto _result = _bundle.apply(                                        \
+        document, sourcemeta::blaze::schema_walker, alterschema_test_resolver, \
+        [](const auto &, const auto &, const auto &, const auto &,             \
+           const auto &) {});                                                  \
+    EXPECT_TRUE(_result.first);                                                \
+    EXPECT_EQ(document, expected);                                             \
   }
 
 #define EXPECT_JSON_EQ_WITH_ORDERING(actual, expected)                         \

--- a/test/alterschema/alterschema_test_utils.h
+++ b/test/alterschema/alterschema_test_utils.h
@@ -140,19 +140,6 @@ static auto alterschema_test_resolver(std::string_view identifier)
     EXPECT_TRUE(_evaluator.validate(compiled_template, document));             \
   }
 
-#define CANONICALIZE_WITHOUT_VALIDATE(document, expected)                      \
-  {                                                                            \
-    sourcemeta::blaze::SchemaTransformer _bundle;                              \
-    sourcemeta::blaze::add(_bundle,                                            \
-                           sourcemeta::blaze::AlterSchemaMode::Canonicalizer); \
-    const auto _result = _bundle.apply(                                        \
-        document, sourcemeta::blaze::schema_walker, alterschema_test_resolver, \
-        [](const auto &, const auto &, const auto &, const auto &,             \
-           const auto &) {});                                                  \
-    EXPECT_TRUE(_result.first);                                                \
-    EXPECT_EQ(document, expected);                                             \
-  }
-
 #define EXPECT_JSON_EQ_WITH_ORDERING(actual, expected)                         \
   {                                                                            \
     EXPECT_EQ(actual, expected);                                               \

--- a/test/documentation/documentation_2020_12_test.cc
+++ b/test/documentation/documentation_2020_12_test.cc
@@ -5026,32 +5026,33 @@ TEST_F(Documentation202012Test, dependent_schemas) {
                             }
                           ],
                           "type": {
+                            "kind": "object"
+                          }
+                        },
+                        {
+                          "identifier": 6,
+                          "path": [
+                            {
+                              "type": "literal",
+                              "value": "a"
+                            }
+                          ],
+                          "type": {
+                            "kind": "never"
+                          },
+                          "required": false
+                        },
+                        {
+                          "identifier": 7,
+                          "path": [
+                            {
+                              "type": "wildcard",
+                              "value": "*"
+                            }
+                          ],
+                          "type": {
                             "kind": "any"
                           }
-                        }
-                      ],
-                      "children": [
-                        {
-                          "label": "Must NOT match",
-                          "children": [
-                            {
-                              "identifier": 6,
-                              "rows": [
-                                {
-                                  "identifier": 7,
-                                  "path": [
-                                    {
-                                      "type": "synthetic",
-                                      "value": "value"
-                                    }
-                                  ],
-                                  "type": {
-                                    "kind": "object"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
                         }
                       ]
                     },
@@ -5269,32 +5270,33 @@ TEST_F(Documentation202012Test, dependent_required) {
                             }
                           ],
                           "type": {
+                            "kind": "object"
+                          }
+                        },
+                        {
+                          "identifier": 6,
+                          "path": [
+                            {
+                              "type": "literal",
+                              "value": "a"
+                            }
+                          ],
+                          "type": {
+                            "kind": "never"
+                          },
+                          "required": false
+                        },
+                        {
+                          "identifier": 7,
+                          "path": [
+                            {
+                              "type": "wildcard",
+                              "value": "*"
+                            }
+                          ],
+                          "type": {
                             "kind": "any"
                           }
-                        }
-                      ],
-                      "children": [
-                        {
-                          "label": "Must NOT match",
-                          "children": [
-                            {
-                              "identifier": 6,
-                              "rows": [
-                                {
-                                  "identifier": 7,
-                                  "path": [
-                                    {
-                                      "type": "synthetic",
-                                      "value": "value"
-                                    }
-                                  ],
-                                  "type": {
-                                    "kind": "object"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
                         }
                       ]
                     },


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

