### PR TITLE
Support `dependentRequired` and `dependentSchemas` on codegen

### DIFF
--- a/test/codegen/e2e/typescript/2020-12/dependent_required/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required/expected.d.ts
@@ -1,0 +1,34 @@
+export type Payment_1Credit_card = string;
+
+export type Payment_1Billing_address = string;
+
+export interface Payment_1 {
+  "credit_card"?: Payment_1Credit_card;
+  "billing_address"?: Payment_1Billing_address;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_1Credit_card = unknown;
+
+export type Payment_0_1Billing_address = unknown;
+
+export interface Payment_0_1 {
+  "credit_card": Payment_0_1Credit_card;
+  "billing_address": Payment_0_1Billing_address;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_0Credit_card = never;
+
+export interface Payment_0_0 {
+  "credit_card"?: Payment_0_0Credit_card;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0 =
+  Payment_0_0 |
+  Payment_0_1;
+
+export type Payment =
+  Payment_0 &
+  Payment_1;

--- a/test/codegen/e2e/typescript/2020-12/dependent_required/options.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "Payment"
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required/schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "credit_card": { "type": "string" },
+    "billing_address": { "type": "string" }
+  },
+  "dependentRequired": {
+    "credit_card": [ "billing_address" ]
+  }
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required/test.ts
@@ -1,0 +1,31 @@
+import { Payment } from "./expected";
+
+// The dependency is not triggered when "credit_card" is absent
+const empty: Payment = {};
+
+const onlyBilling: Payment = {
+  billing_address: "123 Main Street"
+};
+
+// When "credit_card" is present, "billing_address" must be present too
+const both: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street"
+};
+
+// @ts-expect-error "credit_card" requires "billing_address"
+const creditWithoutBilling: Payment = {
+  credit_card: "4111-1111-1111-1111"
+};
+
+const wrongCreditCardType: Payment = {
+  // @ts-expect-error
+  credit_card: 123,
+  billing_address: "123 Main Street"
+};
+
+const wrongBillingType: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  // @ts-expect-error
+  billing_address: 456
+};

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/expected.d.ts
@@ -1,0 +1,9 @@
+export type PaymentCredit_card = string;
+
+export type PaymentBilling_address = string;
+
+export interface Payment {
+  "credit_card": PaymentCredit_card;
+  "billing_address": PaymentBilling_address;
+  [key: string]: unknown | undefined;
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/options.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "Payment"
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "credit_card": { "type": "string" },
+    "billing_address": { "type": "string" }
+  },
+  "required": [ "credit_card" ],
+  "dependentRequired": {
+    "credit_card": [ "billing_address" ]
+  }
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_already_required/test.ts
@@ -1,0 +1,28 @@
+import { Payment } from "./expected";
+
+// Because "credit_card" is already required, the dependency folds into a
+// plain object where both properties are unconditionally required
+const both: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street"
+};
+
+// @ts-expect-error "credit_card" is required
+const empty: Payment = {};
+
+// @ts-expect-error "billing_address" is required
+const onlyCard: Payment = {
+  credit_card: "4111-1111-1111-1111"
+};
+
+const wrongCreditCardType: Payment = {
+  // @ts-expect-error
+  credit_card: 123,
+  billing_address: "123 Main Street"
+};
+
+const wrongBillingType: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  // @ts-expect-error
+  billing_address: 456
+};

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/expected.d.ts
@@ -1,0 +1,68 @@
+export type Payment_2Phone = string;
+
+export type Payment_2Credit_card = string;
+
+export type Payment_2Country_code = string;
+
+export type Payment_2Billing_zip = string;
+
+export type Payment_2Billing_address = string;
+
+export interface Payment_2 {
+  "credit_card"?: Payment_2Credit_card;
+  "billing_address"?: Payment_2Billing_address;
+  "billing_zip"?: Payment_2Billing_zip;
+  "phone"?: Payment_2Phone;
+  "country_code"?: Payment_2Country_code;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_1_1Phone = unknown;
+
+export type Payment_1_1Country_code = unknown;
+
+export interface Payment_1_1 {
+  "phone": Payment_1_1Phone;
+  "country_code": Payment_1_1Country_code;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_1_0Phone = never;
+
+export interface Payment_1_0 {
+  "phone"?: Payment_1_0Phone;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_1 =
+  Payment_1_0 |
+  Payment_1_1;
+
+export type Payment_0_1Credit_card = unknown;
+
+export type Payment_0_1Billing_zip = unknown;
+
+export type Payment_0_1Billing_address = unknown;
+
+export interface Payment_0_1 {
+  "credit_card": Payment_0_1Credit_card;
+  "billing_address": Payment_0_1Billing_address;
+  "billing_zip": Payment_0_1Billing_zip;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_0Credit_card = never;
+
+export interface Payment_0_0 {
+  "credit_card"?: Payment_0_0Credit_card;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0 =
+  Payment_0_0 |
+  Payment_0_1;
+
+export type Payment =
+  Payment_0 &
+  Payment_1 &
+  Payment_2;

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/options.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "Payment"
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "credit_card": { "type": "string" },
+    "billing_address": { "type": "string" },
+    "billing_zip": { "type": "string" },
+    "phone": { "type": "string" },
+    "country_code": { "type": "string" }
+  },
+  "dependentRequired": {
+    "credit_card": [ "billing_address", "billing_zip" ],
+    "phone": [ "country_code" ]
+  }
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_required_multiple/test.ts
@@ -1,0 +1,49 @@
+import { Payment } from "./expected";
+
+// Neither dependency is triggered
+const empty: Payment = {};
+
+// Only the "credit_card" dependency is triggered
+const cardOnly: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street",
+  billing_zip: "90210"
+};
+
+// Only the "phone" dependency is triggered
+const phoneOnly: Payment = {
+  phone: "+1-555-0100",
+  country_code: "US"
+};
+
+// Both dependencies are triggered
+const everything: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street",
+  billing_zip: "90210",
+  phone: "+1-555-0100",
+  country_code: "US"
+};
+
+// @ts-expect-error "credit_card" requires "billing_address" and "billing_zip"
+const cardMissingBoth: Payment = {
+  credit_card: "4111-1111-1111-1111"
+};
+
+// @ts-expect-error "credit_card" still requires "billing_zip"
+const cardMissingZip: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street"
+};
+
+// @ts-expect-error "phone" requires "country_code"
+const phoneMissingCountry: Payment = {
+  phone: "+1-555-0100"
+};
+
+const wrongCreditCardType: Payment = {
+  // @ts-expect-error
+  credit_card: 123,
+  billing_address: "123 Main Street",
+  billing_zip: "90210"
+};

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas/expected.d.ts
@@ -1,0 +1,39 @@
+export type Payment_1Credit_card = string;
+
+export interface Payment_1 {
+  "credit_card"?: Payment_1Credit_card;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_1_1Billing_address = string;
+
+export interface Payment_0_1_1 {
+  "billing_address": Payment_0_1_1Billing_address;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_1_0Credit_card = unknown;
+
+export interface Payment_0_1_0 {
+  "credit_card": Payment_0_1_0Credit_card;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0_1 =
+  Payment_0_1_0 &
+  Payment_0_1_1;
+
+export type Payment_0_0Credit_card = never;
+
+export interface Payment_0_0 {
+  "credit_card"?: Payment_0_0Credit_card;
+  [key: string]: unknown | undefined;
+}
+
+export type Payment_0 =
+  Payment_0_0 |
+  Payment_0_1;
+
+export type Payment =
+  Payment_0 &
+  Payment_1;

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas/options.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "Payment"
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "credit_card": { "type": "string" }
+  },
+  "dependentSchemas": {
+    "credit_card": {
+      "properties": { "billing_address": { "type": "string" } },
+      "required": [ "billing_address" ]
+    }
+  }
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas/test.ts
@@ -1,0 +1,28 @@
+import { Payment } from "./expected";
+
+// The dependent schema does not apply when "credit_card" is absent
+const empty: Payment = {};
+
+// When "credit_card" is present, the dependent schema requires
+// "billing_address" to be a string
+const both: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: "123 Main Street"
+};
+
+// @ts-expect-error "credit_card" triggers the dependent schema
+const creditWithoutBilling: Payment = {
+  credit_card: "4111-1111-1111-1111"
+};
+
+// @ts-expect-error "billing_address" must be a string
+const wrongBillingType: Payment = {
+  credit_card: "4111-1111-1111-1111",
+  billing_address: 456
+};
+
+const wrongCreditCardType: Payment = {
+  // @ts-expect-error
+  credit_card: 123,
+  billing_address: "123 Main Street"
+};

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/expected.d.ts
@@ -1,0 +1,44 @@
+export type Record_1Category = string;
+
+export interface Record_1 {
+  "category"?: Record_1Category;
+  [key: string]: unknown | undefined;
+}
+
+export type Record_0_1_1DetailsCode = number;
+
+export interface Record_0_1_1Details {
+  "code": Record_0_1_1DetailsCode;
+  [key: string]: unknown | undefined;
+}
+
+export interface Record_0_1_1 {
+  "details": Record_0_1_1Details;
+  [key: string]: unknown | undefined;
+}
+
+export type Record_0_1_0Category = unknown;
+
+export interface Record_0_1_0 {
+  "category": Record_0_1_0Category;
+  [key: string]: unknown | undefined;
+}
+
+export type Record_0_1 =
+  Record_0_1_0 &
+  Record_0_1_1;
+
+export type Record_0_0Category = never;
+
+export interface Record_0_0 {
+  "category"?: Record_0_0Category;
+  [key: string]: unknown | undefined;
+}
+
+export type Record_0 =
+  Record_0_0 |
+  Record_0_1;
+
+export type Record =
+  Record_0 &
+  Record_1;

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/options.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "Record"
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "category": { "type": "string" }
+  },
+  "dependentSchemas": {
+    "category": {
+      "properties": {
+        "details": {
+          "type": "object",
+          "properties": {
+            "code": { "type": "integer" }
+          },
+          "required": [ "code" ]
+        }
+      },
+      "required": [ "details" ]
+    }
+  }
+}

--- a/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/dependent_schemas_nested/test.ts
@@ -1,0 +1,31 @@
+import { Record } from "./expected";
+
+// The dependent schema does not apply when "category" is absent
+const empty: Record = {};
+
+// When "category" is present, "details" (with a numeric "code") is required
+const withDetails: Record = {
+  category: "invoice",
+  details: {
+    code: 42
+  }
+};
+
+// @ts-expect-error "category" requires "details"
+const categoryWithoutDetails: Record = {
+  category: "invoice"
+};
+
+// @ts-expect-error "details.code" must be present
+const detailsMissingCode: Record = {
+  category: "invoice",
+  details: {}
+};
+
+// @ts-expect-error "details.code" must be a number
+const detailsWrongCodeType: Record = {
+  category: "invoice",
+  details: {
+    code: "42"
+  }
+};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

