### PR TITLE
Fix `required` sibling to `$ref` not ignored on Draft 3

### DIFF
--- a/schemas/canonical-draft3.json
+++ b/schemas/canonical-draft3.json
@@ -104,6 +104,9 @@
               "type": "array",
               "minItems": 1,
               "uniqueItems": true
+            },
+            "required": {
+              "type": "boolean"
             }
           },
           "unevaluatedProperties": false

--- a/schemas/canonical-draft3.test.json
+++ b/schemas/canonical-draft3.test.json
@@ -233,11 +233,19 @@
       }
     },
     {
-      "description": "Enum with required is rejected",
-      "valid": false,
+      "description": "Enum with boolean required is canonical",
+      "valid": true,
       "data": {
         "enum": [ 1 ],
         "required": true
+      }
+    },
+    {
+      "description": "Enum with non-boolean required is rejected",
+      "valid": false,
+      "data": {
+        "enum": [ 1 ],
+        "required": "yes"
       }
     },
     {

--- a/src/alterschema/canonicalizer/enum_drop_redundant_validation.h
+++ b/src/alterschema/canonicalizer/enum_drop_redundant_validation.h
@@ -63,6 +63,27 @@ public:
         continue;
       }
 
+      // In Draft 3 and older, `required` and `optional` are property-presence
+      // flags read by the parent object validator, not value assertions that an
+      // `enum` could make redundant
+      if (entry.first == "required" &&
+          vocabularies.contains_any(
+              {Vocabularies::Known::JSON_Schema_Draft_3,
+               Vocabularies::Known::JSON_Schema_Draft_3_Hyper})) {
+        continue;
+      }
+
+      if (entry.first == "optional" &&
+          vocabularies.contains_any(
+              {Vocabularies::Known::JSON_Schema_Draft_0,
+               Vocabularies::Known::JSON_Schema_Draft_0_Hyper,
+               Vocabularies::Known::JSON_Schema_Draft_1,
+               Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
+               Vocabularies::Known::JSON_Schema_Draft_2,
+               Vocabularies::Known::JSON_Schema_Draft_2_Hyper})) {
+        continue;
+      }
+
       if (entry.second.is_boolean() && entry.second.to_boolean()) {
         if (!frame.has_references_through(
                 location.pointer, WeakPointer::Token{std::cref(entry.first)})) {

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -409,7 +409,10 @@ inline auto required_properties(const SchemaContext &schema_context)
       schema_context.schema.at("properties").is_object()) {
     for (const auto &entry :
          schema_context.schema.at("properties").as_object()) {
+      // In Draft 3, keywords sibling to `$ref` are never evaluated, so a
+      // `required` flag next to a `$ref` does not make the property mandatory
       if (entry.second.is_object() && entry.second.defines("required") &&
+          !entry.second.defines("$ref") &&
           entry.second.at("required").is_boolean() &&
           entry.second.at("required").to_boolean()) {
         result.insert(entry.first);

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -696,3 +696,290 @@ TEST_F(CanonicalizerDraft3Test, disallow_narrows_type_simple) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
+
+TEST_F(CanonicalizerDraft3Test, ref_sibling_dropped_in_subschema) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "bar": { "$ref": "#", "type": "string" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "bar": { "$ref": "#" }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, ref_metadata_siblings_kept) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "bar": {
+        "$ref": "#",
+        "title": "A ref",
+        "description": "Refers to root"
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "bar": {
+        "title": "A ref",
+        "description": "Refers to root",
+        "$ref": "#"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, embedded_id_typed_property) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/embedded",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/embedded",
+        "type": "string",
+        "minLength": 0,
+        "required": false
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, embedded_id_self_recursive_ref) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/embedded",
+        "type": "object",
+        "properties": {
+          "bar": { "$ref": "#" }
+        }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/embedded",
+        "type": "object",
+        "required": false,
+        "properties": {
+          "bar": { "$ref": "#" }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, nested_embedded_ids) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "https://example.com/a",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/a/b",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "https://example.com/a",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "id": "https://example.com/a/b",
+        "type": "string",
+        "minLength": 0,
+        "required": false
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, ref_into_embedded_resource_pointer) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "id": "https://example.com/embedded",
+        "type": "object",
+        "properties": {
+          "x": { "type": "string" }
+        }
+      },
+      "b": { "$ref": "https://example.com/embedded#/properties/x" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "id": "https://example.com/embedded",
+        "type": "object",
+        "required": false,
+        "properties": {
+          "x": { "type": "string", "minLength": 0, "required": false }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      },
+      "b": { "$ref": "https://example.com/embedded#/properties/x" }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, required_enum_property_preserves_required) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "enum": [ 1, 2 ], "required": true }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "enum": [ 1, 2 ],
+        "required": true
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, optional_enum_property_stays_compact) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "enum": [ 1, 2 ] }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "enum": [ 1, 2 ],
+        "required": false
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, required_boolean_property_preserves_required) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "type": "boolean", "required": true }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "enum": [ false, true ],
+        "required": true
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, required_sibling_to_ref_dropped) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "$ref": "#", "required": true }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "$ref": "#" }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}

--- a/test/evaluator/evaluator_draft3.json
+++ b/test/evaluator/evaluator_draft3.json
@@ -12573,5 +12573,125 @@
         "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
       ]
     }
+  },
+  {
+    "description": "required_sibling_to_ref_is_ignored",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      "type": "object",
+      "properties": { "foo": { "$ref": "#/definitions/target", "required": true } },
+      "definitions": { "target": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "required_sibling_to_ref_present_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      "type": "object",
+      "properties": { "foo": { "$ref": "#/definitions/target", "required": true } },
+      "definitions": { "target": { "type": "string" } }
+    },
+    "instance": { "foo": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionPropertyTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
+        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ],
+        [ true, "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The string value was expected to validate against the referenced schema",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "required_sibling_to_ref_present_invalid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      "type": "object",
+      "properties": { "foo": { "$ref": "#/definitions/target", "required": true } },
+      "definitions": { "target": { "type": "string" } }
+    },
+    "instance": { "foo": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionPropertyTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ]
+      ],
+      "post": [
+        [ false, "AssertionPropertyTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
+        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/properties/foo/$ref/type", "#/definitions/target/type", "/foo" ],
+        [ false, "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The integer value was expected to validate against the referenced schema",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

