### PR TITLE
Only allow `required` sibling to `extends` in Draft 3 canonicalizer

### DIFF
--- a/schemas/canonical-draft3.json
+++ b/schemas/canonical-draft3.json
@@ -104,9 +104,6 @@
               "type": "array",
               "minItems": 1,
               "uniqueItems": true
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -140,9 +137,6 @@
             },
             "format": {
               "type": "string"
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -172,9 +166,6 @@
             },
             "maximum": {
               "type": "number"
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -209,9 +200,6 @@
               "type": "boolean"
             },
             "exclusiveMaximum": {
-              "type": "boolean"
-            },
-            "required": {
               "type": "boolean"
             }
           },
@@ -259,9 +247,6 @@
                   "type": "boolean"
                 }
               ]
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -294,9 +279,6 @@
               "minimum": 0
             },
             "uniqueItems": {
-              "type": "boolean"
-            },
-            "required": {
               "type": "boolean"
             }
           },
@@ -351,9 +333,6 @@
             },
             "uniqueItems": {
               "type": "boolean"
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -400,6 +379,9 @@
               "items": {
                 "$ref": "#/$defs/schema"
               }
+            },
+            "required": {
+              "type": "boolean"
             }
           },
           "unevaluatedProperties": false
@@ -423,9 +405,6 @@
               "items": {
                 "$ref": "#/$defs/schema"
               }
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "unevaluatedProperties": false

--- a/schemas/canonical-draft3.test.json
+++ b/schemas/canonical-draft3.test.json
@@ -233,8 +233,8 @@
       }
     },
     {
-      "description": "Enum with boolean required is canonical",
-      "valid": true,
+      "description": "Enum with boolean required is rejected",
+      "valid": false,
       "data": {
         "enum": [ 1 ],
         "required": true
@@ -383,8 +383,8 @@
       }
     },
     {
-      "description": "String with required is canonical",
-      "valid": true,
+      "description": "String with required is rejected",
+      "valid": false,
       "data": {
         "type": "string",
         "minLength": 0,
@@ -554,8 +554,8 @@
       }
     },
     {
-      "description": "Integer with required is canonical",
-      "valid": true,
+      "description": "Integer with required is rejected",
+      "valid": false,
       "data": {
         "type": "integer",
         "divisibleBy": 1,
@@ -748,8 +748,8 @@
       }
     },
     {
-      "description": "Number with required is canonical",
-      "valid": true,
+      "description": "Number with required is rejected",
+      "valid": false,
       "data": {
         "type": "number",
         "required": false
@@ -918,8 +918,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 0,
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ],
             "required": true
           }
         },
@@ -934,8 +938,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 0,
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ],
             "required": false
           }
         },
@@ -950,13 +958,21 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 0,
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ],
             "required": true
           },
           "age": {
-            "type": "integer",
-            "divisibleBy": 1,
+            "extends": [
+              {
+                "type": "integer",
+                "divisibleBy": 1
+              }
+            ],
             "required": false
           }
         },
@@ -1135,8 +1151,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 0,
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ],
             "required": true
           },
           "ref_prop": {
@@ -1345,8 +1365,8 @@
       }
     },
     {
-      "description": "Array schema items with required is canonical",
-      "valid": true,
+      "description": "Array schema items with required is rejected",
+      "valid": false,
       "data": {
         "type": "array",
         "minItems": 0,
@@ -2088,8 +2108,8 @@
       }
     },
     {
-      "description": "Extends with required is rejected",
-      "valid": false,
+      "description": "Extends with required is canonical",
+      "valid": true,
       "data": {
         "extends": [
           {
@@ -2328,8 +2348,8 @@
       }
     },
     {
-      "description": "Disallow with boolean required is canonical",
-      "valid": true,
+      "description": "Disallow with boolean required is rejected",
+      "valid": false,
       "data": {
         "disallow": [
           {
@@ -2578,30 +2598,46 @@
         "title": "Person",
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 1,
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 1
+              }
+            ],
             "required": true
           },
           "age": {
-            "type": "integer",
-            "divisibleBy": 1,
-            "minimum": 0,
+            "extends": [
+              {
+                "type": "integer",
+                "divisibleBy": 1,
+                "minimum": 0
+              }
+            ],
             "required": false
           },
           "email": {
-            "type": "string",
-            "minLength": 0,
-            "format": "email",
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0,
+                "format": "email"
+              }
+            ],
             "required": false
           },
           "tags": {
-            "type": "array",
-            "minItems": 0,
-            "uniqueItems": false,
-            "items": {
-              "type": "string",
-              "minLength": 0
-            },
+            "extends": [
+              {
+                "type": "array",
+                "minItems": 0,
+                "uniqueItems": false,
+                "items": {
+                  "type": "string",
+                  "minLength": 0
+                }
+              }
+            ],
             "required": false
           }
         },

--- a/schemas/canonical-draft3.test.json
+++ b/schemas/canonical-draft3.test.json
@@ -952,6 +952,22 @@
       }
     },
     {
+      "description": "Object property with required but no extends wrapper is rejected",
+      "valid": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string",
+            "minLength": 0,
+            "required": false
+          }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      }
+    },
+    {
       "description": "Object with all keywords is canonical",
       "valid": true,
       "data": {

--- a/src/alterschema/CMakeLists.txt
+++ b/src/alterschema/CMakeLists.txt
@@ -44,6 +44,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME alterschema
     canonicalizer/optional_property_implicit.h
     canonicalizer/recursive_anchor_false_drop.h
     canonicalizer/required_property_implicit.h
+    canonicalizer/required_to_extends.h
     canonicalizer/single_branch_allof.h
     canonicalizer/single_branch_anyof.h
     canonicalizer/single_branch_oneof.h

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -152,6 +152,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "canonicalizer/optional_property_implicit.h"
 #include "canonicalizer/recursive_anchor_false_drop.h"
 #include "canonicalizer/required_property_implicit.h"
+#include "canonicalizer/required_to_extends.h"
 #include "canonicalizer/single_branch_allof.h"
 #include "canonicalizer/single_branch_anyof.h"
 #include "canonicalizer/single_branch_oneof.h"
@@ -530,6 +531,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<AdditionalItemsImplicit>();
     bundle.add<RequiredPropertyImplicit>();
     bundle.add<OptionalPropertyImplicit>();
+    bundle.add<RequiredToExtends>();
     bundle.add<SingleBranchAllOf>();
     bundle.add<SingleBranchAnyOf>();
     bundle.add<SingleBranchOneOf>();

--- a/src/alterschema/canonicalizer/required_to_extends.h
+++ b/src/alterschema/canonicalizer/required_to_extends.h
@@ -1,0 +1,91 @@
+class RequiredToExtends final : public SchemaTransformRule {
+public:
+  using mutates = std::true_type;
+  using reframe_after_transform = std::true_type;
+  RequiredToExtends()
+      : SchemaTransformRule{
+            "required_to_extends",
+            "In Draft 3 canonical form, `required` is only ever a sibling of "
+            "`extends`; its other siblings are wrapped into an `extends` "
+            "branch"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &, const bool) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+                         {Vocabularies::Known::JSON_Schema_Draft_3,
+                          Vocabularies::Known::JSON_Schema_Draft_3_Hyper}) &&
+                     schema.is_object());
+
+    const auto *required{schema.try_at("required")};
+    ONLY_CONTINUE_IF(required && required->is_boolean());
+
+    for (const auto &entry : schema.as_object()) {
+      if (!stays_at_top(entry.first)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    this->wrapped_keywords_.clear();
+    for (const auto &entry : schema.as_object()) {
+      if (!stays_at_top(entry.first)) {
+        this->wrapped_keywords_.push_back(entry.first);
+      }
+    }
+
+    auto branch{JSON::make_object()};
+    for (const auto &keyword : this->wrapped_keywords_) {
+      branch.assign(keyword, schema.at(keyword));
+    }
+
+    for (const auto &keyword : this->wrapped_keywords_) {
+      schema.erase(keyword);
+    }
+
+    if (schema.defines("extends") && schema.at("extends").is_array()) {
+      this->branch_index_ = schema.at("extends").size();
+      schema.at("extends").push_back(std::move(branch));
+    } else {
+      this->branch_index_ = 0;
+      auto extends{JSON::make_array()};
+      extends.push_back(std::move(branch));
+      schema.assign("extends", std::move(extends));
+    }
+  }
+
+  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
+                                 const Pointer &target,
+                                 const Pointer &current) const
+      -> Pointer override {
+    for (const auto &keyword : this->wrapped_keywords_) {
+      const auto keyword_prefix{current.concat({keyword})};
+      if (target.starts_with(keyword_prefix)) {
+        return target.rebase(
+            keyword_prefix,
+            current.concat({"extends", this->branch_index_, keyword}));
+      }
+    }
+
+    return target;
+  }
+
+private:
+  static auto stays_at_top(const sourcemeta::core::JSON::String &keyword)
+      -> bool {
+    return keyword == "required" || keyword == "extends" ||
+           keyword == "$schema" || keyword == "id" || keyword == "$ref";
+  }
+
+  mutable std::vector<sourcemeta::core::JSON::String> wrapped_keywords_;
+  mutable std::size_t branch_index_{0};
+};

--- a/src/alterschema/canonicalizer/required_to_extends.h
+++ b/src/alterschema/canonicalizer/required_to_extends.h
@@ -55,6 +55,14 @@ public:
     if (schema.defines("extends") && schema.at("extends").is_array()) {
       this->branch_index_ = schema.at("extends").size();
       schema.at("extends").push_back(std::move(branch));
+    } else if (schema.defines("extends")) {
+      // Draft 3 allows `extends` to be a single schema; preserve it as the
+      // first branch of the new array
+      auto extends{JSON::make_array()};
+      extends.push_back(schema.at("extends"));
+      this->branch_index_ = extends.size();
+      extends.push_back(std::move(branch));
+      schema.assign("extends", std::move(extends));
     } else {
       this->branch_index_ = 0;
       auto extends{JSON::make_array()};

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -250,7 +250,15 @@ TEST_F(CanonicalizerDraft3Test, object_with_property_required_implicit) {
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
     "properties": {
-      "name": { "type": "string", "minLength": 0, "required": false }
+      "name": {
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
+        "required": false
+      }
     },
     "patternProperties": {},
     "additionalProperties": {}
@@ -272,7 +280,15 @@ TEST_F(CanonicalizerDraft3Test, object_with_property_required_true) {
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
     "properties": {
-      "name": { "type": "string", "minLength": 0, "required": true }
+      "name": {
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
+        "required": true
+      }
     },
     "patternProperties": {},
     "additionalProperties": {}
@@ -363,8 +379,18 @@ TEST_F(CanonicalizerDraft3Test, object_with_ref_property) {
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
     "properties": {
-      "foo": { "type": "string", "minLength": 0, "required": false },
-      "bar": { "$ref": "#" }
+      "foo": {
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
+        "required": false
+      },
+      "bar": {
+        "$ref": "#"
+      }
     },
     "patternProperties": {},
     "additionalProperties": {}
@@ -767,8 +793,12 @@ TEST_F(CanonicalizerDraft3Test, embedded_id_typed_property) {
     "properties": {
       "foo": {
         "id": "https://example.com/embedded",
-        "type": "string",
-        "minLength": 0,
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
         "required": false
       }
     },
@@ -800,13 +830,19 @@ TEST_F(CanonicalizerDraft3Test, embedded_id_self_recursive_ref) {
     "properties": {
       "foo": {
         "id": "https://example.com/embedded",
-        "type": "object",
-        "required": false,
-        "properties": {
-          "bar": { "$ref": "#" }
-        },
-        "patternProperties": {},
-        "additionalProperties": {}
+        "extends": [
+          {
+            "type": "object",
+            "properties": {
+              "bar": {
+                "$ref": "#"
+              }
+            },
+            "patternProperties": {},
+            "additionalProperties": {}
+          }
+        ],
+        "required": false
       }
     },
     "patternProperties": {},
@@ -836,8 +872,12 @@ TEST_F(CanonicalizerDraft3Test, nested_embedded_ids) {
     "properties": {
       "foo": {
         "id": "https://example.com/a/b",
-        "type": "string",
-        "minLength": 0,
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
         "required": false
       }
     },
@@ -870,15 +910,29 @@ TEST_F(CanonicalizerDraft3Test, ref_into_embedded_resource_pointer) {
     "properties": {
       "a": {
         "id": "https://example.com/embedded",
-        "type": "object",
-        "required": false,
-        "properties": {
-          "x": { "type": "string", "minLength": 0, "required": false }
-        },
-        "patternProperties": {},
-        "additionalProperties": {}
+        "extends": [
+          {
+            "type": "object",
+            "properties": {
+              "x": {
+                "extends": [
+                  {
+                    "type": "string",
+                    "minLength": 0
+                  }
+                ],
+                "required": false
+              }
+            },
+            "patternProperties": {},
+            "additionalProperties": {}
+          }
+        ],
+        "required": false
       },
-      "b": { "$ref": "https://example.com/embedded#/properties/x" }
+      "b": {
+        "$ref": "https://example.com/embedded#/extends/0/properties/x"
+      }
     },
     "patternProperties": {},
     "additionalProperties": {}
@@ -901,7 +955,11 @@ TEST_F(CanonicalizerDraft3Test, required_enum_property_preserves_required) {
     "type": "object",
     "properties": {
       "foo": {
-        "enum": [ 1, 2 ],
+        "extends": [
+          {
+            "enum": [ 1, 2 ]
+          }
+        ],
         "required": true
       }
     },
@@ -926,7 +984,11 @@ TEST_F(CanonicalizerDraft3Test, optional_enum_property_stays_compact) {
     "type": "object",
     "properties": {
       "foo": {
-        "enum": [ 1, 2 ],
+        "extends": [
+          {
+            "enum": [ 1, 2 ]
+          }
+        ],
         "required": false
       }
     },
@@ -951,7 +1013,11 @@ TEST_F(CanonicalizerDraft3Test, required_boolean_property_preserves_required) {
     "type": "object",
     "properties": {
       "foo": {
-        "enum": [ false, true ],
+        "extends": [
+          {
+            "enum": [ false, true ]
+          }
+        ],
         "required": true
       }
     },
@@ -1000,11 +1066,17 @@ TEST_F(CanonicalizerDraft3Test, fragment_id_anchor_with_ref) {
     "properties": {
       "a": {
         "id": "#target",
-        "type": "string",
-        "minLength": 0,
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 0
+          }
+        ],
         "required": false
       },
-      "b": { "$ref": "#target" }
+      "b": {
+        "$ref": "#target"
+      }
     },
     "patternProperties": {},
     "additionalProperties": {}
@@ -1303,7 +1375,15 @@ TEST_F(CanonicalizerDraft3Test, disallow_object_with_properties) {
       {
         "type": "object",
         "properties": {
-          "a": { "type": "string", "minLength": 0, "required": false }
+          "a": {
+            "extends": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ],
+            "required": false
+          }
         },
         "patternProperties": {},
         "additionalProperties": {}
@@ -1688,9 +1768,59 @@ TEST_F(CanonicalizerDraft3Test, disallow_property_keeps_required) {
     "type": "object",
     "properties": {
       "a": {
-        "disallow": [ { "type": "string", "minLength": 0 } ],
+        "extends": [
+          {
+            "disallow": [
+              {
+                "type": "string",
+                "minLength": 0
+              }
+            ]
+          }
+        ],
         "required": false
       }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, ref_through_wrapped_property_rereferenced) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": { "type": "object", "properties": { "x": { "type": "string" } } },
+      "b": { "$ref": "#/properties/a/properties/x" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "type": "object",
+            "properties": {
+              "x": {
+                "extends": [
+                  { "type": "string", "minLength": 0 }
+                ],
+                "required": false
+              }
+            },
+            "patternProperties": {},
+            "additionalProperties": {}
+          }
+        ],
+        "required": false
+      },
+      "b": { "$ref": "#/properties/a/extends/0/properties/x" }
     },
     "patternProperties": {},
     "additionalProperties": {}

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1828,3 +1828,51 @@ TEST_F(CanonicalizerDraft3Test, ref_through_wrapped_property_rereferenced) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
+
+TEST_F(CanonicalizerDraft3Test,
+       required_to_extends_preserves_existing_extends) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": { "extends": [ { "type": "string" } ], "minLength": 3 }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "extends": [
+          { "type": "string", "minLength": 0 },
+          {
+            "type": [
+              { "enum": [ null ] },
+              { "enum": [ false, true ] },
+              {
+                "type": "object",
+                "properties": {},
+                "patternProperties": {},
+                "additionalProperties": {}
+              },
+              {
+                "type": "array",
+                "minItems": 0,
+                "uniqueItems": false,
+                "items": {}
+              },
+              { "type": "string", "minLength": 3 },
+              { "type": "number" }
+            ]
+          }
+        ],
+        "required": false
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

