### PR TITLE
Better push `disallow` through `extends` on Draft 3

### DIFF
--- a/src/alterschema/CMakeLists.txt
+++ b/src/alterschema/CMakeLists.txt
@@ -13,6 +13,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME alterschema
     canonicalizer/deprecated_false_drop.h
     canonicalizer/draft3_type_any.h
     canonicalizer/disallow_array_to_extends.h
+    canonicalizer/disallow_extends_to_type.h
     canonicalizer/disallow_to_array_of_schemas.h
     canonicalizer/divisible_by_implicit.h
     canonicalizer/duplicate_disallow_entries.h

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -119,6 +119,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "canonicalizer/dependent_schemas_to_any_of.h"
 #include "canonicalizer/deprecated_false_drop.h"
 #include "canonicalizer/disallow_array_to_extends.h"
+#include "canonicalizer/disallow_extends_to_type.h"
 #include "canonicalizer/disallow_to_array_of_schemas.h"
 #include "canonicalizer/divisible_by_implicit.h"
 #include "canonicalizer/draft3_type_any.h"
@@ -535,6 +536,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<OptionalPropertyImplicit>();
     bundle.add<DuplicateDisallowEntries>();
     bundle.add<DisallowArrayToExtends>();
+    bundle.add<DisallowExtendsToType>();
     bundle.add<RequiredToExtends>();
     bundle.add<SingleBranchAllOf>();
     bundle.add<SingleBranchAnyOf>();

--- a/src/alterschema/canonicalizer/disallow_extends_to_type.h
+++ b/src/alterschema/canonicalizer/disallow_extends_to_type.h
@@ -1,0 +1,68 @@
+class DisallowExtendsToType final : public SchemaTransformRule {
+public:
+  using mutates = std::true_type;
+  using reframe_after_transform = std::true_type;
+  DisallowExtendsToType()
+      : SchemaTransformRule{
+            "disallow_extends_to_type",
+            "Negating a conjunction is the disjunction of the negations: an "
+            "`extends` under `disallow` becomes a `type` union where each "
+            "branch is its own single negation"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &, const bool) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+                         {Vocabularies::Known::JSON_Schema_Draft_3,
+                          Vocabularies::Known::JSON_Schema_Draft_3_Hyper}) &&
+                     schema.is_object());
+
+    const auto *disallow{schema.try_at("disallow")};
+    ONLY_CONTINUE_IF(disallow && disallow->is_array() && disallow->size() == 1);
+
+    const auto &element{disallow->at(0)};
+    ONLY_CONTINUE_IF(element.is_object() && element.defines("extends") &&
+                     element.at("extends").is_array() &&
+                     !element.at("extends").empty());
+    return true;
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    auto branches{JSON::make_array()};
+    for (auto &branch : schema.at("disallow").at(0).at("extends").as_array()) {
+      auto negation{JSON::make_array()};
+      negation.push_back(std::move(branch));
+      auto element{JSON::make_object()};
+      element.assign("disallow", std::move(negation));
+      branches.push_back(std::move(element));
+    }
+
+    schema.erase("disallow");
+    schema.assign("type", std::move(branches));
+  }
+
+  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
+                                 const Pointer &target,
+                                 const Pointer &current) const
+      -> Pointer override {
+    const auto extends_prefix{current.concat({"disallow", 0, "extends"})};
+    if (!target.starts_with(extends_prefix)) {
+      return target;
+    }
+
+    const auto relative{target.resolve_from(extends_prefix)};
+    if (relative.empty() || !relative.at(0).is_index()) {
+      return target;
+    }
+
+    const auto index{relative.at(0).to_index()};
+    return target.rebase(extends_prefix.concat({index}),
+                         current.concat({"type", index, "disallow", 0}));
+  }
+};

--- a/src/alterschema/canonicalizer/disallow_extends_to_type.h
+++ b/src/alterschema/canonicalizer/disallow_extends_to_type.h
@@ -13,9 +13,9 @@ public:
   condition(const sourcemeta::core::JSON &schema,
             const sourcemeta::core::JSON &,
             const sourcemeta::blaze::Vocabularies &vocabularies,
-            const sourcemeta::blaze::SchemaFrame &,
-            const sourcemeta::blaze::SchemaFrame::Location &,
-            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaFrame &frame,
+            const sourcemeta::blaze::SchemaFrame::Location &location,
+            const sourcemeta::blaze::SchemaWalker &walker,
             const sourcemeta::blaze::SchemaResolver &, const bool) const
       -> SchemaTransformRule::Result override {
     ONLY_CONTINUE_IF(vocabularies.contains_any(
@@ -30,6 +30,22 @@ public:
     ONLY_CONTINUE_IF(element.is_object() && element.defines("extends") &&
                      element.at("extends").is_array() &&
                      !element.at("extends").empty());
+
+    // Only a pure negation can be distributed: the schema must assert nothing
+    // besides `disallow` (otherwise the new `type` would clobber a sibling
+    // constraint), and the negated schema must assert nothing besides `extends`
+    // (otherwise those conjuncts would be silently dropped)
+    ONLY_CONTINUE_IF(
+        wraps_single_constraint(schema, "disallow", walker, vocabularies) &&
+        wraps_single_constraint(element, "extends", walker, vocabularies));
+
+    // A reference into the `disallow` subtree cannot survive the rewrite: the
+    // wrapper schema is dissolved rather than relocated, so leave such cases
+    // for the engine and let other rules normalize them
+    const std::string keyword{"disallow"};
+    ONLY_CONTINUE_IF(!frame.has_references_through(
+        location.pointer, WeakPointer::Token{std::cref(keyword)}));
+
     return true;
   }
 
@@ -47,22 +63,26 @@ public:
     schema.assign("type", std::move(branches));
   }
 
-  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
-                                 const Pointer &target,
-                                 const Pointer &current) const
-      -> Pointer override {
-    const auto extends_prefix{current.concat({"disallow", 0, "extends"})};
-    if (!target.starts_with(extends_prefix)) {
-      return target;
+private:
+  static auto wraps_single_constraint(
+      const sourcemeta::core::JSON &schema, const std::string_view keyword,
+      const sourcemeta::blaze::SchemaWalker &walker,
+      const sourcemeta::blaze::Vocabularies &vocabularies) -> bool {
+    for (const auto &entry : schema.as_object()) {
+      if (entry.first == keyword) {
+        continue;
+      }
+
+      const auto type{walker(entry.first, vocabularies).type};
+      if (type != SchemaKeywordType::Annotation &&
+          type != SchemaKeywordType::Comment &&
+          type != SchemaKeywordType::Other &&
+          type != SchemaKeywordType::Unknown &&
+          type != SchemaKeywordType::LocationMembers) {
+        return false;
+      }
     }
 
-    const auto relative{target.resolve_from(extends_prefix)};
-    if (relative.empty() || !relative.at(0).is_index()) {
-      return target;
-    }
-
-    const auto index{relative.at(0).to_index()};
-    return target.rebase(extends_prefix.concat({index}),
-                         current.concat({"type", index, "disallow", 0}));
+    return true;
   }
 };

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1679,13 +1679,17 @@ TEST_F(CanonicalizerDraft3Test, disallow_wrapping_extends) {
 
   const auto expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "disallow": [
+    "type": [
       {
-        "extends": [
+        "disallow": [
           {
             "type": "string",
             "minLength": 3
-          },
+          }
+        ]
+      },
+      {
+        "disallow": [
           {
             "type": "string",
             "pattern": "^a",
@@ -1694,6 +1698,120 @@ TEST_F(CanonicalizerDraft3Test, disallow_wrapping_extends) {
         ]
       }
     ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, disallow_extends_single_branch) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "disallow": [
+      {
+        "extends": [
+          {
+            "type": "string",
+            "minLength": 3
+          }
+        ]
+      }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [
+      {
+        "disallow": [
+          {
+            "type": "string",
+            "minLength": 3
+          }
+        ]
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test, ref_into_disallow_over_extends_rereferenced) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "disallow": [
+          {
+            "extends": [
+              { "type": "object", "properties": { "x": { "type": "string" } } },
+              { "type": "object", "properties": { "y": { "type": "number" } } }
+            ]
+          }
+        ]
+      },
+      "b": { "$ref": "#/properties/a/disallow/0/extends/1/properties/y" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "type": [
+              {
+                "disallow": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "extends": [
+                          {
+                            "type": "string",
+                            "minLength": 0
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              },
+              {
+                "disallow": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "y": {
+                        "extends": [
+                          {
+                            "type": "number"
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "required": false
+      },
+      "b": {
+        "$ref": "#/properties/a/extends/0/type/1/disallow/0/properties/y"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
   })JSON");
 
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1735,7 +1735,8 @@ TEST_F(CanonicalizerDraft3Test, disallow_extends_single_branch) {
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
 
-TEST_F(CanonicalizerDraft3Test, ref_into_disallow_over_extends_rereferenced) {
+TEST_F(CanonicalizerDraft3Test,
+       disallow_over_extends_with_reference_into_subtree_not_pushed) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
@@ -1761,9 +1762,9 @@ TEST_F(CanonicalizerDraft3Test, ref_into_disallow_over_extends_rereferenced) {
       "a": {
         "extends": [
           {
-            "type": [
+            "disallow": [
               {
-                "disallow": [
+                "extends": [
                   {
                     "type": "object",
                     "properties": {
@@ -1779,11 +1780,7 @@ TEST_F(CanonicalizerDraft3Test, ref_into_disallow_over_extends_rereferenced) {
                     },
                     "patternProperties": {},
                     "additionalProperties": {}
-                  }
-                ]
-              },
-              {
-                "disallow": [
+                  },
                   {
                     "type": "object",
                     "properties": {
@@ -1807,7 +1804,86 @@ TEST_F(CanonicalizerDraft3Test, ref_into_disallow_over_extends_rereferenced) {
         "required": false
       },
       "b": {
-        "$ref": "#/properties/a/extends/0/type/1/disallow/0/properties/y"
+        "$ref": "#/properties/a/extends/0/disallow/0/extends/1/properties/y"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test,
+       disallow_over_extends_with_reference_to_wrapper_not_pushed) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "disallow": [
+          {
+            "extends": [
+              { "type": "object", "properties": { "x": { "type": "string" } } },
+              { "type": "object", "properties": { "y": { "type": "number" } } }
+            ]
+          }
+        ]
+      },
+      "b": { "$ref": "#/properties/a/disallow/0" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "disallow": [
+              {
+                "extends": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "extends": [
+                          {
+                            "type": "string",
+                            "minLength": 0
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "y": {
+                        "extends": [
+                          {
+                            "type": "number"
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "required": false
+      },
+      "b": {
+        "$ref": "#/properties/a/extends/0/disallow/0"
       }
     },
     "patternProperties": {},


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

