### PR TITLE
Canonicalize `disallow` through `type` disjunctions in Draft 3

### DIFF
--- a/src/alterschema/CMakeLists.txt
+++ b/src/alterschema/CMakeLists.txt
@@ -15,6 +15,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT blaze NAME alterschema
     canonicalizer/disallow_array_to_extends.h
     canonicalizer/disallow_extends_to_type.h
     canonicalizer/disallow_to_array_of_schemas.h
+    canonicalizer/disallow_type_union_to_extends.h
     canonicalizer/divisible_by_implicit.h
     canonicalizer/duplicate_disallow_entries.h
     canonicalizer/empty_definitions_drop.h

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -121,6 +121,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "canonicalizer/disallow_array_to_extends.h"
 #include "canonicalizer/disallow_extends_to_type.h"
 #include "canonicalizer/disallow_to_array_of_schemas.h"
+#include "canonicalizer/disallow_type_union_to_extends.h"
 #include "canonicalizer/divisible_by_implicit.h"
 #include "canonicalizer/draft3_type_any.h"
 #include "canonicalizer/duplicate_disallow_entries.h"
@@ -537,6 +538,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<DuplicateDisallowEntries>();
     bundle.add<DisallowArrayToExtends>();
     bundle.add<DisallowExtendsToType>();
+    bundle.add<DisallowTypeUnionToExtends>();
     bundle.add<RequiredToExtends>();
     bundle.add<SingleBranchAllOf>();
     bundle.add<SingleBranchAnyOf>();

--- a/src/alterschema/canonicalizer/disallow_extends_to_type.h
+++ b/src/alterschema/canonicalizer/disallow_extends_to_type.h
@@ -39,12 +39,14 @@ public:
         wraps_single_constraint(schema, "disallow", walker, vocabularies) &&
         wraps_single_constraint(element, "extends", walker, vocabularies));
 
-    // A reference into the `disallow` subtree cannot survive the rewrite: the
-    // wrapper schema is dissolved rather than relocated, so leave such cases
-    // for the engine and let other rules normalize them
-    const std::string keyword{"disallow"};
-    ONLY_CONTINUE_IF(!frame.has_references_through(
-        location.pointer, WeakPointer::Token{std::cref(keyword)}));
+    // The conjuncts relocate to distinct `type` branches (handled by
+    // `rereference`), but the wrapper schema itself is dissolved rather than
+    // moved, so a reference straight at it has no new home: bail in that case
+    static const JSON::String DISALLOW{"disallow"};
+    auto wrapper_pointer{location.pointer};
+    wrapper_pointer.push_back(std::cref(DISALLOW));
+    wrapper_pointer.push_back(static_cast<std::size_t>(0));
+    ONLY_CONTINUE_IF(!frame.has_references_to(wrapper_pointer));
 
     return true;
   }
@@ -61,6 +63,25 @@ public:
 
     schema.erase("disallow");
     schema.assign("type", std::move(branches));
+  }
+
+  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
+                                 const Pointer &target,
+                                 const Pointer &current) const
+      -> Pointer override {
+    const auto extends_prefix{current.concat({"disallow", 0, "extends"})};
+    if (!target.starts_with(extends_prefix)) {
+      return target;
+    }
+
+    const auto relative{target.resolve_from(extends_prefix)};
+    if (relative.empty() || !relative.at(0).is_index()) {
+      return target;
+    }
+
+    const auto index{relative.at(0).to_index()};
+    return target.rebase(extends_prefix.concat({index}),
+                         current.concat({"type", index, "disallow", 0}));
   }
 
 private:

--- a/src/alterschema/canonicalizer/disallow_type_union_to_extends.h
+++ b/src/alterschema/canonicalizer/disallow_type_union_to_extends.h
@@ -39,12 +39,14 @@ public:
         wraps_single_constraint(schema, "disallow", walker, vocabularies) &&
         wraps_single_constraint(element, "type", walker, vocabularies));
 
-    // A reference into the `disallow` subtree cannot survive the rewrite: the
-    // wrapper schema is dissolved rather than relocated, so leave such cases
-    // for the engine and let other rules normalize them
-    const std::string keyword{"disallow"};
-    ONLY_CONTINUE_IF(!frame.has_references_through(
-        location.pointer, WeakPointer::Token{std::cref(keyword)}));
+    // The union members relocate to distinct `extends` branches (handled by
+    // `rereference`), but the wrapper schema itself is dissolved rather than
+    // moved, so a reference straight at it has no new home: bail in that case
+    static const JSON::String DISALLOW{"disallow"};
+    auto wrapper_pointer{location.pointer};
+    wrapper_pointer.push_back(std::cref(DISALLOW));
+    wrapper_pointer.push_back(static_cast<std::size_t>(0));
+    ONLY_CONTINUE_IF(!frame.has_references_to(wrapper_pointer));
 
     return true;
   }
@@ -61,6 +63,25 @@ public:
 
     schema.erase("disallow");
     schema.assign("extends", std::move(branches));
+  }
+
+  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
+                                 const Pointer &target,
+                                 const Pointer &current) const
+      -> Pointer override {
+    const auto type_prefix{current.concat({"disallow", 0, "type"})};
+    if (!target.starts_with(type_prefix)) {
+      return target;
+    }
+
+    const auto relative{target.resolve_from(type_prefix)};
+    if (relative.empty() || !relative.at(0).is_index()) {
+      return target;
+    }
+
+    const auto index{relative.at(0).to_index()};
+    return target.rebase(type_prefix.concat({index}),
+                         current.concat({"extends", index, "disallow", 0}));
   }
 
 private:

--- a/src/alterschema/canonicalizer/disallow_type_union_to_extends.h
+++ b/src/alterschema/canonicalizer/disallow_type_union_to_extends.h
@@ -1,0 +1,88 @@
+class DisallowTypeUnionToExtends final : public SchemaTransformRule {
+public:
+  using mutates = std::true_type;
+  using reframe_after_transform = std::true_type;
+  DisallowTypeUnionToExtends()
+      : SchemaTransformRule{
+            "disallow_type_union_to_extends",
+            "Negating a disjunction is the conjunction of the negations: a "
+            "`type` union under `disallow` becomes an `extends` where each "
+            "branch is its own single negation"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &frame,
+            const sourcemeta::blaze::SchemaFrame::Location &location,
+            const sourcemeta::blaze::SchemaWalker &walker,
+            const sourcemeta::blaze::SchemaResolver &, const bool) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+                         {Vocabularies::Known::JSON_Schema_Draft_3,
+                          Vocabularies::Known::JSON_Schema_Draft_3_Hyper}) &&
+                     schema.is_object());
+
+    const auto *disallow{schema.try_at("disallow")};
+    ONLY_CONTINUE_IF(disallow && disallow->is_array() && disallow->size() == 1);
+
+    const auto &element{disallow->at(0)};
+    ONLY_CONTINUE_IF(element.is_object() && element.defines("type") &&
+                     element.at("type").is_array() &&
+                     !element.at("type").empty());
+
+    // Only a pure negation can be distributed: the schema must assert nothing
+    // besides `disallow` (otherwise the new `extends` would clobber a sibling
+    // constraint), and the negated schema must assert nothing besides its
+    // `type` union (otherwise those conjuncts would be silently dropped)
+    ONLY_CONTINUE_IF(
+        wraps_single_constraint(schema, "disallow", walker, vocabularies) &&
+        wraps_single_constraint(element, "type", walker, vocabularies));
+
+    // A reference into the `disallow` subtree cannot survive the rewrite: the
+    // wrapper schema is dissolved rather than relocated, so leave such cases
+    // for the engine and let other rules normalize them
+    const std::string keyword{"disallow"};
+    ONLY_CONTINUE_IF(!frame.has_references_through(
+        location.pointer, WeakPointer::Token{std::cref(keyword)}));
+
+    return true;
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    auto branches{JSON::make_array()};
+    for (auto &member : schema.at("disallow").at(0).at("type").as_array()) {
+      auto negation{JSON::make_array()};
+      negation.push_back(std::move(member));
+      auto branch{JSON::make_object()};
+      branch.assign("disallow", std::move(negation));
+      branches.push_back(std::move(branch));
+    }
+
+    schema.erase("disallow");
+    schema.assign("extends", std::move(branches));
+  }
+
+private:
+  static auto wraps_single_constraint(
+      const sourcemeta::core::JSON &schema, const std::string_view keyword,
+      const sourcemeta::blaze::SchemaWalker &walker,
+      const sourcemeta::blaze::Vocabularies &vocabularies) -> bool {
+    for (const auto &entry : schema.as_object()) {
+      if (entry.first == keyword) {
+        continue;
+      }
+
+      const auto type{walker(entry.first, vocabularies).type};
+      if (type != SchemaKeywordType::Annotation &&
+          type != SchemaKeywordType::Comment &&
+          type != SchemaKeywordType::Other &&
+          type != SchemaKeywordType::Unknown &&
+          type != SchemaKeywordType::LocationMembers) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1663,7 +1663,7 @@ TEST_F(CanonicalizerDraft3Test, disallow_wrapping_type_union) {
 }
 
 TEST_F(CanonicalizerDraft3Test,
-       disallow_over_type_union_with_reference_into_subtree_not_pushed) {
+       disallow_over_type_union_with_reference_into_subtree_rereferenced) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
@@ -1672,13 +1672,128 @@ TEST_F(CanonicalizerDraft3Test,
         "disallow": [
           {
             "type": [
-              { "type": "object", "properties": { "x": { "type": "string" } } },
-              { "type": "object", "properties": { "y": { "type": "number" } } }
+              {
+                "type": "object",
+                "properties": {
+                  "x": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "y": {
+                    "type": "number"
+                  }
+                }
+              }
             ]
           }
         ]
       },
-      "b": { "$ref": "#/properties/a/disallow/0/type/1/properties/y" }
+      "b": {
+        "$ref": "#/properties/a/disallow/0/type/1/properties/y"
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "extends": [
+              {
+                "disallow": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "extends": [
+                          {
+                            "type": "string",
+                            "minLength": 0
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              },
+              {
+                "disallow": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "y": {
+                        "extends": [
+                          {
+                            "type": "number"
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "required": false
+      },
+      "b": {
+        "$ref": "#/properties/a/extends/0/extends/1/disallow/0/properties/y"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test,
+       disallow_over_type_union_with_reference_to_wrapper_not_pushed) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "disallow": [
+          {
+            "type": [
+              {
+                "type": "object",
+                "properties": {
+                  "x": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "y": {
+                    "type": "number"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "b": {
+        "$ref": "#/properties/a/disallow/0"
+      }
     }
   })JSON");
 
@@ -1731,7 +1846,7 @@ TEST_F(CanonicalizerDraft3Test,
         "required": false
       },
       "b": {
-        "$ref": "#/properties/a/extends/0/disallow/0/type/1/properties/y"
+        "$ref": "#/properties/a/extends/0/disallow/0"
       }
     },
     "patternProperties": {},
@@ -1819,7 +1934,7 @@ TEST_F(CanonicalizerDraft3Test, disallow_extends_single_branch) {
 }
 
 TEST_F(CanonicalizerDraft3Test,
-       disallow_over_extends_with_reference_into_subtree_not_pushed) {
+       disallow_over_extends_with_reference_into_subtree_rereferenced) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
@@ -1828,13 +1943,29 @@ TEST_F(CanonicalizerDraft3Test,
         "disallow": [
           {
             "extends": [
-              { "type": "object", "properties": { "x": { "type": "string" } } },
-              { "type": "object", "properties": { "y": { "type": "number" } } }
+              {
+                "type": "object",
+                "properties": {
+                  "x": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "y": {
+                    "type": "number"
+                  }
+                }
+              }
             ]
           }
         ]
       },
-      "b": { "$ref": "#/properties/a/disallow/0/extends/1/properties/y" }
+      "b": {
+        "$ref": "#/properties/a/disallow/0/extends/1/properties/y"
+      }
     }
   })JSON");
 
@@ -1845,9 +1976,9 @@ TEST_F(CanonicalizerDraft3Test,
       "a": {
         "extends": [
           {
-            "disallow": [
+            "type": [
               {
-                "extends": [
+                "disallow": [
                   {
                     "type": "object",
                     "properties": {
@@ -1863,7 +1994,11 @@ TEST_F(CanonicalizerDraft3Test,
                     },
                     "patternProperties": {},
                     "additionalProperties": {}
-                  },
+                  }
+                ]
+              },
+              {
+                "disallow": [
                   {
                     "type": "object",
                     "properties": {
@@ -1887,7 +2022,7 @@ TEST_F(CanonicalizerDraft3Test,
         "required": false
       },
       "b": {
-        "$ref": "#/properties/a/extends/0/disallow/0/extends/1/properties/y"
+        "$ref": "#/properties/a/extends/0/type/1/disallow/0/properties/y"
       }
     },
     "patternProperties": {},

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1640,19 +1640,102 @@ TEST_F(CanonicalizerDraft3Test, disallow_wrapping_type_union) {
 
   const auto expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "disallow": [
+    "extends": [
       {
-        "type": [
+        "disallow": [
           {
             "type": "string",
             "minLength": 0
-          },
+          }
+        ]
+      },
+      {
+        "disallow": [
           {
             "type": "number"
           }
         ]
       }
     ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(CanonicalizerDraft3Test,
+       disallow_over_type_union_with_reference_into_subtree_not_pushed) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "disallow": [
+          {
+            "type": [
+              { "type": "object", "properties": { "x": { "type": "string" } } },
+              { "type": "object", "properties": { "y": { "type": "number" } } }
+            ]
+          }
+        ]
+      },
+      "b": { "$ref": "#/properties/a/disallow/0/type/1/properties/y" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "disallow": [
+              {
+                "type": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "x": {
+                        "extends": [
+                          {
+                            "type": "string",
+                            "minLength": 0
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "y": {
+                        "extends": [
+                          {
+                            "type": "number"
+                          }
+                        ],
+                        "required": false
+                      }
+                    },
+                    "patternProperties": {},
+                    "additionalProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "required": false
+      },
+      "b": {
+        "$ref": "#/properties/a/extends/0/disallow/0/type/1/properties/y"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
   })JSON");
 
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
@@ -2431,26 +2514,42 @@ TEST_F(CanonicalizerDraft3Test, type_with_typeless_disallow_distributes) {
     "extends": [
       {
         "disallow": [
+          { "enum": [ null ] }
+        ]
+      },
+      {
+        "disallow": [
+          { "enum": [ false, true ] }
+        ]
+      },
+      {
+        "disallow": [
           {
-            "type": [
-              { "enum": [ null ] },
-              { "enum": [ false, true ] },
-              {
-                "type": "object",
-                "properties": {},
-                "patternProperties": {},
-                "additionalProperties": {}
-              },
-              {
-                "type": "array",
-                "minItems": 0,
-                "uniqueItems": false,
-                "items": {}
-              },
-              { "type": "string", "pattern": "^x", "minLength": 0 },
-              { "type": "number" }
-            ]
+            "type": "object",
+            "properties": {},
+            "patternProperties": {},
+            "additionalProperties": {}
           }
+        ]
+      },
+      {
+        "disallow": [
+          {
+            "type": "array",
+            "minItems": 0,
+            "uniqueItems": false,
+            "items": {}
+          }
+        ]
+      },
+      {
+        "disallow": [
+          { "type": "string", "pattern": "^x", "minLength": 0 }
+        ]
+      },
+      {
+        "disallow": [
+          { "type": "number" }
         ]
       },
       { "type": "string", "minLength": 0 }
@@ -2468,24 +2567,44 @@ TEST_F(CanonicalizerDraft3Test, disallow_typeless_scalar_distributes) {
 
   const auto expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "disallow": [
+    "extends": [
       {
-        "type": [
-          { "enum": [ null ] },
-          { "enum": [ false, true ] },
+        "disallow": [
+          { "enum": [ null ] }
+        ]
+      },
+      {
+        "disallow": [
+          { "enum": [ false, true ] }
+        ]
+      },
+      {
+        "disallow": [
           {
             "type": "object",
             "properties": {},
             "patternProperties": {},
             "additionalProperties": {}
-          },
+          }
+        ]
+      },
+      {
+        "disallow": [
           {
             "type": "array",
             "minItems": 0,
             "uniqueItems": false,
             "items": {}
-          },
-          { "type": "string", "minLength": 3 },
+          }
+        ]
+      },
+      {
+        "disallow": [
+          { "type": "string", "minLength": 3 }
+        ]
+      },
+      {
+        "disallow": [
           { "type": "number" }
         ]
       }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

