### PR TITLE
Restrict `disallow` on Draft 3 canonicalizer in more cases

### DIFF
--- a/schemas/canonical-draft3.json
+++ b/schemas/canonical-draft3.json
@@ -70,7 +70,56 @@
         }
       }
     },
-    "schema": {
+    "extends": {
+      "x-lint-exclude": "simple_properties_identifiers",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/metadata"
+        },
+        {
+          "$ref": "#/$defs/core"
+        }
+      ],
+      "required": [ "extends" ],
+      "properties": {
+        "extends": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/schema"
+          }
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "union": {
+      "x-lint-exclude": "simple_properties_identifiers",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/metadata"
+        },
+        {
+          "$ref": "#/$defs/core"
+        }
+      ],
+      "required": [ "type" ],
+      "properties": {
+        "type": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/schema"
+          }
+        }
+      },
+      "unevaluatedProperties": false
+    },
+    "leaf": {
       "anyOf": [
         {
           "const": {}
@@ -336,55 +385,19 @@
             }
           },
           "unevaluatedProperties": false
+        }
+      ]
+    },
+    "schema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/leaf"
         },
         {
-          "x-lint-exclude": "simple_properties_identifiers",
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/metadata"
-            },
-            {
-              "$ref": "#/$defs/core"
-            }
-          ],
-          "required": [ "type" ],
-          "properties": {
-            "type": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/$defs/schema"
-              }
-            }
-          },
-          "unevaluatedProperties": false
+          "$ref": "#/$defs/union"
         },
         {
-          "x-lint-exclude": "simple_properties_identifiers",
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/metadata"
-            },
-            {
-              "$ref": "#/$defs/core"
-            }
-          ],
-          "required": [ "extends" ],
-          "properties": {
-            "extends": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "$ref": "#/$defs/schema"
-              }
-            },
-            "required": {
-              "type": "boolean"
-            }
-          },
-          "unevaluatedProperties": false
+          "$ref": "#/$defs/extends"
         },
         {
           "x-lint-exclude": "simple_properties_identifiers",
@@ -404,7 +417,18 @@
               "maxItems": 1,
               "minItems": 1,
               "items": {
-                "$ref": "#/$defs/schema"
+                "$comment": "TODO: `disallow` should only ever wrap a single-kind leaf. We additionally permit `extends` and `type` unions here as an interim escape hatch: negating a conjunction or disjunction whose wrapper is targeted by a `$ref` cannot be pushed to the leaves, because doing so would dissolve the referenced node. The proper fix is to invert such references so the `disallow` wraps a `$ref` leaf instead, after which both can be dropped from this list",
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/leaf"
+                  },
+                  {
+                    "$ref": "#/$defs/union"
+                  },
+                  {
+                    "$ref": "#/$defs/extends"
+                  }
+                ]
               }
             }
           },

--- a/src/alterschema/canonicalizer/disallow_double_negation.h
+++ b/src/alterschema/canonicalizer/disallow_double_negation.h
@@ -35,8 +35,13 @@ public:
     ONLY_CONTINUE_IF(
         wraps_single_constraint(schema, "disallow", walker, vocabularies));
 
-    ONLY_CONTINUE_IF(!frame.has_references_through(
-        location.pointer, WeakPointer::Token{std::cref(KEYWORD)}));
+    // The doubly-negated schema relocates up (handled by `rereference`), but
+    // the inner `disallow` wrapper itself dissolves, so a reference straight at
+    // it has no new home: bail only in that case
+    auto wrapper{location.pointer};
+    wrapper.push_back(std::cref(KEYWORD));
+    wrapper.push_back(static_cast<std::size_t>(0));
+    ONLY_CONTINUE_IF(!frame.has_references_to(wrapper));
     return true;
   }
 
@@ -53,6 +58,23 @@ public:
     if (inner.is_object()) {
       schema.merge(inner.as_object());
     }
+  }
+
+  [[nodiscard]] auto rereference(const std::string_view, const Pointer &,
+                                 const Pointer &target,
+                                 const Pointer &current) const
+      -> Pointer override {
+    auto old_prefix{current.concat({"disallow", 0, "disallow", 0})};
+    while (
+        target.starts_with(old_prefix.concat({"disallow", 0, "disallow", 0}))) {
+      old_prefix = old_prefix.concat({"disallow", 0, "disallow", 0});
+    }
+
+    if (!target.starts_with(old_prefix)) {
+      return target;
+    }
+
+    return target.rebase(old_prefix, current);
   }
 
 private:

--- a/src/alterschema/canonicalizer/disallow_double_negation.h
+++ b/src/alterschema/canonicalizer/disallow_double_negation.h
@@ -35,13 +35,22 @@ public:
     ONLY_CONTINUE_IF(
         wraps_single_constraint(schema, "disallow", walker, vocabularies));
 
-    // The doubly-negated schema relocates up (handled by `rereference`), but
-    // the inner `disallow` wrapper itself dissolves, so a reference straight at
-    // it has no new home: bail only in that case
+    // Collapsing the chain dissolves every intermediate `disallow` wrapper, so
+    // a reference targeting any of them has no valid new home: bail. A
+    // reference into the surviving innermost schema relocates with it (handled
+    // by `rereference`)
     auto wrapper{location.pointer};
-    wrapper.push_back(std::cref(KEYWORD));
-    wrapper.push_back(static_cast<std::size_t>(0));
-    ONLY_CONTINUE_IF(!frame.has_references_to(wrapper));
+    const sourcemeta::core::JSON *node{&disallow->at(0)};
+    while (is_single_negation(*node)) {
+      wrapper.push_back(std::cref(KEYWORD));
+      wrapper.push_back(static_cast<std::size_t>(0));
+      if (frame.has_references_to(wrapper)) {
+        return false;
+      }
+
+      node = &node->at(KEYWORD).at(0);
+    }
+
     return true;
   }
 

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1456,7 +1456,7 @@ TEST_F(CanonicalizerDraft3Test, disallow_quadruple_negation) {
 }
 
 TEST_F(CanonicalizerDraft3Test,
-       disallow_double_negation_with_reference_into_subtree_not_eliminated) {
+       disallow_double_negation_with_reference_into_subtree_rereferenced) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object",
@@ -1490,34 +1490,26 @@ TEST_F(CanonicalizerDraft3Test,
       "a": {
         "extends": [
           {
-            "disallow": [
-              {
-                "disallow": [
+            "type": "object",
+            "properties": {
+              "x": {
+                "extends": [
                   {
-                    "type": "object",
-                    "properties": {
-                      "x": {
-                        "extends": [
-                          {
-                            "type": "string",
-                            "minLength": 0
-                          }
-                        ],
-                        "required": false
-                      }
-                    },
-                    "patternProperties": {},
-                    "additionalProperties": {}
+                    "type": "string",
+                    "minLength": 0
                   }
-                ]
+                ],
+                "required": false
               }
-            ]
+            },
+            "patternProperties": {},
+            "additionalProperties": {}
           }
         ],
         "required": false
       },
       "b": {
-        "$ref": "#/properties/a/extends/0/disallow/0/disallow/0/properties/x"
+        "$ref": "#/properties/a/extends/0/properties/x"
       }
     },
     "patternProperties": {},

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -1643,6 +1643,78 @@ TEST_F(CanonicalizerDraft3Test,
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
 
+TEST_F(CanonicalizerDraft3Test,
+       disallow_double_negation_deep_with_reference_into_subtree_rereferenced) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "disallow": [
+          {
+            "disallow": [
+              {
+                "disallow": [
+                  {
+                    "disallow": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "x": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "b": {
+        "$ref": "#/properties/a/disallow/0/disallow/0/disallow/0/disallow/0/properties/x"
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+      "a": {
+        "extends": [
+          {
+            "type": "object",
+            "properties": {
+              "x": {
+                "extends": [
+                  {
+                    "type": "string",
+                    "minLength": 0
+                  }
+                ],
+                "required": false
+              }
+            },
+            "patternProperties": {},
+            "additionalProperties": {}
+          }
+        ],
+        "required": false
+      },
+      "b": {
+        "$ref": "#/properties/a/extends/0/properties/x"
+      }
+    },
+    "patternProperties": {},
+    "additionalProperties": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
 TEST_F(CanonicalizerDraft3Test, disallow_double_negation_over_type_union) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

