### PR TITLE
Fix post-processing messing up some `prefixItems` cases

### DIFF
--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -67,7 +67,10 @@ is_parent_to_children_instruction(const InstructionIndex type) noexcept
 inline auto convert_to_property_type_assertions(Instructions &instructions)
     -> void {
   for (auto &instruction : instructions) {
-    if (!instruction.relative_instance_location.empty()) {
+    if (!instruction.relative_instance_location.empty() &&
+        std::ranges::all_of(
+            instruction.relative_instance_location,
+            [](const auto &token) { return token.is_property(); })) {
       switch (instruction.type) {
         case InstructionIndex::AssertionTypeStrict:
           instruction.type = InstructionIndex::AssertionPropertyTypeStrict;

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -5011,5 +5011,60 @@
         "The string value was expected to validate against the referenced schema"
       ]
     }
+  },
+  {
+    "description": "items_array_type_union_inside_property",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "properties": {
+        "presets": {
+          "type": "array",
+          "items": {
+            "type": [ "string", "array" ],
+            "items": [ { "type": "string" }, { "type": "object" } ]
+          }
+        }
+      }
+    },
+    "instance": { "presets": [ [ true, {} ] ] },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItems", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ "AssertionArrayPrefix", "/properties/presets/items/items", "#/properties/presets/items/items", "/presets/0" ],
+        [ "AssertionTypeStrict", "/properties/presets/items/items/0/type", "#/properties/presets/items/items/0/type", "/presets/0/0" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/properties/presets/items/items/0/type", "#/properties/presets/items/items/0/type", "/presets/0/0" ],
+        [ false, "AssertionArrayPrefix", "/properties/presets/items/items", "#/properties/presets/items/items", "/presets/0" ],
+        [ false, "LoopItems", "/properties/presets/items", "#/properties/presets/items", "/presets" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type boolean",
+        "The first 2 items of the array value were expected to validate against the corresponding subschemas",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ "AssertionArrayPrefix", "/properties/presets/items/items", "#/properties/presets/items/items", "/presets/0" ],
+        [ "AssertionTypeStrict", "/properties/presets/items/items/0/type", "#/properties/presets/items/items/0/type", "/presets/0/0" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/properties/presets/items/items/0/type", "#/properties/presets/items/items/0/type", "/presets/0/0" ],
+        [ false, "AssertionArrayPrefix", "/properties/presets/items/items", "#/properties/presets/items/items", "/presets/0" ],
+        [ false, "LoopItems", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type boolean",
+        "The first 2 items of the array value were expected to validate against the corresponding subschemas",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -4480,5 +4480,60 @@
         "The unrecognized keyword \"type\" was collected as the annotation \"string\""
       ]
     }
+  },
+  {
+    "description": "prefix_items_type_union_inside_property",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "presets": {
+          "type": "array",
+          "items": {
+            "type": [ "string", "array" ],
+            "prefixItems": [ { "type": "string" }, { "type": "object" } ]
+          }
+        }
+      }
+    },
+    "instance": { "presets": [ [ true, {} ] ] },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
+        [ "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ],
+        [ false, "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
+        [ false, "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type boolean",
+        "The first 2 items of the array value were expected to validate against the corresponding subschemas",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
+        [ "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ],
+        [ false, "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
+        [ false, "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type boolean",
+        "The first 2 items of the array value were expected to validate against the corresponding subschemas",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/874
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

