### PR TITLE
Fix `additionalProperties: false` edge case invalid optimisation

### DIFF
--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -1073,6 +1073,52 @@ auto compiler_draft3_applicator_patternproperties(
       context, schema_context, dynamic_context, false, false);
 }
 
+// Determine whether the `properties` keyword on its own enforces a closed
+// object (i.e. compiles to one of the `LoopPropertiesExactly*` forms). This
+// happens when every property subschema reduces to a single strict type
+// assertion of the same type. In that case `additionalProperties: false` is
+// already enforced by `properties` and does not need to emit anything.
+inline auto
+properties_enforce_closed_object(const Context &context,
+                                 const SchemaContext &schema_context) -> bool {
+  const bool assume_object{schema_context.schema.defines("type") &&
+                           schema_context.schema.at("type").is_string() &&
+                           schema_context.schema.at("type").to_string() ==
+                               "object"};
+  if (!assume_object || !schema_context.schema.defines("properties") ||
+      !schema_context.schema.at("properties").is_object()) {
+    return false;
+  }
+
+  const SchemaContext new_schema_context{
+      .relative_pointer = schema_context.relative_pointer.initial().concat(
+          sourcemeta::blaze::make_weak_pointer(KEYWORD_PROPERTIES)),
+      .schema = schema_context.schema,
+      .vocabularies = schema_context.vocabularies,
+      .base = schema_context.base,
+      .is_property_name = schema_context.is_property_name};
+  const DynamicContext new_dynamic_context{
+      .keyword = KEYWORD_PROPERTIES,
+      .base_schema_location = sourcemeta::core::empty_weak_pointer,
+      .base_instance_location = sourcemeta::core::empty_weak_pointer};
+  const auto properties{
+      compile_properties(context, new_schema_context, new_dynamic_context, {})};
+  if (!std::ranges::all_of(properties, [](const auto &property) {
+        return property.second.size() == 1 &&
+               property.second.front().type ==
+                   InstructionIndex::AssertionTypeStrict;
+      })) {
+    return false;
+  }
+
+  std::set<ValueType> types;
+  for (const auto &property : properties) {
+    types.insert(std::get<ValueType>(property.second.front().value));
+  }
+
+  return types.size() == 1;
+}
+
 auto compiler_draft3_applicator_additionalproperties_with_options(
     const Context &context, const SchemaContext &schema_context,
     const DynamicContext &dynamic_context, const bool annotate,
@@ -1145,17 +1191,24 @@ auto compiler_draft3_applicator_additionalproperties_with_options(
     return {};
   }
 
-  // When all properties are required and `additionalProperties: false`,
-  // the `required` keyword compiles to `AssertionDefinesExactly` which already
-  // checks that the object has exactly the required properties, so we don't
-  // need to emit anything for `additionalProperties`
+  // When all properties are required and `additionalProperties: false`, the
+  // object is closed by another keyword, so we don't need to emit anything for
+  // `additionalProperties`. This happens either because `required` compiles to
+  // an `AssertionDefinesExactly` variant (only when there is more than one
+  // required property) or because `properties` itself compiles to a closed
+  // form. With a single required property `required` only compiles to
+  // `AssertionDefinesStrict`, which does not reject unknown properties, so we
+  // must still emit the closure unless `properties` enforces it.
   if (context.mode == Mode::FastValidation && children.size() == 1 &&
       children.front().type == InstructionIndex::AssertionFail &&
       !filter_strings.empty() && filter_prefixes.empty() &&
-      filter_regexes.empty() &&
-      is_closed_properties_required(schema_context.schema,
-                                    required_properties(schema_context))) {
-    return {};
+      filter_regexes.empty()) {
+    const auto required{required_properties(schema_context)};
+    if (is_closed_properties_required(schema_context.schema, required) &&
+        (required.size() > 1 ||
+         properties_enforce_closed_object(context, schema_context))) {
+      return {};
+    }
   }
 
   if (context.mode == Mode::FastValidation && filter_strings.empty() &&

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -204,10 +204,13 @@ auto compile_required_assertions(const Context &context,
     if (is_closed_properties_required(schema_context.schema, properties_set)) {
       if (context.mode == Mode::FastValidation && assume_object) {
         static const std::string properties_keyword{"properties"};
+        // `SchemaContext::relative_pointer` is a reference, so the concatenated
+        // pointer must outlive `new_schema_context`
+        const auto properties_pointer{
+            schema_context.relative_pointer.initial().concat(
+                sourcemeta::blaze::make_weak_pointer(properties_keyword))};
         const SchemaContext new_schema_context{
-            .relative_pointer =
-                schema_context.relative_pointer.initial().concat(
-                    sourcemeta::blaze::make_weak_pointer(properties_keyword)),
+            .relative_pointer = properties_pointer,
             .schema = schema_context.schema,
             .vocabularies = schema_context.vocabularies,
             .base = schema_context.base,
@@ -1090,9 +1093,13 @@ properties_enforce_closed_object(const Context &context,
     return false;
   }
 
+  // `SchemaContext::relative_pointer` is a reference, so the concatenated
+  // pointer must outlive `new_schema_context`
+  const auto properties_pointer{
+      schema_context.relative_pointer.initial().concat(
+          sourcemeta::blaze::make_weak_pointer(KEYWORD_PROPERTIES))};
   const SchemaContext new_schema_context{
-      .relative_pointer = schema_context.relative_pointer.initial().concat(
-          sourcemeta::blaze::make_weak_pointer(KEYWORD_PROPERTIES)),
+      .relative_pointer = properties_pointer,
       .schema = schema_context.schema,
       .vocabularies = schema_context.vocabularies,
       .base = schema_context.base,

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -5066,5 +5066,63 @@
         "The object value was expected to validate against the single defined property subschema"
       ]
     }
+  },
+  {
+    "description": "single_required_property_closed",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "handle" ],
+      "properties": { "handle": { "enum": [ "filesystem" ] } },
+      "additionalProperties": false
+    },
+    "instance": { "extra": "x", "handle": "filesystem" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"handle\"",
+        "The string value \"filesystem\" was expected to equal the string constant \"filesystem\"",
+        "The object value was not expected to define the property \"extra\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "handle" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"handle\"",
+        "The string value \"filesystem\" was expected to equal the string constant \"filesystem\"",
+        "The object property \"handle\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was not expected to define the property \"extra\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -4535,5 +4535,63 @@
         "The object value was expected to validate against the single defined property subschema"
       ]
     }
+  },
+  {
+    "description": "single_required_property_closed",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "handle" ],
+      "properties": { "handle": { "enum": [ "filesystem" ] } },
+      "additionalProperties": false
+    },
+    "instance": { "extra": "x", "handle": "filesystem" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"handle\"",
+        "The string value \"filesystem\" was expected to equal the string constant \"filesystem\"",
+        "The object value was not expected to define the property \"extra\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "handle" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"handle\"",
+        "The string value \"filesystem\" was expected to equal the string constant \"filesystem\"",
+        "The object property \"handle\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was not expected to define the property \"extra\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/878
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

