### PR TITLE
Fix broken camelCase normalisation in `src/codegen`

### DIFF
--- a/src/codegen/codegen_mangle.cc
+++ b/src/codegen/codegen_mangle.cc
@@ -28,24 +28,26 @@ auto symbol_to_identifier(const std::string_view prefix,
       continue;
     }
 
-    bool first_in_segment{true};
+    bool at_word_start{true};
+    bool at_segment_start{true};
     for (const auto character : segment) {
       if (is_alpha(character)) {
-        if (first_in_segment) {
-          result += to_upper(character);
-          first_in_segment = false;
-        } else {
-          result += character;
-        }
+        result += at_word_start ? to_upper(character) : character;
+        at_word_start = false;
+        at_segment_start = false;
       } else if (is_digit(character)) {
-        if (first_in_segment) {
+        if (at_segment_start) {
           result += '_';
         }
         result += character;
-        first_in_segment = false;
+        at_word_start = false;
+        at_segment_start = false;
       } else if (character == '_' || character == '$') {
         result += character;
-        first_in_segment = false;
+        at_word_start = false;
+        at_segment_start = false;
+      } else {
+        at_word_start = true;
       }
     }
   }

--- a/test/codegen/CMakeLists.txt
+++ b/test/codegen/CMakeLists.txt
@@ -1,7 +1,7 @@
 sourcemeta_googletest(NAMESPACE sourcemeta PROJECT blaze NAME codegen
   FOLDER "Blaze/Codegen"
   SOURCES codegen_test.cc codegen_2020_12_test.cc
-    codegen_symbol_test.cc codegen_test_utils.h)
+    codegen_symbol_test.cc codegen_mangle_test.cc codegen_test_utils.h)
 
 target_link_libraries(sourcemeta_blaze_codegen_unit
   PRIVATE sourcemeta::blaze::codegen)

--- a/test/codegen/codegen_mangle_test.cc
+++ b/test/codegen/codegen_mangle_test.cc
@@ -1,0 +1,204 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/blaze/codegen.h>
+
+#include <map>    // std::map
+#include <string> // std::string
+#include <vector> // std::vector
+
+TEST(Codegen_mangle, prefix_only_no_symbol) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{}, cache),
+            "Schema");
+}
+
+TEST(Codegen_mangle, single_lowercase_word) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"address"}, cache),
+            "SchemaAddress");
+}
+
+TEST(Codegen_mangle, single_already_capitalized_word) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"Address"}, cache),
+            "SchemaAddress");
+}
+
+TEST(Codegen_mangle, hyphenated_two_words) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer,
+                std::vector<std::string>{"structured-address"}, cache),
+            "SchemaStructuredAddress");
+}
+
+TEST(Codegen_mangle, hyphenated_three_words) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(
+      sourcemeta::blaze::mangle(
+          "Schema", pointer, std::vector<std::string>{"very-long-name"}, cache),
+      "SchemaVeryLongName");
+}
+
+TEST(Codegen_mangle, dot_separator) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"user.profile"},
+                                      cache),
+            "SchemaUserProfile");
+}
+
+TEST(Codegen_mangle, whitespace_separator) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer,
+                std::vector<std::string>{"structured address"}, cache),
+            "SchemaStructuredAddress");
+}
+
+TEST(Codegen_mangle, mixed_separators) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"a-b.c d"}, cache),
+            "SchemaABCD");
+}
+
+TEST(Codegen_mangle, consecutive_separators) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"a--b"}, cache),
+            "SchemaAB");
+}
+
+TEST(Codegen_mangle, leading_separator) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"-abc"}, cache),
+            "SchemaAbc");
+}
+
+TEST(Codegen_mangle, trailing_separator) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"abc-"}, cache),
+            "SchemaAbc");
+}
+
+TEST(Codegen_mangle, multiple_segments_with_hyphen) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer,
+                std::vector<std::string>{"user", "structured-address"}, cache),
+            "SchemaUserStructuredAddress");
+}
+
+TEST(Codegen_mangle, digit_inside_word) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"line1"}, cache),
+            "SchemaLine1");
+}
+
+TEST(Codegen_mangle, segment_starting_with_digit) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"2fa"}, cache),
+            "Schema_2fa");
+}
+
+TEST(Codegen_mangle, digit_after_separator) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"a-2b"}, cache),
+            "SchemaA2b");
+}
+
+TEST(Codegen_mangle, underscore_preserved) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"foo_bar"}, cache),
+            "SchemaFoo_bar");
+}
+
+TEST(Codegen_mangle, dollar_preserved) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"$ref"}, cache),
+            "Schema$ref");
+}
+
+TEST(Codegen_mangle, empty_segment_skipped) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"", "name"}, cache),
+            "SchemaName");
+}
+
+TEST(Codegen_mangle, segment_of_only_separators) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"---"}, cache),
+            "Schema");
+}
+
+TEST(Codegen_mangle, acronym_preserved) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle("Schema", pointer,
+                                      std::vector<std::string>{"HTTPServer"},
+                                      cache),
+            "SchemaHTTPServer");
+}
+
+TEST(Codegen_mangle, other_characters_dropped_as_boundary) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"foo@bar"}, cache),
+            "SchemaFooBar");
+}
+
+TEST(Codegen_mangle, collision_same_pointer_returns_same_name) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer pointer{"a"};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"address"}, cache),
+            "SchemaAddress");
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", pointer, std::vector<std::string>{"address"}, cache),
+            "SchemaAddress");
+}
+
+TEST(Codegen_mangle, collision_different_pointer_gets_prefixed) {
+  std::map<std::string, sourcemeta::core::Pointer> cache;
+  const sourcemeta::core::Pointer first{"a"};
+  const sourcemeta::core::Pointer second{"b"};
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", first, std::vector<std::string>{"address"}, cache),
+            "SchemaAddress");
+  EXPECT_EQ(sourcemeta::blaze::mangle(
+                "Schema", second, std::vector<std::string>{"address"}, cache),
+            "_SchemaAddress");
+}

--- a/test/codegen/e2e/typescript/2020-12/control_characters_in_property_names/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/control_characters_in_property_names/expected.d.ts
@@ -1,12 +1,12 @@
-export type TestWithus = string;
+export type TestWithUs = string;
 
-export type TestWithformfeed = string;
+export type TestWithFormfeed = string;
 
-export type TestWithbackspace = string;
+export type TestWithBackspace = string;
 
-export type TestWithsoh = string;
+export type TestWithSoh = string;
 
-export type TestWithnull = string;
+export type TestWithNull = string;
 
 export type TestNormal = string;
 
@@ -14,9 +14,9 @@ export type TestAdditionalProperties = never;
 
 export interface Test {
   "normal"?: TestNormal;
-  "with\bbackspace"?: TestWithbackspace;
-  "with\fformfeed"?: TestWithformfeed;
-  "with\u0000null"?: TestWithnull;
-  "with\u0001soh"?: TestWithsoh;
-  "with\u001fus"?: TestWithus;
+  "with\bbackspace"?: TestWithBackspace;
+  "with\fformfeed"?: TestWithFormfeed;
+  "with\u0000null"?: TestWithNull;
+  "with\u0001soh"?: TestWithSoh;
+  "with\u001fus"?: TestWithUs;
 }

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_additional_false/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_additional_false/expected.d.ts
@@ -1,6 +1,6 @@
 export type StrictFallbackName = string;
 
-export type StrictFallbackAz_id = number;
+export type StrictFallbackAZ_id = number;
 
 export type StrictFallbackAdditionalProperties = never;
 
@@ -11,6 +11,6 @@ export interface StrictFallback {
     // to also include the types of all of its properties, so we must
     // match a superset of what JSON Schema allows
     StrictFallbackName |
-    StrictFallbackAz_id |
+    StrictFallbackAZ_id |
     undefined;
 }

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_fallback/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_fallback/expected.d.ts
@@ -1,6 +1,6 @@
 export type FallbackName = string;
 
-export type FallbackAz_id = number;
+export type FallbackAZ_id = number;
 
 export interface Fallback {
   "name"?: FallbackName;

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_only/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_non_prefix_only/expected.d.ts
@@ -1,4 +1,4 @@
-export type NonPrefixAz_id = number;
+export type NonPrefixAZ_id = number;
 
 export interface NonPrefix {
   [key: string]: unknown | undefined;

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_overlapping_prefixes/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_overlapping_prefixes/expected.d.ts
@@ -1,4 +1,4 @@
-export type OverlapXdata = number;
+export type OverlapXData = number;
 
 export type OverlapX = string;
 
@@ -6,5 +6,5 @@ export type OverlapAdditionalProperties = never;
 
 export interface Overlap {
   [key: `x-${string}`]: OverlapX;
-  [key: `x-data-${string}`]: OverlapXdata & OverlapX;
+  [key: `x-data-${string}`]: OverlapXData & OverlapX;
 }

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_overlapping_same_type/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_overlapping_same_type/expected.d.ts
@@ -1,4 +1,4 @@
-export type SameTypeXdata = string;
+export type SameTypeXData = string;
 
 export type SameTypeX = string;
 
@@ -6,5 +6,5 @@ export type SameTypeAdditionalProperties = never;
 
 export interface SameType {
   [key: `x-${string}`]: SameTypeX;
-  [key: `x-data-${string}`]: SameTypeXdata & SameTypeX;
+  [key: `x-data-${string}`]: SameTypeXData & SameTypeX;
 }

--- a/test/codegen/e2e/typescript/2020-12/pattern_properties_partial_overlap/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/pattern_properties_partial_overlap/expected.d.ts
@@ -2,7 +2,7 @@ export type PartialId = number;
 
 export type PartialY = number;
 
-export type PartialXinternal = boolean;
+export type PartialXInternal = boolean;
 
 export type PartialX = string;
 
@@ -11,6 +11,6 @@ export type PartialAdditionalProperties = never;
 export interface Partial {
   "id": PartialId;
   [key: `x-${string}`]: PartialX;
-  [key: `x-internal-${string}`]: PartialXinternal & PartialX;
+  [key: `x-internal-${string}`]: PartialXInternal & PartialX;
   [key: `y-${string}`]: PartialY;
 }

--- a/test/codegen/e2e/typescript/2020-12/special_property_names/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/special_property_names/expected.d.ts
@@ -1,28 +1,28 @@
-export type SchemaSayhello = string;
+export type SchemaSayHello = string;
 
-export type SchemaPathtofile = string;
+export type SchemaPathToFile = string;
 
-export type SchemaMypropertyname = string;
+export type SchemaMyPropertyName = string;
 
-export type SchemaLine1line2 = string;
+export type SchemaLine1Line2 = string;
 
-export type SchemaCol1col2 = string;
+export type SchemaCol1Col2 = string;
 
 export type SchemaClass = string;
 
 export type Schema_123abc = string;
 
-export type Schema$specialchars = string;
+export type Schema$specialChars = string;
 
 export type SchemaAdditionalProperties = never;
 
 export interface Schema {
-  "say \"hello\""?: SchemaSayhello;
-  "path\\to\\file"?: SchemaPathtofile;
-  "line1\nline2"?: SchemaLine1line2;
-  "col1\tcol2"?: SchemaCol1col2;
-  "$special@chars"?: Schema$specialchars;
-  "my property name"?: SchemaMypropertyname;
+  "say \"hello\""?: SchemaSayHello;
+  "path\\to\\file"?: SchemaPathToFile;
+  "line1\nline2"?: SchemaLine1Line2;
+  "col1\tcol2"?: SchemaCol1Col2;
+  "$special@chars"?: Schema$specialChars;
+  "my property name"?: SchemaMyPropertyName;
   "123abc"?: Schema_123abc;
   "class"?: SchemaClass;
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

