### PR TITLE
Delete `type` when all logical applicators have it in the canonicaliser

### DIFF
--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -166,6 +166,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "canonicalizer/type_boolean_as_enum.h"
 #include "canonicalizer/type_inherit_in_place.h"
 #include "canonicalizer/type_null_as_enum.h"
+#include "canonicalizer/type_subsumed_by_branches.h"
 #include "canonicalizer/type_union_distribute_keywords.h"
 #include "canonicalizer/type_union_implicit.h"
 #include "canonicalizer/type_union_to_schemas.h"
@@ -349,6 +350,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
   }
 
   if (mode == AlterSchemaMode::Canonicalizer) {
+    bundle.add<TypeSubsumedByBranches>();
     bundle.add<ExclusiveMinimumBooleanIntegerFold>();
     bundle.add<ExclusiveMaximumBooleanIntegerFold>();
     bundle.add<UnsatisfiableExclusiveEqualBounds>();

--- a/src/alterschema/canonicalizer/type_subsumed_by_branches.h
+++ b/src/alterschema/canonicalizer/type_subsumed_by_branches.h
@@ -1,0 +1,105 @@
+class TypeSubsumedByBranches final : public SchemaTransformRule {
+public:
+  using mutates = std::true_type;
+  using reframe_after_transform = std::true_type;
+  TypeSubsumedByBranches()
+      : SchemaTransformRule{
+            "type_subsumed_by_branches",
+            "A `type` already guaranteed by every branch of a sibling `anyOf`, "
+            "`oneOf`, or `if`/`then`/`else` is redundant and can be removed"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &walker,
+            const sourcemeta::blaze::SchemaResolver &, const bool) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(
+        (vocabularies.contains_any({Vocabularies::Known::JSON_Schema_Draft_7,
+                                    Vocabularies::Known::JSON_Schema_Draft_6,
+                                    Vocabularies::Known::JSON_Schema_Draft_4}) ||
+         (vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2019_09_Validation) &&
+          vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2019_09_Applicator)) ||
+         (vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2020_12_Validation) &&
+          vocabularies.contains(
+              Vocabularies::Known::JSON_Schema_2020_12_Applicator))) &&
+        schema.is_object());
+
+    const auto *type_value{schema.try_at("type")};
+    ONLY_CONTINUE_IF(type_value && type_value->is_string());
+    const auto &type_string{type_value->to_string()};
+
+    bool subsumed{false};
+
+    static const std::array<const char *, 2> UNIONS{{"anyOf", "oneOf"}};
+    for (const auto *keyword : UNIONS) {
+      const auto *branches{schema.try_at(keyword)};
+      if (branches == nullptr || !branches->is_array() || branches->empty()) {
+        continue;
+      }
+
+      bool all_branches_assert{true};
+      for (const auto &branch : branches->as_array()) {
+        if (!asserts_type(branch, type_string)) {
+          all_branches_assert = false;
+          break;
+        }
+      }
+
+      if (all_branches_assert) {
+        subsumed = true;
+        break;
+      }
+    }
+
+    // The `if` schema only selects which arm applies, so both arms must assert
+    // the type for the conditional to guarantee it
+    if (!subsumed && schema.defines("if")) {
+      const auto *then_schema{schema.try_at("then")};
+      const auto *else_schema{schema.try_at("else")};
+      subsumed = then_schema != nullptr && else_schema != nullptr &&
+                 asserts_type(*then_schema, type_string) &&
+                 asserts_type(*else_schema, type_string);
+    }
+
+    ONLY_CONTINUE_IF(subsumed);
+
+    // Only drop the type when the subsuming branches are the sole
+    // instance-affecting sibling. Otherwise removing it would orphan another
+    // assertion (such as `properties`) that relies on the type being present
+    for (const auto &entry : schema.as_object()) {
+      if (entry.first == "type" || entry.first == "anyOf" ||
+          entry.first == "oneOf" || entry.first == "if" ||
+          entry.first == "then" || entry.first == "else") {
+        continue;
+      }
+
+      if (walker(entry.first, vocabularies).instances.any()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("type");
+  }
+
+private:
+  static auto asserts_type(const sourcemeta::core::JSON &schema,
+                           const sourcemeta::core::JSON::String &type) -> bool {
+    if (!schema.is_object()) {
+      return false;
+    }
+
+    const auto *value{schema.try_at("type")};
+    return value != nullptr && value->is_string() && value->to_string() == type;
+  }
+};

--- a/test/alterschema/alterschema_canonicalize_2019_09_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2019_09_test.cc
@@ -29,6 +29,41 @@ protected:
 std::unique_ptr<sourcemeta::blaze::Template>
     Canonicalizer201909Test::compiled_meta_ = nullptr;
 
+TEST_F(Canonicalizer201909Test, type_subsumed_by_oneof) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "object",
+    "oneOf": [
+      { "type": "object", "required": [ "a" ] },
+      { "type": "object", "required": [ "b" ] }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [ "a" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "a": true },
+        "patternProperties": {}
+      },
+      {
+        "type": "object",
+        "required": [ "b" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "b": true },
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
 TEST_F(Canonicalizer201909Test, duplicate_allof_branches_2) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -81,6 +81,248 @@ TEST_F(Canonicalizer202012Test, duplicate_allof_branches_3) {
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
 }
 
+TEST_F(Canonicalizer202012Test, type_subsumed_by_oneof) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "oneOf": [
+      { "type": "object", "required": [ "a" ] },
+      { "type": "object", "required": [ "b" ] }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [ "a" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "a": true },
+        "patternProperties": {}
+      },
+      {
+        "type": "object",
+        "required": [ "b" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "b": true },
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(Canonicalizer202012Test, type_subsumed_by_anyof) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "anyOf": [
+      { "type": "object", "required": [ "a" ] },
+      { "type": "object", "required": [ "b" ] }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "anyOf": [
+      {
+        "type": "object",
+        "required": [ "a" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "a": true },
+        "patternProperties": {}
+      },
+      {
+        "type": "object",
+        "required": [ "b" ],
+        "minProperties": 1,
+        "propertyNames": true,
+        "properties": { "b": true },
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(Canonicalizer202012Test, type_subsumed_by_if_then_else) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "if": { "type": "object", "required": [ "kind" ] },
+    "then": { "type": "object", "required": [ "a" ] },
+    "else": { "type": "object", "required": [ "b" ] }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "if": {
+      "type": "object",
+      "required": [ "kind" ],
+      "minProperties": 1,
+      "propertyNames": true,
+      "properties": { "kind": true },
+      "patternProperties": {}
+    },
+    "then": {
+      "type": "object",
+      "required": [ "a" ],
+      "minProperties": 1,
+      "propertyNames": true,
+      "properties": { "a": true },
+      "patternProperties": {}
+    },
+    "else": {
+      "type": "object",
+      "required": [ "b" ],
+      "minProperties": 1,
+      "propertyNames": true,
+      "properties": { "b": true },
+      "patternProperties": {}
+    }
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(Canonicalizer202012Test, type_not_subsumed_by_if_then_else_open_else) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "if": { "type": "object", "required": [ "kind" ] },
+    "then": { "type": "object", "required": [ "a" ] },
+    "else": true
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      {
+        "if": {
+          "type": "object",
+          "required": [ "kind" ],
+          "minProperties": 1,
+          "propertyNames": true,
+          "properties": { "kind": true },
+          "patternProperties": {}
+        },
+        "then": {
+          "type": "object",
+          "required": [ "a" ],
+          "minProperties": 1,
+          "propertyNames": true,
+          "properties": { "a": true },
+          "patternProperties": {}
+        },
+        "else": true
+      },
+      {
+        "type": "object",
+        "minProperties": 0,
+        "propertyNames": true,
+        "properties": {},
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(Canonicalizer202012Test, type_not_subsumed_when_branches_differ) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "oneOf": [
+      { "type": "object", "required": [ "a" ] },
+      { "type": "string" }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [ "a" ],
+            "minProperties": 1,
+            "propertyNames": true,
+            "properties": { "a": true },
+            "patternProperties": {}
+          },
+          false
+        ]
+      },
+      {
+        "type": "object",
+        "minProperties": 0,
+        "propertyNames": true,
+        "properties": {},
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
+TEST_F(Canonicalizer202012Test, type_not_subsumed_when_property_sibling) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "name": { "type": "string" } },
+    "oneOf": [
+      { "type": "object", "required": [ "a" ] },
+      { "type": "object", "required": [ "b" ] }
+    ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [ "a" ],
+            "minProperties": 1,
+            "propertyNames": true,
+            "properties": { "a": true },
+            "patternProperties": {}
+          },
+          {
+            "type": "object",
+            "required": [ "b" ],
+            "minProperties": 1,
+            "propertyNames": true,
+            "properties": { "b": true },
+            "patternProperties": {}
+          }
+        ]
+      },
+      {
+        "type": "object",
+        "minProperties": 0,
+        "propertyNames": true,
+        "properties": {
+          "name": { "type": "string", "minLength": 0 }
+        },
+        "patternProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
+}
+
 TEST_F(Canonicalizer202012Test, duplicate_allof_branches_4) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_canonicalize_draft4_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft4_test.cc
@@ -1953,40 +1953,29 @@ TEST_F(CanonicalizerDraft4Test, anyof_with_type_sibling) {
   const auto expected = sourcemeta::core::parse_json(R"JSON(
     {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [
+      "anyOf": [
         {
-          "anyOf": [
-            {
-              "type": "object",
-              "required": [
-                "a"
-              ],
-              "patternProperties": {},
-              "minProperties": 1,
-              "properties": {
-                "a": true
-              },
-              "additionalProperties": true
-            },
-            {
-              "type": "object",
-              "required": [
-                "b"
-              ],
-              "patternProperties": {},
-              "minProperties": 1,
-              "properties": {
-                "b": true
-              },
-              "additionalProperties": true
-            }
-          ]
+          "type": "object",
+          "required": [
+            "a"
+          ],
+          "patternProperties": {},
+          "minProperties": 1,
+          "properties": {
+            "a": true
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",
+          "required": [
+            "b"
+          ],
           "patternProperties": {},
-          "minProperties": 0,
-          "properties": {},
+          "minProperties": 1,
+          "properties": {
+            "b": true
+          },
           "additionalProperties": true
         }
       ]

--- a/test/alterschema/alterschema_canonicalize_draft6_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft6_test.cc
@@ -1977,43 +1977,31 @@ TEST_F(CanonicalizerDraft6Test, anyof_with_type_sibling) {
   const auto expected = sourcemeta::core::parse_json(R"JSON(
     {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "allOf": [
+      "anyOf": [
         {
-          "anyOf": [
-            {
-              "type": "object",
-              "required": [
-                "a"
-              ],
-              "patternProperties": {},
-              "propertyNames": true,
-              "minProperties": 1,
-              "properties": {
-                "a": true
-              },
-              "additionalProperties": true
-            },
-            {
-              "type": "object",
-              "required": [
-                "b"
-              ],
-              "patternProperties": {},
-              "propertyNames": true,
-              "minProperties": 1,
-              "properties": {
-                "b": true
-              },
-              "additionalProperties": true
-            }
-          ]
+          "type": "object",
+          "required": [
+            "a"
+          ],
+          "patternProperties": {},
+          "propertyNames": true,
+          "minProperties": 1,
+          "properties": {
+            "a": true
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",
+          "required": [
+            "b"
+          ],
           "patternProperties": {},
           "propertyNames": true,
-          "minProperties": 0,
-          "properties": {},
+          "minProperties": 1,
+          "properties": {
+            "b": true
+          },
           "additionalProperties": true
         }
       ]

--- a/test/alterschema/alterschema_canonicalize_draft7_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft7_test.cc
@@ -1977,43 +1977,31 @@ TEST_F(CanonicalizerDraft7Test, anyof_with_type_sibling) {
   const auto expected = sourcemeta::core::parse_json(R"JSON(
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "allOf": [
+      "anyOf": [
         {
-          "anyOf": [
-            {
-              "type": "object",
-              "required": [
-                "a"
-              ],
-              "patternProperties": {},
-              "propertyNames": true,
-              "minProperties": 1,
-              "properties": {
-                "a": true
-              },
-              "additionalProperties": true
-            },
-            {
-              "type": "object",
-              "required": [
-                "b"
-              ],
-              "patternProperties": {},
-              "propertyNames": true,
-              "minProperties": 1,
-              "properties": {
-                "b": true
-              },
-              "additionalProperties": true
-            }
-          ]
+          "type": "object",
+          "required": [
+            "a"
+          ],
+          "patternProperties": {},
+          "propertyNames": true,
+          "minProperties": 1,
+          "properties": {
+            "a": true
+          },
+          "additionalProperties": true
         },
         {
           "type": "object",
+          "required": [
+            "b"
+          ],
           "patternProperties": {},
           "propertyNames": true,
-          "minProperties": 0,
-          "properties": {},
+          "minProperties": 1,
+          "properties": {
+            "b": true
+          },
           "additionalProperties": true
         }
       ]
@@ -4758,17 +4746,9 @@ TEST_F(CanonicalizerDraft7Test, if_then_else_with_type_string) {
 
   const auto expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "allOf": [
-      {
-        "if": { "type": "string", "minLength": 5 },
-        "then": { "type": "string", "minLength": 0, "pattern": "^[a-z]+$" },
-        "else": { "type": "string", "minLength": 0, "maxLength": 10 }
-      },
-      {
-        "type": "string",
-        "minLength": 0
-      }
-    ]
+    "if": { "type": "string", "minLength": 5 },
+    "then": { "type": "string", "minLength": 0, "pattern": "^[a-z]+$" },
+    "else": { "type": "string", "minLength": 0, "maxLength": 10 }
   })JSON");
 
   CANONICALIZE_AND_VALIDATE(document, expected, *compiled_meta_);
@@ -5917,14 +5897,6 @@ TEST_F(CanonicalizerDraft7Test, if_then_else_with_type_not_anyof) {
             "additionalProperties": true
           },
           "else": true
-        },
-        {
-          "type": "object",
-          "patternProperties": {},
-          "propertyNames": true,
-          "minProperties": 0,
-          "properties": {},
-          "additionalProperties": true
         }
       ]
     }

--- a/test/codegen/codegen_2020_12_test.cc
+++ b/test/codegen/codegen_2020_12_test.cc
@@ -1642,9 +1642,7 @@ TEST(Codegen_2020_12, if_then_else_with_type_sibling) {
 
   using namespace sourcemeta::blaze;
 
-  EXPECT_IR_CONDITIONAL(result, result.size() - 2, "/allOf/0", "/allOf/0/if",
-                        "/allOf/0/then", "/allOf/0/else");
-  EXPECT_IR_INTERSECTION(result, result.size() - 1, "", 2);
+  EXPECT_IR_CONDITIONAL(result, result.size() - 1, "", "/if", "/then", "/else");
 }
 
 TEST(Codegen_2020_12, if_then_else_with_ref_branches) {

--- a/test/codegen/e2e/typescript/2020-12/if_then_else_validation_only/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/if_then_else_validation_only/expected.d.ts
@@ -1,16 +1,10 @@
-export type PatternString_1 = string;
+export type PatternStringThen = string;
 
-export type PatternString_0Then = string;
+export type PatternStringIf = string;
 
-export type PatternString_0If = string;
-
-export type PatternString_0Else = string;
+export type PatternStringElse = string;
 
 // (if & then) | else approximation: the else branch is wider than what
 // JSON Schema allows, as TypeScript cannot express type negation
-export type PatternString_0 =
-  (PatternString_0If & PatternString_0Then) | PatternString_0Else;
-
 export type PatternString =
-  PatternString_0 &
-  PatternString_1;
+  (PatternStringIf & PatternStringThen) | PatternStringElse;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

