### PR TITLE
Support collecting annotations in `FastValidation` mode

### DIFF
--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -340,9 +340,23 @@ inline auto requires_evaluation(const Context &context,
 
 inline auto annotations_enabled(const Context &context,
                                 const std::string_view keyword) -> bool {
-  return context.mode == Mode::Exhaustive &&
-         (!context.tweaks.annotations.has_value() ||
-          context.tweaks.annotations.value().contains(keyword));
+  if (context.tweaks.annotations.has_value()) {
+    return context.tweaks.annotations.value().contains(keyword);
+  }
+
+  return context.mode == Mode::Exhaustive;
+}
+
+// Whether any annotation may be collected anywhere in this compilation. Drives
+// the "do not short-circuit / keep iterating" behavior of applicators like
+// `contains` so that nested annotations are reached on every instance location,
+// independently of whether the applicator's own annotation was whitelisted.
+inline auto annotations_collected(const Context &context) -> bool {
+  if (context.tweaks.annotations.has_value()) {
+    return !context.tweaks.annotations.value().empty();
+  }
+
+  return context.mode == Mode::Exhaustive;
 }
 
 // TODO: Elevate to Core and test

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -351,12 +351,15 @@ inline auto annotations_enabled(const Context &context,
 // the "do not short-circuit / keep iterating" behavior of applicators like
 // `contains` so that nested annotations are reached on every instance location,
 // independently of whether the applicator's own annotation was whitelisted.
+// Exhaustive mode always keeps iterating for complete error reporting,
+// regardless of whether annotations are disabled via an empty whitelist.
 inline auto annotations_collected(const Context &context) -> bool {
-  if (context.tweaks.annotations.has_value()) {
-    return !context.tweaks.annotations.value().empty();
+  if (context.mode == Mode::Exhaustive) {
+    return true;
   }
 
-  return context.mode == Mode::Exhaustive;
+  return context.tweaks.annotations.has_value() &&
+         !context.tweaks.annotations.value().empty();
 }
 
 // TODO: Elevate to Core and test

--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -203,8 +203,7 @@ auto compiler_2019_09_applicator_additionalproperties(
 
     -> Instructions {
   return compiler_draft3_applicator_additionalproperties_with_options(
-      context, schema_context, dynamic_context,
-      context.mode == Mode::Exhaustive,
+      context, schema_context, dynamic_context, annotations_collected(context),
       requires_evaluation(context, schema_context));
 }
 
@@ -222,12 +221,11 @@ auto compiler_2019_09_applicator_items(const Context &context,
   if (schema_context.schema.at(dynamic_context.keyword).is_array()) {
     return compiler_draft3_applicator_items_with_options(
         context, schema_context, dynamic_context,
-        context.mode == Mode::Exhaustive, track);
+        annotations_collected(context), track);
   }
 
   return compiler_draft3_applicator_items_with_options(
-      context, schema_context, dynamic_context,
-      context.mode == Mode::Exhaustive,
+      context, schema_context, dynamic_context, annotations_collected(context),
       track && !schema_context.schema.defines("unevaluatedItems"));
 }
 
@@ -243,8 +241,7 @@ auto compiler_2019_09_applicator_additionalitems(
       })};
 
   return compiler_draft3_applicator_additionalitems_with_options(
-      context, schema_context, dynamic_context,
-      context.mode == Mode::Exhaustive,
+      context, schema_context, dynamic_context, annotations_collected(context),
       track && !schema_context.schema.defines("unevaluatedItems"));
 }
 
@@ -434,7 +431,7 @@ auto compiler_2019_09_applicator_properties(
     -> Instructions {
   return compiler_draft3_applicator_properties_with_options(
       context, schema_context, dynamic_context, current,
-      context.mode == Mode::Exhaustive,
+      annotations_collected(context),
       requires_evaluation(context, schema_context));
 }
 
@@ -443,8 +440,7 @@ auto compiler_2019_09_applicator_patternproperties(
     const DynamicContext &dynamic_context, const Instructions &)
     -> Instructions {
   return compiler_draft3_applicator_patternproperties_with_options(
-      context, schema_context, dynamic_context,
-      context.mode == Mode::Exhaustive,
+      context, schema_context, dynamic_context, annotations_collected(context),
       requires_evaluation(context, schema_context));
 }
 

--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -194,7 +194,8 @@ auto compiler_2019_09_applicator_contains(const Context &context,
                                           const Instructions &current)
     -> Instructions {
   return compiler_2019_09_applicator_contains_with_options(
-      context, schema_context, dynamic_context, current, false, false);
+      context, schema_context, dynamic_context, current,
+      annotations_collected(context), false);
 }
 
 auto compiler_2019_09_applicator_additionalproperties(

--- a/src/compiler/default_compiler_2020_12.h
+++ b/src/compiler/default_compiler_2020_12.h
@@ -22,8 +22,8 @@ auto compiler_2020_12_applicator_prefixitems(
       })};
 
   return compiler_draft3_applicator_items_array(
-      context, schema_context, dynamic_context,
-      context.mode == Mode::Exhaustive, track);
+      context, schema_context, dynamic_context, annotations_collected(context),
+      track);
 }
 
 auto compiler_2020_12_applicator_items(const Context &context,
@@ -44,7 +44,7 @@ auto compiler_2020_12_applicator_items(const Context &context,
 
   return compiler_draft3_applicator_additionalitems_from_cursor(
       context, schema_context, dynamic_context, cursor,
-      context.mode == Mode::Exhaustive,
+      annotations_collected(context),
       track && !schema_context.schema.defines("unevaluatedItems"));
 }
 
@@ -62,7 +62,7 @@ auto compiler_2020_12_applicator_contains(const Context &context,
 
   return compiler_2019_09_applicator_contains_with_options(
       context, schema_context, dynamic_context, current,
-      context.mode == Mode::Exhaustive, track);
+      annotations_collected(context), track);
 }
 
 auto compiler_2020_12_core_dynamicref(const Context &context,

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -614,7 +614,8 @@ auto compiler_draft3_applicator_properties_with_options(
   auto properties{compile_properties(context, schema_context,
                                      effective_dynamic_context, current)};
 
-  if (context.mode == Mode::FastValidation && !required.empty() &&
+  if (!emit_annotation && context.mode == Mode::FastValidation &&
+      !required.empty() &&
       schema_context.schema.defines("additionalProperties") &&
       schema_context.schema.at("additionalProperties").is_boolean() &&
       !schema_context.schema.at("additionalProperties").to_boolean() &&
@@ -689,7 +690,8 @@ auto compiler_draft3_applicator_properties_with_options(
   }
 
   auto attempt_object_fusion{context.mode == Mode::FastValidation &&
-                             !annotate && !track_evaluation && assume_object};
+                             !emit_annotation && !track_evaluation &&
+                             assume_object};
   if (attempt_object_fusion) {
     for (const auto &entry : schema_context.schema.as_object()) {
       const auto &keyword{entry.first};
@@ -1220,7 +1222,8 @@ auto compiler_draft3_applicator_additionalproperties_with_options(
     const auto required{required_properties(schema_context)};
     if (is_closed_properties_required(schema_context.schema, required) &&
         (required.size() > 1 ||
-         properties_enforce_closed_object(context, schema_context))) {
+         (properties_enforce_closed_object(context, schema_context) &&
+          !annotations_enabled(context, "properties")))) {
       return {};
     }
   }
@@ -1586,8 +1589,9 @@ auto compiler_draft3_applicator_additionalitems_from_cursor(
   Instructions children;
 
   if (!subchildren.empty()) {
-    if (context.mode == Mode::FastValidation && cursor == 0 && !annotate &&
-        !track_evaluation && is_integer_bounded_pattern(subchildren)) {
+    if (context.mode == Mode::FastValidation && cursor == 0 &&
+        !emit_annotation && !track_evaluation &&
+        is_integer_bounded_pattern(subchildren)) {
       children.push_back(
           make(sourcemeta::blaze::InstructionIndex::LoopItemsIntegerBounded,
                context, schema_context, dynamic_context,

--- a/src/compiler/default_compiler_draft4.h
+++ b/src/compiler/default_compiler_draft4.h
@@ -141,6 +141,7 @@ auto compiler_draft4_applicator_anyof(const Context &context,
   }
 
   const auto requires_exhaustive{context.mode == Mode::Exhaustive ||
+                                 annotations_collected(context) ||
                                  requires_evaluation(context, schema_context)};
 
   return {make(sourcemeta::blaze::InstructionIndex::LogicalOr, context,
@@ -171,6 +172,7 @@ auto compiler_draft4_applicator_oneof(const Context &context,
   }
 
   const auto requires_exhaustive{context.mode == Mode::Exhaustive ||
+                                 annotations_collected(context) ||
                                  requires_evaluation(context, schema_context)};
 
   return {make(sourcemeta::blaze::InstructionIndex::LogicalXor, context,

--- a/test/evaluator/annotationsuite.cc
+++ b/test/evaluator/annotationsuite.cc
@@ -116,19 +116,34 @@ public:
     this->frame.analyse(this->schema_json, sourcemeta::blaze::schema_walker,
                         sourcemeta::blaze::schema_resolver,
                         test_default_dialect);
-    this->schema = sourcemeta::blaze::compile(
+    this->exhaustive_schema = sourcemeta::blaze::compile(
         this->schema_json, sourcemeta::blaze::schema_walker,
         sourcemeta::blaze::schema_resolver,
         sourcemeta::blaze::default_schema_compiler, this->frame,
         this->frame.root(), sourcemeta::blaze::Mode::Exhaustive);
+
+    for (const auto &assertion : this->assertions) {
+      assert(assertion.is_object());
+      assert(assertion.defines("keyword"));
+      assert(assertion.at("keyword").is_string());
+      this->keywords.insert(assertion.at("keyword").to_string());
+    }
+
+    std::unordered_set<sourcemeta::core::JSON::StringView> whitelist;
+    for (const auto &keyword : this->keywords) {
+      whitelist.insert(keyword);
+    }
+
+    sourcemeta::blaze::Tweaks tweaks;
+    tweaks.annotations = std::move(whitelist);
+    this->fast_validation_schema = sourcemeta::blaze::compile(
+        this->schema_json, sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        sourcemeta::blaze::default_schema_compiler, this->frame,
+        this->frame.root(), sourcemeta::blaze::Mode::FastValidation, tweaks);
   }
 
-  auto TestBody() -> void override {
-    sourcemeta::blaze::SimpleOutput output{this->instance};
-    const auto result{this->evaluator.validate(this->schema, this->instance,
-                                               std::ref(output))};
-    EXPECT_TRUE(result);
-
+  auto check_assertions(const sourcemeta::blaze::SimpleOutput &output) -> void {
     for (const auto &assertion : this->assertions) {
       assert(assertion.is_object());
       assert(assertion.defines("location"));
@@ -160,11 +175,29 @@ public:
     }
   }
 
+  auto TestBody() -> void override {
+    sourcemeta::blaze::SimpleOutput output{this->instance};
+    const auto result{this->evaluator.validate(
+        this->exhaustive_schema, this->instance, std::ref(output))};
+    EXPECT_TRUE(result);
+    this->check_assertions(output);
+
+    // The same annotations must be collected in fast validation mode when the
+    // relevant keywords are whitelisted via tweaks
+    sourcemeta::blaze::SimpleOutput fast_output{this->instance};
+    const auto fast_result{this->evaluator.validate(
+        this->fast_validation_schema, this->instance, std::ref(fast_output))};
+    EXPECT_TRUE(fast_result);
+    this->check_assertions(fast_output);
+  }
+
 private:
   sourcemeta::core::JSON schema_json;
   sourcemeta::blaze::SchemaFrame frame{
       sourcemeta::blaze::SchemaFrame::Mode::References};
-  sourcemeta::blaze::Template schema;
+  sourcemeta::blaze::Template exhaustive_schema;
+  std::unordered_set<sourcemeta::core::JSON::String> keywords;
+  sourcemeta::blaze::Template fast_validation_schema;
   sourcemeta::core::JSON instance;
   sourcemeta::core::JSON::Array assertions;
   sourcemeta::blaze::Evaluator evaluator;

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -622,16 +622,22 @@
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ]
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
       ],
       "post": [
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string but it was of type integer",
         "The array value was expected to contain at least 1 item that validates against the given subschema"
       ]
     }
@@ -710,14 +716,29 @@
     "exhaustive": {
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain at least 1 item that validates against the given subschema"
       ]
     }
@@ -756,18 +777,24 @@
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain at least 2 items that validate against the given subschema"
       ]
     }
@@ -806,18 +833,30 @@
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 3 ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 3 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain at least 2 items that validate against the given subschema"
       ]
     }
@@ -856,17 +895,20 @@
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
       ],
       "post": [
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
         [ false, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string but it was of type integer",
         "The array value was expected to contain at least 2 items that validate against the given subschema"
       ]
@@ -906,18 +948,24 @@
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain 1 to 2 items that validate against the given subschema"
       ]
     }
@@ -955,19 +1003,28 @@
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
         [ false, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain 1 to 2 items that validate against the given subschema"
       ]
     }
@@ -1006,18 +1063,24 @@
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
       ],
       "post": [
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
         [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string but it was of type integer",
         "The array value was expected to contain exactly 2 items that validate against the given subschema"
       ]
@@ -1057,19 +1120,28 @@
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
         [ false, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
         "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain exactly 2 items that validate against the given subschema"
       ]
     }
@@ -1128,13 +1200,22 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
-        "The array value was expected to contain at least 1 item and it contained 3 items"
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain at least 1 item that validates against the given subschema"
       ]
     }
   },
@@ -3349,17 +3430,20 @@
       "pre": [
         [ "LoopContains", "/contains", "#/contains", "" ],
         [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
         [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
         [ "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ]
       ],
       "post": [
         [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
         [ true, "LoopContains", "/contains", "#/contains", "" ],
         [ false, "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ],
         [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
         "The array value was expected to contain at least 1 item that validates against the given subschema",
         "The array value was not expected to define the item at index 0",
         "The array items not covered by other array keywords, if any, were expected to validate against this subschema"

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -8,6 +8,8 @@
 
 #include "evaluator_utils.h"
 
+#include <iostream>
+
 TEST(Evaluator_2019_09, metaschema_1) {
   const auto metaschema{sourcemeta::blaze::schema_resolver(
       "https://json-schema.org/draft/2019-09/schema")};
@@ -3965,20 +3967,38 @@ TEST(Evaluator_2019_09, annotation_fast_contains) {
   tweaks.annotations =
       std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
 
   EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
   EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
                      "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(3, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/contains", "#/contains", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
                               "#/contains/type", "/0");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/contains", "#/contains", "", 0);
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/contains", "#/contains", "", 1);
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopContains, "/contains", "#/contains", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 1,
+      "The item at index 0 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The item at index 1 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
       "The array value was expected to contain at least 1 item that validates "
       "against the given subschema");
 }
@@ -3998,33 +4018,45 @@ TEST(Evaluator_2019_09, annotation_fast_contains_min_max) {
   tweaks.annotations =
       std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
 
   EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
   EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
                      "/0");
-  EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
-                     "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/contains", "#/contains", "");
   EVALUATE_TRACE_PRE(3, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(5, AssertionType, "/contains/type", "#/contains/type",
                      "/2");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
                               "#/contains/type", "/0");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/contains", "#/contains", "", 0);
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/contains/type",
                               "#/contains/type", "/1");
-  EVALUATE_TRACE_POST_FAILURE(2, AssertionType, "/contains/type",
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/contains", "#/contains", "", 1);
+  EVALUATE_TRACE_POST_FAILURE(4, AssertionType, "/contains/type",
                               "#/contains/type", "/2");
-  EVALUATE_TRACE_POST_SUCCESS(3, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_POST_SUCCESS(5, LoopContains, "/contains", "#/contains", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type integer");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The item at index 0 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 2,
+      instance, 3,
+      "The item at index 1 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
       "The value was expected to be of type integer but it was of type string");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 3,
+      instance, 5,
       "The array value was expected to contain 1 to 3 items that validate "
       "against the given subschema");
 }
@@ -4042,25 +4074,36 @@ TEST(Evaluator_2019_09, annotation_fast_contains_nested_annotation) {
   tweaks.annotations =
       std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
 
   EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
   EVALUATE_TRACE_PRE_ANNOTATION(1, "/contains/title", "#/contains/title", "/0");
   EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
                      "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/contains/title", "#/contains/title", "/1");
+  EVALUATE_TRACE_PRE(4, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
 
   EVALUATE_TRACE_POST_ANNOTATION(0, "/contains/title", "#/contains/title", "/0",
                                  "hit");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
                               "#/contains/type", "/0");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/contains/title", "#/contains/title", "/1",
+                                 "hit");
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopContains, "/contains", "#/contains", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0, "The title of the instance location \"/0\" was \"hit\"");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(
-      instance, 2,
+      instance, 2, "The title of the instance location \"/1\" was \"hit\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
       "The array value was expected to contain at least 1 item that validates "
       "against the given subschema");
 }

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -8,8 +8,6 @@
 
 #include "evaluator_utils.h"
 
-#include <iostream>
-
 TEST(Evaluator_2019_09, metaschema_1) {
   const auto metaschema{sourcemeta::blaze::schema_resolver(
       "https://json-schema.org/draft/2019-09/schema")};

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -3622,14 +3622,12 @@ TEST(Evaluator_2019_09, x_assertion_true_without_format_no_tweak_exhaustive) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_metadata_title) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "title": "Test title"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "Test title"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -3646,14 +3644,12 @@ TEST(Evaluator_2019_09, annotation_fast_metadata_title) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_format) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "format": "email"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "format": "email"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON("a@b.com")JSON")};
+  const sourcemeta::core::JSON instance{"a@b.com"};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -3671,14 +3667,12 @@ TEST(Evaluator_2019_09, annotation_fast_format) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_content_media_type) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "contentMediaType": "text/plain"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contentMediaType": "text/plain"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON("hi")JSON")};
+  const sourcemeta::core::JSON instance{"hi"};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
@@ -3697,15 +3691,10 @@ TEST(Evaluator_2019_09, annotation_fast_content_media_type) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "foo": {
-      "type": "string"
-    }
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": { "foo": { "type": "string" } }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};
@@ -3733,15 +3722,10 @@ TEST(Evaluator_2019_09, annotation_fast_properties) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_pattern_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "patternProperties": {
-    "^x": {
-      "type": "string"
-    }
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "patternProperties": { "^x": { "type": "string" } }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "xa": "y" })JSON")};
@@ -3780,18 +3764,11 @@ TEST(Evaluator_2019_09, annotation_fast_pattern_properties) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_additional_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "foo": {
-      "type": "integer"
-    }
-  },
-  "additionalProperties": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": { "foo": { "type": "integer" } },
+    "additionalProperties": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
@@ -3836,18 +3813,11 @@ TEST(Evaluator_2019_09, annotation_fast_additional_properties) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_items_array) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "items": [
-    {
-      "type": "integer"
-    }
-  ],
-  "additionalItems": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "items": [ { "type": "integer" } ],
+    "additionalItems": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
@@ -3894,18 +3864,11 @@ TEST(Evaluator_2019_09, annotation_fast_items_array) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_additional_items) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "items": [
-    {
-      "type": "integer"
-    }
-  ],
-  "additionalItems": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "items": [ { "type": "integer" } ],
+    "additionalItems": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
@@ -3958,13 +3921,10 @@ TEST(Evaluator_2019_09, annotation_fast_additional_items) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_items_schema) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "items": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "items": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ "a" ])JSON")};
@@ -3999,13 +3959,10 @@ TEST(Evaluator_2019_09, annotation_fast_items_schema) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_contains) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "contains": {
-    "type": "integer"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": { "type": "integer" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
@@ -4033,18 +3990,11 @@ TEST(Evaluator_2019_09, annotation_fast_contains) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_unevaluated_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "properties": {
-    "foo": {
-      "type": "integer"
-    }
-  },
-  "unevaluatedProperties": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": { "foo": { "type": "integer" } },
+    "unevaluatedProperties": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
@@ -4089,18 +4039,11 @@ TEST(Evaluator_2019_09, annotation_fast_unevaluated_properties) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_unevaluated_items) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "items": [
-    {
-      "type": "integer"
-    }
-  ],
-  "unevaluatedItems": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "items": [ { "type": "integer" } ],
+    "unevaluatedItems": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
@@ -4150,14 +4093,12 @@ TEST(Evaluator_2019_09, annotation_fast_unevaluated_items) {
 }
 
 TEST(Evaluator_2019_09, annotation_fast_unknown_keyword) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "x-custom": "hello"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "x-custom": "hello"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -3636,9 +3636,7 @@ TEST(Evaluator_2019_09, annotation_fast_metadata_title) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "Test title");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The title of the instance was \"Test title\"");
 }
@@ -3658,9 +3656,7 @@ TEST(Evaluator_2019_09, annotation_fast_format) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/format", "#/format", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/format", "#/format", "", "email");
-
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0,
       "The logical type of the instance was expected to be \"email\"");
@@ -3682,10 +3678,8 @@ TEST(Evaluator_2019_09, annotation_fast_content_media_type) {
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
                                 "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
                                  "", "text/plain");
-
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0, "The content media type of the instance was \"text/plain\"");
 }
@@ -3989,6 +3983,88 @@ TEST(Evaluator_2019_09, annotation_fast_contains) {
       "against the given subschema");
 }
 
+TEST(Evaluator_2019_09, annotation_fast_contains_min_max) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": { "type": "integer" },
+    "minContains": 1,
+    "maxContains": 3
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2, "x" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+  EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+  EVALUATE_TRACE_PRE(3, AssertionType, "/contains/type", "#/contains/type",
+                     "/2");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_FAILURE(2, AssertionType, "/contains/type",
+                              "#/contains/type", "/2");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The value was expected to be of type integer but it was of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The array value was expected to contain 1 to 3 items that validate "
+      "against the given subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_contains_nested_annotation) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": { "title": "hit", "type": "integer" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/contains/title", "#/contains/title", "/0");
+  EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/contains/title", "#/contains/title", "/0",
+                                 "hit");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0, "The title of the instance location \"/0\" was \"hit\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
+}
+
 TEST(Evaluator_2019_09, annotation_fast_unevaluated_properties) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -4107,9 +4183,7 @@ TEST(Evaluator_2019_09, annotation_fast_unknown_keyword) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/x-custom", "#/x-custom", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/x-custom", "#/x-custom", "", "hello");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The unrecognized keyword \"x-custom\" was "
                                "collected as the annotation \"hello\"");

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -3620,3 +3620,556 @@ TEST(Evaluator_2019_09, x_assertion_true_without_format_no_tweak_exhaustive) {
                                "The unrecognized keyword \"x-format-assertion\""
                                " was collected as the annotation true");
 }
+
+TEST(Evaluator_2019_09, annotation_fast_metadata_title) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Test title"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "Test title");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The title of the instance was \"Test title\"");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_format) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "format": "email"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("a@b.com")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"format"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/format", "#/format", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/format", "#/format", "", "email");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The logical type of the instance was expected to be \"email\"");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_content_media_type) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "contentMediaType": "text/plain"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("hi")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "contentMediaType"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
+                                "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
+                                 "", "text/plain");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0, "The content media type of the instance was \"text/plain\"");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"properties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/properties", "#/properties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object property \"foo\" successfully "
+                               "validated against its property subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_pattern_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "patternProperties": {
+    "^x": {
+      "type": "string"
+    }
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "xa": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "patternProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopPropertiesStartsWith, "/patternProperties",
+                     "#/patternProperties", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/patternProperties/^x/type",
+                     "#/patternProperties/%5Ex/type", "/xa");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
+                                "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
+                              "/patternProperties/^x/type",
+                              "#/patternProperties/%5Ex/type", "/xa");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                 "", "xa");
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesStartsWith, "/patternProperties",
+                              "#/patternProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The object property \"xa\" successfully validated against its pattern "
+      "property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object properties that start with the string \"x\" were expected to "
+      "validate against the defined pattern property subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_additional_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "properties": {
+    "foo": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "additionalProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyType, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/additionalProperties",
+                     "#/additionalProperties", "");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/additionalProperties/type",
+                     "#/additionalProperties/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/additionalProperties",
+                                "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyType, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/additionalProperties/type",
+                              "#/additionalProperties/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/additionalProperties",
+                                 "#/additionalProperties", "", "bar");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesExcept, "/additionalProperties",
+                              "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object property \"bar\" successfully validated against the "
+      "additional properties subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The object properties not covered by other adjacent object keywords "
+      "were expected to validate against this subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_items_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "items": [
+    {
+      "type": "integer"
+    }
+  ],
+  "additionalItems": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"items"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefix, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/items/0/type", "#/items/0/type", "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(3, LoopItemsFrom, "/additionalItems", "#/additionalItems",
+                     "");
+  EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/additionalItems/type",
+                     "#/additionalItems/type", "/1");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/items/0/type",
+                              "#/items/0/type", "/0");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/items", "#/items", "", 0);
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionArrayPrefix, "/items", "#/items", "");
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/additionalItems/type",
+                              "#/additionalItems/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopItemsFrom, "/additionalItems",
+                              "#/additionalItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value successfully validated against the "
+      "first positional subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "Every item in the array value except for the first one was expected to "
+      "validate against the given subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_additional_items) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "items": [
+    {
+      "type": "integer"
+    }
+  ],
+  "additionalItems": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"additionalItems"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefix, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/items/0/type", "#/items/0/type", "/0");
+  EVALUATE_TRACE_PRE(2, LoopItemsFrom, "/additionalItems", "#/additionalItems",
+                     "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/additionalItems/type",
+                     "#/additionalItems/type", "/1");
+  EVALUATE_TRACE_PRE(4, LogicalWhenArraySizeGreater, "/additionalItems",
+                     "#/additionalItems", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(5, "/additionalItems", "#/additionalItems", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/items/0/type",
+                              "#/items/0/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionArrayPrefix, "/items", "#/items", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/additionalItems/type",
+                              "#/additionalItems/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsFrom, "/additionalItems",
+                              "#/additionalItems", "");
+  EVALUATE_TRACE_POST_ANNOTATION(4, "/additionalItems", "#/additionalItems", "",
+                                 true);
+  EVALUATE_TRACE_POST_SUCCESS(5, LogicalWhenArraySizeGreater,
+                              "/additionalItems", "#/additionalItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "Every item in the array value except for the first one was expected to "
+      "validate against the given subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4, "Every item in the array value was successfully validated");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 5,
+                               "The array value contains 1 additional item not "
+                               "described by related keywords");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_items_schema) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "items": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"items"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopItems, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/items/type", "#/items/type",
+                     "/0");
+  EVALUATE_TRACE_PRE(2, LogicalWhenType, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/items", "#/items", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/items/type",
+                              "#/items/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopItems, "/items", "#/items", "");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/items", "#/items", "", true);
+  EVALUATE_TRACE_POST_SUCCESS(3, LogicalWhenType, "/items", "#/items", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "Every item in the array value was expected to "
+                               "validate against the given subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2, "Every item in the array value was successfully validated");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type array");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_contains) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "contains": {
+    "type": "integer"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_unevaluated_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "properties": {
+    "foo": {
+      "type": "integer"
+    }
+  },
+  "unevaluatedProperties": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "unevaluatedProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyType, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/unevaluatedProperties",
+                     "#/unevaluatedProperties", "");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/unevaluatedProperties/type",
+                     "#/unevaluatedProperties/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/unevaluatedProperties",
+                                "#/unevaluatedProperties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyType, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/unevaluatedProperties/type",
+                              "#/unevaluatedProperties/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/unevaluatedProperties",
+                                 "#/unevaluatedProperties", "", "bar");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesExcept, "/unevaluatedProperties",
+                              "#/unevaluatedProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object property \"bar\" successfully validated against the "
+      "subschema for unevaluated properties");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The object properties not covered by other object keywords were "
+      "expected to validate against this subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_unevaluated_items) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "items": [
+    {
+      "type": "integer"
+    }
+  ],
+  "unevaluatedItems": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "unevaluatedItems"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefixEvaluate, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/items/0/type", "#/items/0/type", "/0");
+  EVALUATE_TRACE_PRE(2, LoopItemsUnevaluated, "/unevaluatedItems",
+                     "#/unevaluatedItems", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/unevaluatedItems/type",
+                     "#/unevaluatedItems/type", "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/unevaluatedItems", "#/unevaluatedItems",
+                                "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/items/0/type",
+                              "#/items/0/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionArrayPrefixEvaluate, "/items",
+                              "#/items", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/unevaluatedItems/type",
+                              "#/unevaluatedItems/type", "/1");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/unevaluatedItems", "#/unevaluatedItems",
+                                 "", true);
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "At least one item of the array value successfully validated against the "
+      "subschema for unevaluated items");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The array items not covered by other array keywords, if any, were "
+      "expected to validate against this subschema");
+}
+
+TEST(Evaluator_2019_09, annotation_fast_unknown_keyword) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "x-custom": "hello"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/x-custom", "#/x-custom", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/x-custom", "#/x-custom", "", "hello");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-custom\" was "
+                               "collected as the annotation \"hello\"");
+}

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -13,6 +13,8 @@
 
 #include "evaluator_utils.h"
 
+#include <iostream>
+
 static const std::string FORMAT_ASSERTION_METASCHEMA_URI{
     "https://example.com/2020-12-format-assertion-meta"};
 
@@ -4223,9 +4225,7 @@ TEST(Evaluator_2020_12, annotation_fast_metadata_title) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "Test title");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The title of the instance was \"Test title\"");
 }
@@ -4246,9 +4246,7 @@ TEST(Evaluator_2020_12, annotation_fast_metadata_selective) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "T");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The title of the instance was \"T\"");
 }
@@ -4268,9 +4266,7 @@ TEST(Evaluator_2020_12, annotation_fast_format) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/format", "#/format", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/format", "#/format", "", "email");
-
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0,
       "The logical type of the instance was expected to be \"email\"");
@@ -4292,10 +4288,8 @@ TEST(Evaluator_2020_12, annotation_fast_content_media_type) {
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
                                 "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
                                  "", "text/plain");
-
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0, "The content media type of the instance was \"text/plain\"");
 }
@@ -4571,6 +4565,111 @@ TEST(Evaluator_2020_12, annotation_fast_contains) {
       "against the given subschema");
 }
 
+TEST(Evaluator_2020_12, annotation_fast_contains_min_max) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "type": "integer" },
+    "minContains": 1,
+    "maxContains": 3
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2, "x" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(3, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(5, AssertionType, "/contains/type", "#/contains/type",
+                     "/2");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/contains", "#/contains", "", 0);
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/contains", "#/contains", "", 1);
+  EVALUATE_TRACE_POST_FAILURE(4, AssertionType, "/contains/type",
+                              "#/contains/type", "/2");
+  EVALUATE_TRACE_POST_SUCCESS(5, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The item at index 0 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The item at index 1 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The value was expected to be of type integer but it was of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 5,
+      "The array value was expected to contain 1 to 3 items that validate "
+      "against the given subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_contains_nested_annotation) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "title": "hit", "type": "integer" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/contains/title", "#/contains/title", "/0");
+  EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/contains/title", "#/contains/title", "/1");
+  EVALUATE_TRACE_PRE(4, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/contains/title", "#/contains/title", "/0",
+                                 "hit");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/contains/title", "#/contains/title", "/1",
+                                 "hit");
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0, "The title of the instance location \"/0\" was \"hit\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2, "The title of the instance location \"/1\" was \"hit\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
+}
+
 TEST(Evaluator_2020_12, annotation_fast_unevaluated_properties) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -4691,9 +4790,7 @@ TEST(Evaluator_2020_12, annotation_fast_unknown_keyword) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE_ANNOTATION(0, "/x-custom", "#/x-custom", "");
-
   EVALUATE_TRACE_POST_ANNOTATION(0, "/x-custom", "#/x-custom", "", "hello");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The unrecognized keyword \"x-custom\" was "
                                "collected as the annotation \"hello\"");

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -482,7 +482,7 @@ TEST(Evaluator_2020_12, annotation_custom_keyword_selected) {
                                "collected as the annotation \"hello\"");
 }
 
-TEST(Evaluator_2020_12, annotation_fast_mode_ignores_tweak) {
+TEST(Evaluator_2020_12, annotation_fast_mode_respects_tweak) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "string",
@@ -495,12 +495,74 @@ TEST(Evaluator_2020_12, annotation_fast_mode_ignores_tweak) {
   tweaks.annotations =
       std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
 
-  EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "My title");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/type", "#/type", "");
+
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The title of the instance was \"My title\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The value was expected to be of type string");
+}
+
+TEST(Evaluator_2020_12,
+     annotation_properties_closed_object_fast_keeps_closure) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [ "foo" ],
+    "additionalProperties": false,
+    "properties": { "foo": { "type": "string" } }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "bar", "extra": 1 })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"properties"};
+
+  EVALUATE_WITH_TRACE_FAST_FAILURE_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesStrict, "/required", "#/required", "");
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, LoopPropertiesExcept, "/additionalProperties",
+                     "#/additionalProperties", "");
+  EVALUATE_TRACE_PRE(4, AssertionFail, "/additionalProperties",
+                     "#/additionalProperties", "/extra");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesStrict, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties", "#/properties", "", "foo");
+  EVALUATE_TRACE_POST_FAILURE(3, AssertionFail, "/additionalProperties",
+                              "#/additionalProperties", "/extra");
+  EVALUATE_TRACE_POST_FAILURE(4, LoopPropertiesExcept, "/additionalProperties",
+                              "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an object that defines the property "
+      "\"foo\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The object property \"foo\" successfully "
+                               "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The object value was not expected to define the property \"extra\"");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The object value was not expected to define additional properties");
 }
 
 TEST(Evaluator_2020_12, unevaluated_properties_annotations_none_still_tracks) {
@@ -4144,4 +4206,551 @@ TEST(Evaluator_2020_12, x_assertion_nested_selective_valid_no_tweak_fast) {
       instance, 0,
       "The string value \"https://example.com\" was expected to represent a "
       "valid URI");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_metadata_title) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Test title"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "Test title");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The title of the instance was \"Test title\"");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_metadata_selective) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "T",
+  "description": "D"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/title", "#/title", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/title", "#/title", "", "T");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The title of the instance was \"T\"");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_format) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "email"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("a@b.com")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"format"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/format", "#/format", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/format", "#/format", "", "email");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The logical type of the instance was expected to be \"email\"");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_content_media_type) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "contentMediaType": "text/plain"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("hi")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "contentMediaType"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
+                                "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/contentMediaType", "#/contentMediaType",
+                                 "", "text/plain");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0, "The content media type of the instance was \"text/plain\"");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"properties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/properties", "#/properties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object property \"foo\" successfully "
+                               "validated against its property subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_pattern_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "patternProperties": {
+    "^x": {
+      "type": "string"
+    }
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "xa": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "patternProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopPropertiesStartsWith, "/patternProperties",
+                     "#/patternProperties", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/patternProperties/^x/type",
+                     "#/patternProperties/%5Ex/type", "/xa");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
+                                "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
+                              "/patternProperties/^x/type",
+                              "#/patternProperties/%5Ex/type", "/xa");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                 "", "xa");
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesStartsWith, "/patternProperties",
+                              "#/patternProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The object property \"xa\" successfully validated against its pattern "
+      "property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object properties that start with the string \"x\" were expected to "
+      "validate against the defined pattern property subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_additional_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "additionalProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyType, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/additionalProperties",
+                     "#/additionalProperties", "");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/additionalProperties/type",
+                     "#/additionalProperties/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/additionalProperties",
+                                "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyType, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/additionalProperties/type",
+                              "#/additionalProperties/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/additionalProperties",
+                                 "#/additionalProperties", "", "bar");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesExcept, "/additionalProperties",
+                              "#/additionalProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object property \"bar\" successfully validated against the "
+      "additional properties subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The object properties not covered by other adjacent object keywords "
+      "were expected to validate against this subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_prefix_items) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "prefixItems": [
+    {
+      "type": "integer"
+    }
+  ]
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"prefixItems"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefix, "/prefixItems", "#/prefixItems",
+                     "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/prefixItems/0/type",
+                     "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/prefixItems", "#/prefixItems", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/prefixItems", "#/prefixItems", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/prefixItems/0/type",
+                              "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/prefixItems", "#/prefixItems", "", 0);
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/prefixItems", "#/prefixItems", "", true);
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionArrayPrefix, "/prefixItems",
+                              "#/prefixItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value successfully validated against the "
+      "first positional subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "Every item of the array value validated "
+                               "against the given positional subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_items) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "prefixItems": [
+    {
+      "type": "integer"
+    }
+  ],
+  "items": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"items"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefix, "/prefixItems", "#/prefixItems",
+                     "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/prefixItems/0/type",
+                     "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_PRE(2, LoopItemsFrom, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/items/type", "#/items/type",
+                     "/1");
+  EVALUATE_TRACE_PRE(4, LogicalWhenArraySizeGreater, "/items", "#/items", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(5, "/items", "#/items", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/prefixItems/0/type",
+                              "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionArrayPrefix, "/prefixItems",
+                              "#/prefixItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/items/type",
+                              "#/items/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsFrom, "/items", "#/items", "");
+  EVALUATE_TRACE_POST_ANNOTATION(4, "/items", "#/items", "", true);
+  EVALUATE_TRACE_POST_SUCCESS(5, LogicalWhenArraySizeGreater, "/items",
+                              "#/items", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "Every item in the array value except for the first one was expected to "
+      "validate against the given subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4, "Every item in the array value was successfully validated");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 5,
+                               "The array value contains 1 additional item not "
+                               "described by related keywords");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_contains) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "contains": {
+    "type": "integer"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(3, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/contains", "#/contains", "", 0);
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/contains", "#/contains", "", 1);
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The item at index 0 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The item at index 1 of the array value successfully validated against "
+      "the containment check subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_unevaluated_properties) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "type": "integer"
+    }
+  },
+  "unevaluatedProperties": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "unevaluatedProperties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyType, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/unevaluatedProperties",
+                     "#/unevaluatedProperties", "");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/unevaluatedProperties/type",
+                     "#/unevaluatedProperties/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/unevaluatedProperties",
+                                "#/unevaluatedProperties", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyType, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/unevaluatedProperties/type",
+                              "#/unevaluatedProperties/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/unevaluatedProperties",
+                                 "#/unevaluatedProperties", "", "bar");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesExcept, "/unevaluatedProperties",
+                              "#/unevaluatedProperties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The object property \"bar\" successfully validated against the "
+      "subschema for unevaluated properties");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The object properties not covered by other object keywords were "
+      "expected to validate against this subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_unevaluated_items) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "prefixItems": [
+    {
+      "type": "integer"
+    }
+  ],
+  "unevaluatedItems": {
+    "type": "string"
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
+      "unevaluatedItems"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 5, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionArrayPrefixEvaluate, "/prefixItems",
+                     "#/prefixItems", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/prefixItems/0/type",
+                     "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_PRE(2, LoopItemsUnevaluated, "/unevaluatedItems",
+                     "#/unevaluatedItems", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/unevaluatedItems/type",
+                     "#/unevaluatedItems/type", "/1");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/unevaluatedItems", "#/unevaluatedItems",
+                                "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/prefixItems/0/type",
+                              "#/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionArrayPrefixEvaluate, "/prefixItems",
+                              "#/prefixItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/unevaluatedItems/type",
+                              "#/unevaluatedItems/type", "/1");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/unevaluatedItems", "#/unevaluatedItems",
+                                 "", true);
+  EVALUATE_TRACE_POST_SUCCESS(4, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The first item of the array value was expected to validate against the "
+      "corresponding subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "At least one item of the array value successfully validated against the "
+      "subschema for unevaluated items");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The array items not covered by other array keywords, if any, were "
+      "expected to validate against this subschema");
+}
+
+TEST(Evaluator_2020_12, annotation_fast_unknown_keyword) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "x-custom": "hello"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/x-custom", "#/x-custom", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/x-custom", "#/x-custom", "", "hello");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-custom\" was "
+                               "collected as the annotation \"hello\"");
 }

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -13,8 +13,6 @@
 
 #include "evaluator_utils.h"
 
-#include <iostream>
-
 static const std::string FORMAT_ASSERTION_METASCHEMA_URI{
     "https://example.com/2020-12-format-assertion-meta"};
 

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -4793,3 +4793,41 @@ TEST(Evaluator_2020_12, annotation_fast_unknown_keyword) {
                                "The unrecognized keyword \"x-custom\" was "
                                "collected as the annotation \"hello\"");
 }
+
+TEST(Evaluator_2020_12,
+     annotation_exhaustive_empty_whitelist_no_short_circuit) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "type": "integer" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations.emplace();
+
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS_TWEAKED(schema, instance, 3, "",
+                                                 tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+  EVALUATE_TRACE_PRE(2, AssertionType, "/contains/type", "#/contains/type",
+                     "/1");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/contains/type",
+                              "#/contains/type", "/1");
+  EVALUATE_TRACE_POST_SUCCESS(2, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
+}

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -4209,14 +4209,12 @@ TEST(Evaluator_2020_12, x_assertion_nested_selective_valid_no_tweak_fast) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_metadata_title) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Test title"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Test title"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -4233,15 +4231,13 @@ TEST(Evaluator_2020_12, annotation_fast_metadata_title) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_metadata_selective) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "T",
-  "description": "D"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "T",
+    "description": "D"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -4258,14 +4254,12 @@ TEST(Evaluator_2020_12, annotation_fast_metadata_selective) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_format) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "format": "email"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "format": "email"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON("a@b.com")JSON")};
+  const sourcemeta::core::JSON instance{"a@b.com"};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -4283,14 +4277,12 @@ TEST(Evaluator_2020_12, annotation_fast_format) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_content_media_type) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "contentMediaType": "text/plain"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contentMediaType": "text/plain"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON("hi")JSON")};
+  const sourcemeta::core::JSON instance{"hi"};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
@@ -4309,15 +4301,10 @@ TEST(Evaluator_2020_12, annotation_fast_content_media_type) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "type": "string"
-    }
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": { "foo": { "type": "string" } }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};
@@ -4345,15 +4332,10 @@ TEST(Evaluator_2020_12, annotation_fast_properties) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_pattern_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "patternProperties": {
-    "^x": {
-      "type": "string"
-    }
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "patternProperties": { "^x": { "type": "string" } }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "xa": "y" })JSON")};
@@ -4392,18 +4374,11 @@ TEST(Evaluator_2020_12, annotation_fast_pattern_properties) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_additional_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "type": "integer"
-    }
-  },
-  "additionalProperties": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": { "foo": { "type": "integer" } },
+    "additionalProperties": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
@@ -4448,15 +4423,10 @@ TEST(Evaluator_2020_12, annotation_fast_additional_properties) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_prefix_items) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "prefixItems": [
-    {
-      "type": "integer"
-    }
-  ]
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "prefixItems": [ { "type": "integer" } ]
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1 ])JSON")};
@@ -4497,18 +4467,11 @@ TEST(Evaluator_2020_12, annotation_fast_prefix_items) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_items) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "prefixItems": [
-    {
-      "type": "integer"
-    }
-  ],
-  "items": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "prefixItems": [ { "type": "integer" } ],
+    "items": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
@@ -4560,13 +4523,10 @@ TEST(Evaluator_2020_12, annotation_fast_items) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_contains) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "contains": {
-    "type": "integer"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": { "type": "integer" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
@@ -4612,18 +4572,11 @@ TEST(Evaluator_2020_12, annotation_fast_contains) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_unevaluated_properties) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "type": "integer"
-    }
-  },
-  "unevaluatedProperties": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": { "foo": { "type": "integer" } },
+    "unevaluatedProperties": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": "y" })JSON")};
@@ -4668,18 +4621,11 @@ TEST(Evaluator_2020_12, annotation_fast_unevaluated_properties) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_unevaluated_items) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "prefixItems": [
-    {
-      "type": "integer"
-    }
-  ],
-  "unevaluatedItems": {
-    "type": "string"
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "prefixItems": [ { "type": "integer" } ],
+    "unevaluatedItems": { "type": "string" }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON([ 1, "a" ])JSON")};
@@ -4731,14 +4677,12 @@ TEST(Evaluator_2020_12, annotation_fast_unevaluated_items) {
 }
 
 TEST(Evaluator_2020_12, annotation_fast_unknown_keyword) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-custom": "hello"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "x-custom": "hello"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =

--- a/test/evaluator/evaluator_draft7_test.cc
+++ b/test/evaluator/evaluator_draft7_test.cc
@@ -3057,9 +3057,7 @@ TEST(Evaluator_draft7, annotation_fast_metadata_no_effect) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
-
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
 }
@@ -3080,9 +3078,7 @@ TEST(Evaluator_draft7, annotation_fast_unknown_no_effect) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
 
   EVALUATE_TRACE_PRE(0, AssertionType, "/type", "#/type", "");
-
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/type", "#/type", "");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type integer");
 }
@@ -3104,11 +3100,40 @@ TEST(Evaluator_draft7, annotation_fast_properties_no_effect) {
 
   EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrict,
                               "/properties/foo/type", "#/properties/foo/type",
                               "/foo");
-
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
+}
+
+TEST(Evaluator_draft7, annotation_fast_contains_no_effect) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "contains": { "type": "integer" }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"contains"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LoopContains, "/contains", "#/contains", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/contains/type", "#/contains/type",
+                     "/0");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/contains/type",
+                              "#/contains/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(1, LoopContains, "/contains", "#/contains", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The array value was expected to contain at least 1 item that validates "
+      "against the given subschema");
 }

--- a/test/evaluator/evaluator_draft7_test.cc
+++ b/test/evaluator/evaluator_draft7_test.cc
@@ -3040,3 +3040,84 @@ TEST(Evaluator_draft7, additionalitems_annotations_none_no_empty_wrapper) {
                                "first one was expected to validate against the "
                                "given subschema");
 }
+
+TEST(Evaluator_draft7, annotation_fast_metadata_no_effect) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "T",
+  "type": "string"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("x")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"title"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+}
+
+TEST(Evaluator_draft7, annotation_fast_unknown_no_effect) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "x-custom": "hi",
+  "type": "integer"
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionType, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+}
+
+TEST(Evaluator_draft7, annotation_fast_properties_no_effect) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+})JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"properties"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionPropertyTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionPropertyTypeStrict,
+                              "/properties/foo/type", "#/properties/foo/type",
+                              "/foo");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+}

--- a/test/evaluator/evaluator_draft7_test.cc
+++ b/test/evaluator/evaluator_draft7_test.cc
@@ -3042,15 +3042,13 @@ TEST(Evaluator_draft7, additionalitems_annotations_none_no_empty_wrapper) {
 }
 
 TEST(Evaluator_draft7, annotation_fast_metadata_no_effect) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "T",
-  "type": "string"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "T",
+    "type": "string"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON("x")JSON")};
+  const sourcemeta::core::JSON instance{"x"};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -3067,15 +3065,13 @@ TEST(Evaluator_draft7, annotation_fast_metadata_no_effect) {
 }
 
 TEST(Evaluator_draft7, annotation_fast_unknown_no_effect) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "x-custom": "hi",
-  "type": "integer"
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "x-custom": "hi",
+    "type": "integer"
+  })JSON")};
 
-  const sourcemeta::core::JSON instance{
-      sourcemeta::core::parse_json(R"JSON(5)JSON")};
+  const sourcemeta::core::JSON instance{5};
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations =
@@ -3092,15 +3088,10 @@ TEST(Evaluator_draft7, annotation_fast_unknown_no_effect) {
 }
 
 TEST(Evaluator_draft7, annotation_fast_properties_no_effect) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON(
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {
-    "foo": {
-      "type": "string"
-    }
-  }
-})JSON")};
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": { "foo": { "type": "string" } }
+  })JSON")};
 
   const sourcemeta::core::JSON instance{
       sourcemeta::core::parse_json(R"JSON({ "foo": "x" })JSON")};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

