### PR TITLE
Upgrade JSON Schema Test Suite to `1acd90e53554fa24d2529b49fd7d50bab18f8b7e`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 core https://github.com/sourcemeta/core 428cbdf92f6330b0f6ae918ac0a9dce089a0470b
-jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite 60755c1097769e313fae3ec4d63bcc9d49b5d2d5
+jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite 1acd90e53554fa24d2529b49fd7d50bab18f8b7e
 jsonschema-2020-12 https://github.com/json-schema-org/json-schema-spec 769daad75a9553562333a8937a187741cb708c72
 jsonschema-2019-09 https://github.com/json-schema-org/json-schema-spec 41014ea723120ce70b314d72f863c6929d9f3cfd
 jsonschema-draft7 https://github.com/json-schema-org/json-schema-spec 567f768506aaa33a38e552c85bf0586029ef1b32

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -225,12 +230,6 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
-            },
-            {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
             },
             {
                 "description": "century year 0100 is not a leap year",
@@ -337,6 +336,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -330,6 +335,71 @@
             {
                 "description": "empty string",
                 "data": "",
+                "valid": false
+            },
+            {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
+                "valid": false
+            },
+            {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -70,6 +80,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -160,6 +180,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uuid.json
@@ -115,6 +115,21 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/maxProperties.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/maxProperties.json
@@ -1,6 +1,11 @@
 [
     {
         "description": "maxProperties validation",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 2
@@ -40,6 +45,11 @@
     },
     {
         "description": "maxProperties validation with a decimal",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 2.0
@@ -59,6 +69,11 @@
     },
     {
         "description": "maxProperties = 0 means the object is empty",
+        "specification": [
+            {
+                "validation": "6.5.1"
+            }
+        ],
         "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "maxProperties": 0

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -225,12 +230,6 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
-            },
-            {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
             },
             {
                 "description": "century year 0100 is not a leap year",
@@ -337,6 +336,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -330,6 +335,71 @@
             {
                 "description": "empty string",
                 "data": "",
+                "valid": false
+            },
+            {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
+                "valid": false
+            },
+            {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -70,6 +80,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -160,6 +180,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uuid.json
@@ -115,6 +115,21 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft4/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft4/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -67,6 +77,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -157,6 +177,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -67,6 +77,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -157,6 +177,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/date.json
@@ -199,6 +199,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -222,12 +227,6 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
-            },
-            {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
             },
             {
                 "description": "century year 0100 is not a leap year",
@@ -334,6 +333,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-hostname.json
@@ -49,8 +49,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -322,6 +327,71 @@
             {
                 "description": "empty string",
                 "data": "",
+                "valid": false
+            },
+            {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
+                "valid": false
+            },
+            {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/ipv4.json
@@ -55,6 +55,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -67,6 +77,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -157,6 +177,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/v1/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/date.json
@@ -202,6 +202,11 @@
                 "valid": false
             },
             {
+                "description": "invalid: non-ASCII Bengali digit in month field",
+                "data": "2020-0৪-01",
+                "valid": false
+            },
+            {
                 "description": "ISO8601 / non-RFC3339: YYYYMMDD without dashes (2023-03-28)",
                 "data": "20230328",
                 "valid": false
@@ -225,12 +230,6 @@
                 "description": "an invalid time string in date-time format",
                 "data": "2020-11-28T23:55:45Z",
                 "valid": false
-            },
-            {
-                "description": "year 0000 is a leap year (0 % 400 == 0)",
-                "comment": "https://www.rfc-editor.org/rfc/rfc3339#appendix-C — year zero leap year edge case",
-                "data": "0000-02-29",
-                "valid": true
             },
             {
                 "description": "century year 0100 is not a leap year",
@@ -337,6 +336,26 @@
             {
                 "description": "invalid: alphabetic characters in year field",
                 "data": "YYYY-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit month (N+1 digits)",
+                "data": "2020-001-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in month field",
+                "data": "2020-MM-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: three-digit day (N+1 digits)",
+                "data": "2020-01-001",
+                "valid": false
+            },
+            {
+                "description": "invalid: alphabetic characters in day field",
+                "data": "2020-01-DD",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/v1/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/idn-hostname.json
@@ -52,8 +52,13 @@
                 "valid": false
             },
             {
-                "description": "a host name with a component too long",
-                "data": "실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실실례례테스트례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례례례례례례례례테스트례례례례례례례례례례례례테스트례례실례.테스트",
+                "description": "a single label of 63 characters is valid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": true
+            },
+            {
+                "description": "a single label of 64 characters is too long",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "valid": false
             },
             {
@@ -330,6 +335,71 @@
             {
                 "description": "empty string",
                 "data": "",
+                "valid": false
+            },
+            {
+                "description": "zero width non-joiner must pass at every occurrence",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+                "data": "\u0915\u094d\u200c\u0937x\u200cy",
+                "valid": false
+            },
+            {
+                "description": "Bidi domain name with a digit-first label is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2 a label in a Bidi domain name must start with an L, R or AL character",
+                "data": "0a.\u05d0",
+                "valid": false
+            },
+            {
+                "description": "label starting with a digit before a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "0\u0627",
+                "valid": false
+            },
+            {
+                "description": "left-to-right label containing a right-to-left letter is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "a\u05d0",
+                "valid": false
+            },
+            {
+                "description": "right-to-left label mixing both digit types is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5893#section-2",
+                "data": "\u05d00\u0660",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a disallowed code point is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5892#section-2.6",
+                "data": "xn--7a",
+                "valid": false
+            },
+            {
+                "description": "A-label that decodes to a Bidi rule violation is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 https://www.rfc-editor.org/rfc/rfc5893",
+                "data": "xn--0ca24w",
+                "valid": false
+            },
+            {
+                "description": "a U-label whose A-label form is longer than 63 octets is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-4.2.4 the 63-octet limit is on the A-label form, not the code point count",
+                "data": "\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc\u00fc",
+                "valid": false
+            },
+            {
+                "description": "empty label between two dots is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc1034#section-3.1",
+                "data": "a..b",
+                "valid": false
+            },
+            {
+                "description": "a name longer than 253 characters is invalid",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "valid": false
+            },
+            {
+                "description": "non-canonical Punycode that does not re-encode to itself is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
+                "data": "xn---9uc",
                 "valid": false
             }
         ]

--- a/vendor/jsonschema-test-suite/tests/v1/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/ipv4.json
@@ -58,6 +58,16 @@
                 "valid": false
             },
             {
+                "description": "a 2-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.1",
+                "valid": false
+            },
+            {
+                "description": "a 3-part address resolving to a routable IP (inet_aton shorthand)",
+                "data": "127.0.1",
+                "valid": false
+            },
+            {
                 "description": "an IP address as an integer",
                 "data": "0x7f000001",
                 "valid": false
@@ -70,6 +80,16 @@
             {
                 "description": "invalid non-ASCII '২' (a Bengali 2)",
                 "data": "1২7.0.0.1",
+                "valid": false
+            },
+            {
+                "description": "invalid fullwidth digits (non-ASCII)",
+                "data": "１９２.１６８.１.１",
+                "valid": false
+            },
+            {
+                "description": "invalid mathematical bold digits (non-ASCII)",
+                "data": "𝟏𝟗𝟐.𝟏𝟔𝟖.𝟏.𝟏",
                 "valid": false
             },
             {
@@ -160,6 +180,11 @@
             {
                 "description": "tab character is invalid",
                 "data": "192.168.0.1\t",
+                "valid": false
+            },
+            {
+                "description": "additional content after an embedded NUL byte",
+                "data": "192.168.0.1\u0000.evil.com",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/v1/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/uuid.json
@@ -115,6 +115,21 @@
                 "description": "hypothetical version 15",
                 "data": "99c17cbb-656f-f64a-940f-1a4568f03487",
                 "valid": true
+            },
+            {
+                "description": "URN prefixed UUID is invalid",
+                "data": "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
+            },
+            {
+                "description": "trailing hyphen after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380-",
+                "valid": false
+            },
+            {
+                "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
+                "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

