### PR TITLE
Add frame embedded resource reset tests

### DIFF
--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -3475,3 +3475,439 @@ TEST(vocabularies_embedded_custom_metaschema_precedence) {
   EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Core);
   EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Validation);
 }
+
+TEST(reuse_embedded_custom_metaschema_implicit_reset) {
+  const sourcemeta::core::JSON document_a =
+      sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::core::JSON document_b =
+      sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  // Reusing a single frame across two analyses of documents that embed the
+  // same custom meta-schema identifier with a different definition must
+  // reflect the second document, as a new analysis resets the internal state
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document_a, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+  frame.analyse(document_b, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 19);
+
+  // Resources
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com/schema", "https://example.com/schema", "",
+      "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com/meta", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "", "", false, true);
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_POINTER(frame, "https://example.com/schema#/$schema",
+                              "https://example.com/schema", "/$schema",
+                              "https://example.com/meta", JSON_Schema_2020_12,
+                              "https://example.com/schema", "/$schema", "",
+                              false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/$id", "https://example.com/schema",
+      "/$id", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/$id", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/type", "https://example.com/schema",
+      "/type", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/type", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/$defs", "https://example.com/schema",
+      "/$defs", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/$defs", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://example.com/schema#/$defs/https:~1~1example.com~1meta",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "", "", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/$id",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$id", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/$schema",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$schema",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$vocabulary",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/type",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/type", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$id", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$id", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$schema", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$schema",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$vocabulary",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$vocabulary",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/meta#/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/meta#/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/type", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/type", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+
+  // References
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(frame, "/$schema", "https://example.com/meta",
+                          "https://example.com/meta", std::nullopt,
+                          "https://example.com/meta");
+  EXPECT_STATIC_REFERENCE(frame, "/$defs/https:~1~1example.com~1meta/$schema",
+                          "https://json-schema.org/draft/2020-12/schema",
+                          "https://json-schema.org/draft/2020-12/schema",
+                          std::nullopt,
+                          "https://json-schema.org/draft/2020-12/schema");
+
+  // Vocabularies
+
+  const auto root_location{frame.traverse("https://example.com/schema")};
+  EXPECT_TRUE(root_location.has_value());
+  const auto root_vocabularies{frame.vocabularies(
+      root_location->get(), sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(root_vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Applicator);
+  EXPECT_FALSE(root_vocabularies.contains(
+      sourcemeta::blaze::Vocabularies::Known::JSON_Schema_2020_12_Validation));
+}
+
+TEST(reuse_embedded_custom_metaschema_explicit_reset) {
+  const sourcemeta::core::JSON document_a =
+      sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  const sourcemeta::core::JSON document_b =
+      sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/applicator": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document_a, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  // An explicit reset must clear every trace of the first analysis, including
+  // the cache of meta-schemas embedded in the previous document
+  frame.reset();
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  frame.analyse(document_b, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 19);
+
+  // Resources
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com/schema", "https://example.com/schema", "",
+      "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com/meta", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "", "", false, true);
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_POINTER(frame, "https://example.com/schema#/$schema",
+                              "https://example.com/schema", "/$schema",
+                              "https://example.com/meta", JSON_Schema_2020_12,
+                              "https://example.com/schema", "/$schema", "",
+                              false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/$id", "https://example.com/schema",
+      "/$id", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/$id", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/type", "https://example.com/schema",
+      "/type", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/type", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/schema#/$defs", "https://example.com/schema",
+      "/$defs", "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "/$defs", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://example.com/schema#/$defs/https:~1~1example.com~1meta",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "", "", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/$id",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$id", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/$schema",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$schema",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$vocabulary",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/"
+      "$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/schema#/$defs/https:~1~1example.com~1meta/type",
+      "https://example.com/schema", "/$defs/https:~1~1example.com~1meta/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/type", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$id", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$id", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$schema", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$schema",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/$vocabulary",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/$vocabulary",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/meta#/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/https:~1~1json-schema.org~1draft~12020-12~1vocab~1core",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame,
+      "https://example.com/meta#/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta",
+      "/$vocabulary/"
+      "https:~1~1json-schema.org~1draft~12020-12~1vocab~1applicator",
+      "/$defs/https:~1~1example.com~1meta", false, true);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com/meta#/type", "https://example.com/schema",
+      "/$defs/https:~1~1example.com~1meta/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com/meta", "/type", "/$defs/https:~1~1example.com~1meta",
+      false, true);
+
+  // References
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(frame, "/$schema", "https://example.com/meta",
+                          "https://example.com/meta", std::nullopt,
+                          "https://example.com/meta");
+  EXPECT_STATIC_REFERENCE(frame, "/$defs/https:~1~1example.com~1meta/$schema",
+                          "https://json-schema.org/draft/2020-12/schema",
+                          "https://json-schema.org/draft/2020-12/schema",
+                          std::nullopt,
+                          "https://json-schema.org/draft/2020-12/schema");
+
+  // Vocabularies
+
+  const auto root_location{frame.traverse("https://example.com/schema")};
+  EXPECT_TRUE(root_location.has_value());
+  const auto root_vocabularies{frame.vocabularies(
+      root_location->get(), sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(root_vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(root_vocabularies, JSON_Schema_2020_12_Applicator);
+  EXPECT_FALSE(root_vocabularies.contains(
+      sourcemeta::blaze::Vocabularies::Known::JSON_Schema_2020_12_Validation));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

