### PR TITLE
Do not fuse object properties when collecting annotations

### DIFF
--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -921,7 +921,8 @@ auto compiler_draft3_applicator_properties_with_options(
   }
 
   if (context.mode == Mode::FastValidation) {
-    if (fusion_possible && !fusion_entries.empty()) {
+    if (fusion_possible && !fusion_entries.empty() &&
+        !annotations_collected(context)) {
       for (const auto &req : required) {
         const auto &req_name{req.first};
         bool already_tracked{false};

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -507,6 +507,346 @@ TEST(annotation_fast_mode_respects_tweak) {
                                "The value was expected to be of type string");
 }
 
+TEST(annotation_fast_whitelist_oneof_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "oneOf": [
+          { "type": "string", "x-test-custom": "First" },
+          { "type": "integer", "x-test-custom": "Second" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalXor, "/properties/value/oneOf",
+                     "#/properties/value/oneOf", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/properties/value/oneOf/0/x-test-custom",
+                                "#/properties/value/oneOf/0/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/value/oneOf/0/type",
+                     "#/properties/value/oneOf/0/type", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/properties/value/oneOf/1/x-test-custom",
+                                "#/properties/value/oneOf/1/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(4, AssertionType, "/properties/value/oneOf/1/type",
+                     "#/properties/value/oneOf/1/type", "/value");
+  EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/properties/value/oneOf/0/x-test-custom",
+                                 "#/properties/value/oneOf/0/x-test-custom",
+                                 "/value", "First");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/properties/value/oneOf/0/type",
+                              "#/properties/value/oneOf/0/type", "/value");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties/value/oneOf/1/x-test-custom",
+                                 "#/properties/value/oneOf/1/x-test-custom",
+                                 "/value", "Second");
+  EVALUATE_TRACE_POST_FAILURE(3, AssertionType,
+                              "/properties/value/oneOf/1/type",
+                              "#/properties/value/oneOf/1/type", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalXor, "/properties/value/oneOf",
+                              "#/properties/value/oneOf", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(5, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"First\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Second\"");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The value was expected to be of type integer but "
+      "it was of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
+                               "The string value was expected to validate "
+                               "against one and only one of the 2 given "
+                               "subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 5,
+                               "The value was expected to be of type object");
+}
+
+TEST(annotation_fast_whitelist_anyof_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "anyOf": [
+          { "type": "string", "x-test-custom": "First" },
+          { "type": "integer", "x-test-custom": "Second" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 6, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalOr, "/properties/value/anyOf",
+                     "#/properties/value/anyOf", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/properties/value/anyOf/0/x-test-custom",
+                                "#/properties/value/anyOf/0/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/value/anyOf/0/type",
+                     "#/properties/value/anyOf/0/type", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/properties/value/anyOf/1/x-test-custom",
+                                "#/properties/value/anyOf/1/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(4, AssertionType, "/properties/value/anyOf/1/type",
+                     "#/properties/value/anyOf/1/type", "/value");
+  EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/properties/value/anyOf/0/x-test-custom",
+                                 "#/properties/value/anyOf/0/x-test-custom",
+                                 "/value", "First");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
+                              "/properties/value/anyOf/0/type",
+                              "#/properties/value/anyOf/0/type", "/value");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties/value/anyOf/1/x-test-custom",
+                                 "#/properties/value/anyOf/1/x-test-custom",
+                                 "/value", "Second");
+  EVALUATE_TRACE_POST_FAILURE(3, AssertionType,
+                              "/properties/value/anyOf/1/type",
+                              "#/properties/value/anyOf/1/type", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalOr, "/properties/value/anyOf",
+                              "#/properties/value/anyOf", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(5, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"First\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Second\"");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 3,
+      "The value was expected to be of type integer but "
+      "it was of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 4,
+      "The string value was expected to validate "
+      "against at least one of the 2 given subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 5,
+                               "The value was expected to be of type object");
+}
+
+TEST(annotation_fast_whitelist_if_then_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "if": { "type": "string" },
+        "then": { "x-test-custom": "Then" }
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalCondition, "/properties/value/if",
+                     "#/properties/value/if", "/value");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/value/if/type",
+                     "#/properties/value/if/type", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties/value/then/x-test-custom",
+                                "#/properties/value/then/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
+                              "/properties/value/if/type",
+                              "#/properties/value/if/type", "/value");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties/value/then/x-test-custom",
+                                 "#/properties/value/then/x-test-custom",
+                                 "/value", "Then");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalCondition, "/properties/value/if",
+                              "#/properties/value/if", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Then\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The string value was expected to validate "
+                               "against the given conditional");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type object");
+}
+
+TEST(annotation_fast_whitelist_allof_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "allOf": [ { "type": "string", "x-test-custom": "All" } ]
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/properties/value/allOf/0/x-test-custom",
+                                "#/properties/value/allOf/0/x-test-custom",
+                                "/value");
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict,
+                     "/properties/value/allOf/0/type",
+                     "#/properties/value/allOf/0/type", "/value");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/properties/value/allOf/0/x-test-custom",
+                                 "#/properties/value/allOf/0/x-test-custom",
+                                 "/value", "All");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
+                              "/properties/value/allOf/0/type",
+                              "#/properties/value/allOf/0/type", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"All\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type object");
+}
+
+TEST(annotation_fast_whitelist_ref_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "atom": { "type": "string", "x-test-custom": "Atom" }
+    },
+    "type": "object",
+    "properties": {
+      "value": { "$ref": "#/$defs/atom" }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 3, "", tweaks);
+
+  EVALUATE_TRACE_PRE_ANNOTATION(0, "/properties/value/$ref/x-test-custom",
+                                "#/$defs/atom/x-test-custom", "/value");
+  EVALUATE_TRACE_PRE(1, AssertionPropertyTypeStrict,
+                     "/properties/value/$ref/type", "#/$defs/atom/type",
+                     "/value");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/properties/value/$ref/x-test-custom",
+                                 "#/$defs/atom/x-test-custom", "/value",
+                                 "Atom");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionPropertyTypeStrict,
+                              "/properties/value/$ref/type",
+                              "#/$defs/atom/type", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Atom\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type object");
+}
+
+TEST(annotation_fast_whitelist_not_sibling_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "not": { "type": "integer" },
+        "x-test-custom": "Not"
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalNot, "/properties/value/not",
+                     "#/properties/value/not", "/value");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/properties/value/not/type",
+                     "#/properties/value/not/type", "/value");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties/value/x-test-custom",
+                                "#/properties/value/x-test-custom", "/value");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionType, "/properties/value/not/type",
+                              "#/properties/value/not/type", "/value");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalNot, "/properties/value/not",
+                              "#/properties/value/not", "/value");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/properties/value/x-test-custom",
+                                 "#/properties/value/x-test-custom", "/value",
+                                 "Not");
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/type", "#/type", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be of type integer but "
+      "it was of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The string value was expected to not validate "
+                               "against the given subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Not\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type object");
+}
+
 TEST(annotation_properties_closed_object_fast_keeps_closure) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/output/output_simple_test.cc
+++ b/test/output/output_simple_test.cc
@@ -7,6 +7,8 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/jsonpointer.h>
 
+#include <unordered_set>
+
 #define EXPECT_OUTPUT(traces, index, expected_instance_location,               \
                       expected_evaluate_path, expected_schema_location,        \
                       expected_message)                                        \
@@ -1024,6 +1026,52 @@ TEST(annotations_success_oneof_1) {
   EXPECT_ANNOTATION_ENTRY(output, "", "/oneOf/1/title", "#/oneOf/1/title", 1);
   EXPECT_ANNOTATION_VALUE(output, "", "/oneOf/1/title", "#/oneOf/1/title", 0,
                           sourcemeta::core::JSON{"Second"});
+}
+
+TEST(annotations_success_whitelist_oneof_within_object_property) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "value": {
+        "oneOf": [
+          { "type": "string", "x-custom": "First" },
+          { "type": "integer", "x-custom": "Second" }
+        ]
+      }
+    }
+  })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-custom"};
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON({ "value": "foo" })JSON")};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_TRUE(result);
+  std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{output.cbegin(),
+                                                             output.cend()};
+  EXPECT_TRUE(traces.empty());
+
+  EXPECT_ANNOTATION_COUNT(output, 1);
+
+  EXPECT_ANNOTATION_ENTRY(output, "/value",
+                          "/properties/value/oneOf/0/x-custom",
+                          "#/properties/value/oneOf/0/x-custom", 1);
+  EXPECT_ANNOTATION_VALUE(output, "/value",
+                          "/properties/value/oneOf/0/x-custom",
+                          "#/properties/value/oneOf/0/x-custom", 0,
+                          sourcemeta::core::JSON{"First"});
 }
 
 TEST(annotations_success_if_then_1) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

