### PR TITLE
Implement a `SimpleOutput::release` utility method

### DIFF
--- a/src/output/include/sourcemeta/blaze/output_simple.h
+++ b/src/output/include/sourcemeta/blaze/output_simple.h
@@ -103,6 +103,13 @@ public:
     return this->annotations_;
   }
 
+  /// Move out the collected error entries, leaving this output empty. Useful to
+  /// take ownership of the trace without copying when the output is no longer
+  /// needed
+  [[nodiscard]] auto release() && -> container_type {
+    return std::move(this->output);
+  }
+
   // NOLINTNEXTLINE(bugprone-exception-escape)
   struct Location {
     auto operator<(const Location &other) const noexcept -> bool {

--- a/src/output/include/sourcemeta/blaze/output_simple.h
+++ b/src/output/include/sourcemeta/blaze/output_simple.h
@@ -107,7 +107,11 @@ public:
   /// take ownership of the trace without copying when the output is no longer
   /// needed
   [[nodiscard]] auto release() && -> container_type {
-    return std::move(this->output);
+    auto result{std::move(this->output)};
+    // A moved-from container is left in a valid but unspecified state, so
+    // clear it to honor the documented empty postcondition portably
+    this->output.clear();
+    return result;
   }
 
   // NOLINTNEXTLINE(bugprone-exception-escape)

--- a/test/output/output_simple_test.cc
+++ b/test/output/output_simple_test.cc
@@ -280,6 +280,61 @@ TEST(fail_string) {
   EXPECT_ANNOTATION_COUNT(output, 0);
 }
 
+TEST(release_yields_collected_errors_and_consumes_them) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{5};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_FALSE(result);
+
+  const auto entries{std::move(output).release()};
+
+  EXPECT_EQ(entries.size(), 1);
+  EXPECT_OUTPUT(
+      entries, 0, "", "/type", "#/type",
+      "The value was expected to be of type string but it was of type integer");
+
+  EXPECT_TRUE(output.cbegin() == output.cend());
+}
+
+TEST(release_yields_no_errors_on_success) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{"foo"};
+
+  sourcemeta::blaze::SimpleOutput output{instance};
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_TRUE(result);
+
+  const auto entries{std::move(output).release()};
+
+  EXPECT_TRUE(entries.empty());
+}
+
 TEST(fail_string_over_ref) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

