### PR TITLE
Add support for more `x-jsonld-*` keywords

### DIFF
--- a/benchmark/micro/jsonld.cc
+++ b/benchmark/micro/jsonld.cc
@@ -161,7 +161,9 @@ static auto Micro_JSONLD_Catalog(benchmark::State &state) -> void {
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
-      "x-jsonld-id", "x-jsonld-type"};
+      "x-jsonld-id",       "x-jsonld-type",     "x-jsonld-reverse",
+      "x-jsonld-datatype", "x-jsonld-language", "x-jsonld-direction",
+      "x-jsonld-json",     "x-jsonld-graph"};
   const auto schema_template{sourcemeta::blaze::compile(
       schema, sourcemeta::blaze::schema_walker,
       sourcemeta::blaze::schema_resolver,

--- a/benchmark/micro/jsonld.cc
+++ b/benchmark/micro/jsonld.cc
@@ -161,9 +161,8 @@ static auto Micro_JSONLD_Catalog(benchmark::State &state) -> void {
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
-      "x-jsonld-id",       "x-jsonld-type",     "x-jsonld-reverse",
-      "x-jsonld-datatype", "x-jsonld-language", "x-jsonld-direction",
-      "x-jsonld-json",     "x-jsonld-graph"};
+      sourcemeta::blaze::JSONLD_KEYWORDS.begin(),
+      sourcemeta::blaze::JSONLD_KEYWORDS.end()};
   const auto schema_template{sourcemeta::blaze::compile(
       schema, sourcemeta::blaze::schema_walker,
       sourcemeta::blaze::schema_resolver,

--- a/contrib/jsonld.cc
+++ b/contrib/jsonld.cc
@@ -39,9 +39,8 @@ static auto run(const char *schema_path, const char *instance_path) -> int {
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
-      "x-jsonld-id",       "x-jsonld-type",     "x-jsonld-reverse",
-      "x-jsonld-datatype", "x-jsonld-language", "x-jsonld-direction",
-      "x-jsonld-json",     "x-jsonld-graph"};
+      sourcemeta::blaze::JSONLD_KEYWORDS.begin(),
+      sourcemeta::blaze::JSONLD_KEYWORDS.end()};
   const auto schema_template{sourcemeta::blaze::compile(
       schema, sourcemeta::blaze::schema_walker,
       sourcemeta::blaze::schema_resolver,

--- a/contrib/jsonld.cc
+++ b/contrib/jsonld.cc
@@ -39,7 +39,9 @@ static auto run(const char *schema_path, const char *instance_path) -> int {
 
   sourcemeta::blaze::Tweaks tweaks;
   tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
-      "x-jsonld-id", "x-jsonld-type"};
+      "x-jsonld-id",       "x-jsonld-type",     "x-jsonld-reverse",
+      "x-jsonld-datatype", "x-jsonld-language", "x-jsonld-direction",
+      "x-jsonld-json",     "x-jsonld-graph"};
   const auto schema_template{sourcemeta::blaze::compile(
       schema, sourcemeta::blaze::schema_walker,
       sourcemeta::blaze::schema_resolver,

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -19,6 +19,8 @@ target_link_libraries(sourcemeta_blaze_output PRIVATE
   sourcemeta::core::jsonld)
 target_link_libraries(sourcemeta_blaze_output PRIVATE
   sourcemeta::core::langtag)
+target_link_libraries(sourcemeta_blaze_output PRIVATE
+  sourcemeta::core::text)
 target_link_libraries(sourcemeta_blaze_output PUBLIC
   sourcemeta::blaze::foundation)
 target_link_libraries(sourcemeta_blaze_output PUBLIC

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -17,6 +17,8 @@ target_link_libraries(sourcemeta_blaze_output PUBLIC
   sourcemeta::core::jsonpointer)
 target_link_libraries(sourcemeta_blaze_output PRIVATE
   sourcemeta::core::jsonld)
+target_link_libraries(sourcemeta_blaze_output PRIVATE
+  sourcemeta::core::langtag)
 target_link_libraries(sourcemeta_blaze_output PUBLIC
   sourcemeta::blaze::foundation)
 target_link_libraries(sourcemeta_blaze_output PUBLIC

--- a/src/output/include/sourcemeta/blaze/output_jsonld.h
+++ b/src/output/include/sourcemeta/blaze/output_jsonld.h
@@ -23,10 +23,9 @@ namespace sourcemeta::blaze {
 /// The x-jsonld-* keywords that jsonld() resolves. Use these as the annotation
 /// whitelist when compiling a schema so that its annotations are collected.
 inline constexpr std::array<sourcemeta::core::JSON::StringView, 8>
-    JSONLD_KEYWORDS{"x-jsonld-id",       "x-jsonld-type",
-                    "x-jsonld-reverse",  "x-jsonld-datatype",
-                    "x-jsonld-language", "x-jsonld-direction",
-                    "x-jsonld-json",     "x-jsonld-graph"};
+    JSONLD_KEYWORDS{{"x-jsonld-id", "x-jsonld-type", "x-jsonld-reverse",
+                     "x-jsonld-datatype", "x-jsonld-language",
+                     "x-jsonld-direction", "x-jsonld-json", "x-jsonld-graph"}};
 
 /// @ingroup output
 /// The descriptor facet that a JSON-LD resolution error is about

--- a/src/output/include/sourcemeta/blaze/output_jsonld.h
+++ b/src/output/include/sourcemeta/blaze/output_jsonld.h
@@ -20,7 +20,15 @@ namespace sourcemeta::blaze {
 
 /// @ingroup output
 /// The descriptor facet that a JSON-LD resolution error is about
-enum class JSONLDFacet : std::uint8_t { Type, Predicate };
+enum class JSONLDFacet : std::uint8_t {
+  Type,
+  Predicate,
+  Datatype,
+  Language,
+  Direction,
+  Graph,
+  JSON
+};
 
 /// @ingroup output
 /// The instance conforms but one of its JSON-LD annotations cannot be resolved

--- a/src/output/include/sourcemeta/blaze/output_jsonld.h
+++ b/src/output/include/sourcemeta/blaze/output_jsonld.h
@@ -11,12 +11,22 @@
 #include <sourcemeta/blaze/evaluator.h>
 #include <sourcemeta/blaze/output_simple.h>
 
+#include <array>   // std::array
 #include <cstdint> // std::uint8_t
 #include <string>  // std::string
 #include <variant> // std::variant
 #include <vector>  // std::vector
 
 namespace sourcemeta::blaze {
+
+/// @ingroup output
+/// The x-jsonld-* keywords that jsonld() resolves. Use these as the annotation
+/// whitelist when compiling a schema so that its annotations are collected.
+inline constexpr std::array<sourcemeta::core::JSON::StringView, 8>
+    JSONLD_KEYWORDS{"x-jsonld-id",       "x-jsonld-type",
+                    "x-jsonld-reverse",  "x-jsonld-datatype",
+                    "x-jsonld-language", "x-jsonld-direction",
+                    "x-jsonld-json",     "x-jsonld-graph"};
 
 /// @ingroup output
 /// The descriptor facet that a JSON-LD resolution error is about
@@ -80,8 +90,9 @@ using JSONLDOutcome =
 /// })JSON");
 ///
 /// sourcemeta::blaze::Tweaks tweaks;
-/// tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>{
-///     "x-jsonld-id", "x-jsonld-type"};
+/// tweaks.annotations = std::unordered_set<sourcemeta::core::JSON::StringView>(
+///     sourcemeta::blaze::JSONLD_KEYWORDS.begin(),
+///     sourcemeta::blaze::JSONLD_KEYWORDS.end());
 ///
 /// const auto schema_template{sourcemeta::blaze::compile(
 ///     schema, sourcemeta::blaze::schema_walker,

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -2,29 +2,45 @@
 
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/langtag.h>
 #include <sourcemeta/core/uri.h>
 
-#include <algorithm>  // std::ranges::sort, std::ranges::any_of
-#include <functional> // std::ref
-#include <tuple>      // std::tie
-#include <utility>    // std::move
-#include <variant>    // std::variant, std::get, std::holds_alternative
-#include <vector>     // std::vector
+#include <algorithm>     // std::ranges::sort, std::ranges::any_of
+#include <functional>    // std::ref
+#include <optional>      // std::optional
+#include <string>        // std::string
+#include <tuple>         // std::tie
+#include <unordered_map> // std::unordered_map
+#include <utility>       // std::move
+#include <variant>       // std::variant, std::get, std::holds_alternative
+#include <vector>        // std::vector
 
 namespace {
 
-// Default the undescribed elements of a collection: a scalar becomes a native
-// literal, and a nested array becomes an inner (unordered) collection, whose
-// own elements are filled the same way. As unordered collections, nested arrays
-// flatten into their parent during materialization. Elements that already carry
-// a descriptor are left untouched.
+// The facts gathered at one instance location before its kind is known
+struct Facts {
+  std::vector<sourcemeta::core::JSONLDEdge> edges;
+  std::vector<sourcemeta::core::JSON::String> types;
+  std::optional<sourcemeta::core::JSON::String> datatype;
+  std::optional<sourcemeta::core::JSON::String> language;
+  std::optional<sourcemeta::core::JSONLDDirection> direction;
+  bool json{false};
+  bool graph{false};
+};
+
+using Accumulator = std::unordered_map<sourcemeta::core::WeakPointer, Facts,
+                                       sourcemeta::core::WeakPointer::Hasher>;
+
+// Give the undescribed elements of a collection a default kind so they still
+// materialize, a scalar as a literal and a nested array as an inner collection
 auto fill_collection(sourcemeta::core::JSONLDWeakAnnotationMap &map,
+                     const Accumulator &accumulator,
                      const sourcemeta::core::WeakPointer &pointer,
                      const sourcemeta::core::JSON &array) -> void {
   for (std::size_t index = 0; index < array.size(); index += 1) {
     auto element_pointer{pointer};
     element_pointer.push_back(index);
-    if (map.contains(element_pointer)) {
+    if (accumulator.contains(element_pointer)) {
       continue;
     }
 
@@ -34,7 +50,7 @@ auto fill_collection(sourcemeta::core::JSONLDWeakAnnotationMap &map,
           element_pointer,
           sourcemeta::core::JSONLDDescriptor{
               .edges = {}, .value = sourcemeta::core::JSONLDCollection{}});
-      fill_collection(map, element_pointer, element);
+      fill_collection(map, accumulator, element_pointer, element);
     } else if (!element.is_object()) {
       map.emplace(std::move(element_pointer),
                   sourcemeta::core::JSONLDDescriptor{
@@ -79,20 +95,125 @@ auto type_iri_error(const sourcemeta::core::WeakPointer &instance_location)
           .message = "The value of x-jsonld-type must be an absolute IRI"};
 }
 
-// Turn the applicable x-jsonld-* annotations into a resolved annotation map, or
-// into the first resolution error found. Only x-jsonld-id and x-jsonld-type are
-// handled for now, so resolution fails on a malformed IRI value or on a type
-// assigned to a position that does not denote a node.
+auto facet_error(const sourcemeta::core::WeakPointer &instance_location,
+                 const sourcemeta::blaze::JSONLDFacet facet,
+                 std::string message)
+    -> sourcemeta::blaze::JSONLDResolutionError {
+  return {.instance_location = sourcemeta::core::to_pointer(instance_location),
+          .facet = facet,
+          .message = std::move(message)};
+}
+
+auto parse_direction(const sourcemeta::core::JSON &value)
+    -> std::optional<sourcemeta::core::JSONLDDirection> {
+  if (!value.is_string()) {
+    return std::nullopt;
+  }
+
+  const auto &text{value.to_string()};
+  if (text == "ltr") {
+    return sourcemeta::core::JSONLDDirection::LTR;
+  }
+  if (text == "rtl") {
+    return sourcemeta::core::JSONLDDirection::RTL;
+  }
+
+  return std::nullopt;
+}
+
+// Whether the facts suit the value shape, as a node fact needs an object and a
+// literal fact needs a scalar. Returns the first mismatch, or nothing
+auto placement_error(const sourcemeta::core::WeakPointer &pointer,
+                     const Facts &facts, const sourcemeta::core::JSON &value)
+    -> std::optional<sourcemeta::blaze::JSONLDResolutionError> {
+  if (!value.is_object()) {
+    if (!facts.types.empty()) {
+      return facet_error(
+          pointer, sourcemeta::blaze::JSONLDFacet::Type,
+          "A JSON-LD type can only be assigned to an object value");
+    }
+
+    if (facts.graph) {
+      return facet_error(
+          pointer, sourcemeta::blaze::JSONLDFacet::Graph,
+          "A JSON-LD graph flag can only be assigned to an object value");
+    }
+  }
+
+  if (!value.is_object() && !value.is_array()) {
+    return std::nullopt;
+  }
+
+  if (facts.datatype.has_value()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Datatype,
+        "A JSON-LD datatype can only be assigned to a scalar value");
+  }
+
+  if (facts.language.has_value()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Language,
+        "A JSON-LD language can only be assigned to a scalar value");
+  }
+
+  if (facts.direction.has_value()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Direction,
+        "A JSON-LD direction can only be assigned to a scalar value");
+  }
+
+  if (facts.json) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::JSON,
+        "A JSON-LD JSON literal can only be assigned to a scalar value");
+  }
+
+  return std::nullopt;
+}
+
+// The constraints among literal facts, as an opaque value cannot also be typed
+// or tagged, a datatype excludes a language or direction, and a language or
+// direction needs a string. Returns the first violation, or nothing
+auto literal_error(const sourcemeta::core::WeakPointer &pointer,
+                   const Facts &facts, const sourcemeta::core::JSON &value)
+    -> std::optional<sourcemeta::blaze::JSONLDResolutionError> {
+  if (facts.json && (facts.datatype.has_value() || facts.language.has_value() ||
+                     facts.direction.has_value())) {
+    return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::JSON,
+                       "A JSON-LD JSON literal cannot carry a datatype, "
+                       "language, or direction");
+  }
+
+  if (facts.datatype.has_value() &&
+      (facts.language.has_value() || facts.direction.has_value())) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Datatype,
+        "A JSON-LD datatype cannot carry a language or direction");
+  }
+
+  if (facts.language.has_value() && !value.is_string()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Language,
+        "A JSON-LD language can only be assigned to a string value");
+  }
+
+  if (facts.direction.has_value() && !value.is_string()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Direction,
+        "A JSON-LD direction can only be assigned to a string value");
+  }
+
+  return std::nullopt;
+}
+
+// Turn the JSON-LD annotations into a resolved map, or the first error found.
+// The first pass groups the facts by location, the second derives each kind
+// from the value shape and validates the facts against it
 auto resolve(const sourcemeta::core::JSON &instance,
              const sourcemeta::blaze::SimpleOutput &output)
     -> std::variant<sourcemeta::core::JSONLDWeakAnnotationMap,
                     sourcemeta::blaze::JSONLDResolutionError> {
-  // Accumulate straight into the descriptor map so that each instance location
-  // is hashed once, rather than once into a scratch map and again into the
-  // output. Edges and provisional types land on the default node descriptor;
-  // the second pass settles the descriptor kind once the value shape is known.
-  sourcemeta::core::JSONLDWeakAnnotationMap map;
-  map.reserve(output.annotations().size());
+  Accumulator accumulator;
 
   for (const auto &[location, values] : output.annotations()) {
     if (location.evaluate_path.empty()) {
@@ -100,102 +221,192 @@ auto resolve(const sourcemeta::core::JSON &instance,
     }
 
     const auto &keyword{location.evaluate_path.back().to_property()};
-    // Only the keywords resolved below may contribute facts. An unhandled
-    // keyword must not create a map entry, as the empty facts would otherwise
-    // materialize a spurious node or literal descriptor
-    if (keyword != "x-jsonld-id" && keyword != "x-jsonld-type") {
-      continue;
-    }
+    const auto &instance_location{location.instance_location};
 
-    auto &descriptor{map[location.instance_location]};
-    if (keyword == "x-jsonld-id") {
+    if (keyword == "x-jsonld-id" || keyword == "x-jsonld-reverse") {
+      const bool reverse{keyword == "x-jsonld-reverse"};
       for (const auto &value : values) {
         if (!is_iri_value(value)) {
-          return sourcemeta::blaze::JSONLDResolutionError{
-              .instance_location =
-                  sourcemeta::core::to_pointer(location.instance_location),
-              .facet = sourcemeta::blaze::JSONLDFacet::Predicate,
-              .message = "The value of x-jsonld-id must be an absolute IRI"};
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Predicate,
+              reverse ? "The value of x-jsonld-reverse must be an absolute IRI"
+                      : "The value of x-jsonld-id must be an absolute IRI");
         }
 
-        add_edge(descriptor.edges, value.to_string(), false);
+        add_edge(accumulator[instance_location].edges, value.to_string(),
+                 reverse);
       }
     } else if (keyword == "x-jsonld-type") {
-      auto &types{
-          std::get<sourcemeta::core::JSONLDNode>(descriptor.value).types};
+      auto &types{accumulator[instance_location].types};
       for (const auto &value : values) {
         if (value.is_array()) {
           for (const auto &element : value.as_array()) {
             if (!is_iri_value(element)) {
-              return type_iri_error(location.instance_location);
+              return type_iri_error(instance_location);
             }
 
             add_type(types, element.to_string());
           }
         } else {
           if (!is_iri_value(value)) {
-            return type_iri_error(location.instance_location);
+            return type_iri_error(instance_location);
           }
 
           add_type(types, value.to_string());
         }
       }
+    } else if (keyword == "x-jsonld-datatype") {
+      for (const auto &value : values) {
+        if (!is_iri_value(value)) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Datatype,
+              "The value of x-jsonld-datatype must be an absolute IRI");
+        }
+
+        auto &datatype{accumulator[instance_location].datatype};
+        if (datatype.has_value() && datatype.value() != value.to_string()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Datatype,
+              "A JSON-LD datatype cannot be assigned more than one value");
+        }
+
+        datatype = value.to_string();
+      }
+    } else if (keyword == "x-jsonld-language") {
+      for (const auto &value : values) {
+        if (!value.is_string() ||
+            !sourcemeta::core::is_langtag(value.to_string())) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Language,
+              "The value of x-jsonld-language must be a BCP 47 language tag");
+        }
+
+        auto &language{accumulator[instance_location].language};
+        if (language.has_value() && language.value() != value.to_string()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Language,
+              "A JSON-LD language cannot be assigned more than one value");
+        }
+
+        language = value.to_string();
+      }
+    } else if (keyword == "x-jsonld-direction") {
+      for (const auto &value : values) {
+        const auto parsed{parse_direction(value)};
+        if (!parsed.has_value()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Direction,
+              R"(The value of x-jsonld-direction must be "ltr" or "rtl")");
+        }
+
+        auto &direction{accumulator[instance_location].direction};
+        if (direction.has_value() && direction.value() != parsed.value()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Direction,
+              "A JSON-LD direction cannot be assigned more than one value");
+        }
+
+        direction = parsed;
+      }
+    } else if (keyword == "x-jsonld-json") {
+      for (const auto &value : values) {
+        if (!value.is_boolean()) {
+          return facet_error(instance_location,
+                             sourcemeta::blaze::JSONLDFacet::JSON,
+                             "The value of x-jsonld-json must be a boolean");
+        }
+
+        accumulator[instance_location].json =
+            accumulator[instance_location].json || value.to_boolean();
+      }
+    } else if (keyword == "x-jsonld-graph") {
+      for (const auto &value : values) {
+        if (!value.is_boolean()) {
+          return facet_error(instance_location,
+                             sourcemeta::blaze::JSONLDFacet::Graph,
+                             "The value of x-jsonld-graph must be a boolean");
+        }
+
+        accumulator[instance_location].graph =
+            accumulator[instance_location].graph || value.to_boolean();
+      }
     }
   }
 
-  // Settle each descriptor in place, so no location is hashed a second time,
-  // and note the array locations whose undescribed elements must be filled once
-  // the map is no longer being iterated.
-  std::vector<sourcemeta::core::WeakPointer> collections;
-  for (auto &[pointer, descriptor] : map) {
-    std::ranges::sort(descriptor.edges,
+  sourcemeta::core::JSONLDWeakAnnotationMap map;
+  map.reserve(accumulator.size());
+  for (auto &[pointer, facts] : accumulator) {
+    std::ranges::sort(facts.edges,
                       [](const sourcemeta::core::JSONLDEdge &left,
                          const sourcemeta::core::JSONLDEdge &right) -> bool {
                         return std::tie(left.predicate, left.reverse) <
                                std::tie(right.predicate, right.reverse);
                       });
-    auto &types{std::get<sourcemeta::core::JSONLDNode>(descriptor.value).types};
-    std::ranges::sort(types);
+    std::ranges::sort(facts.types);
 
     const auto &value{sourcemeta::core::get(instance, pointer)};
 
-    // A type denotes an rdf:type, which only a node can carry
-    if (!value.is_object() && !types.empty()) {
-      return sourcemeta::blaze::JSONLDResolutionError{
-          .instance_location = sourcemeta::core::to_pointer(pointer),
-          .facet = sourcemeta::blaze::JSONLDFacet::Type,
-          .message = "A JSON-LD type can only be assigned to an object value"};
+    if (const auto error{placement_error(pointer, facts, value)};
+        error.has_value()) {
+      return error.value();
     }
 
-    // A predicate is only meaningful on an object property, whose parent node
-    // it attaches to. The document root (an empty pointer) has no parent, and
-    // an array element (an index token) inherits the enclosing edge, so a
-    // predicate on either is an error. A type on such a position is fine when
-    // it is a node.
-    if (!descriptor.edges.empty() &&
+    if (const auto error{literal_error(pointer, facts, value)};
+        error.has_value()) {
+      return error.value();
+    }
+
+    // A predicate attaches to the parent node of an object property. The
+    // document root has no parent and an array element inherits the enclosing
+    // edge, so neither can carry one
+    if (!facts.edges.empty() &&
         (pointer.empty() || !pointer.back().is_property())) {
-      return sourcemeta::blaze::JSONLDResolutionError{
-          .instance_location = sourcemeta::core::to_pointer(pointer),
-          .facet = sourcemeta::blaze::JSONLDFacet::Predicate,
-          .message = pointer.empty()
-                         ? "A JSON-LD predicate cannot be assigned to the "
-                           "document root"
-                         : "A JSON-LD predicate cannot be assigned to an array "
-                           "element"};
+      return facet_error(
+          pointer, sourcemeta::blaze::JSONLDFacet::Predicate,
+          pointer.empty()
+              ? "A JSON-LD predicate cannot be assigned to the document root"
+              : "A JSON-LD predicate cannot be assigned to an array element");
     }
 
-    // The descriptor already carries a node with the collected types; only the
-    // non-object shapes need their kind corrected.
-    if (value.is_array()) {
+    // A reverse predicate makes its value the subject, so the value must be a
+    // node or an array of nodes. A literal cannot be a subject
+    if (std::ranges::any_of(
+            facts.edges, [](const sourcemeta::core::JSONLDEdge &edge) -> bool {
+              return edge.reverse;
+            })) {
+      const bool points_to_node{
+          value.is_object() ||
+          (value.is_array() &&
+           std::ranges::all_of(value.as_array(),
+                               [](const sourcemeta::core::JSON &element)
+                                   -> bool { return element.is_object(); }))};
+      if (!points_to_node) {
+        return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Predicate,
+                           "A JSON-LD reverse predicate can only point to a "
+                           "node or an array of nodes");
+      }
+    }
+
+    sourcemeta::core::JSONLDDescriptor descriptor;
+    descriptor.edges = std::move(facts.edges);
+    if (value.is_object()) {
+      descriptor.value = sourcemeta::core::JSONLDNode{
+          .id = {}, .types = std::move(facts.types), .graph = facts.graph};
+    } else if (value.is_array()) {
       descriptor.value = sourcemeta::core::JSONLDCollection{};
-      collections.push_back(pointer);
-    } else if (!value.is_object()) {
-      descriptor.value = sourcemeta::core::JSONLDLiteral{};
+    } else {
+      descriptor.value =
+          sourcemeta::core::JSONLDLiteral{.datatype = std::move(facts.datatype),
+                                          .language = std::move(facts.language),
+                                          .direction = facts.direction,
+                                          .json = facts.json};
     }
-  }
 
-  for (const auto &pointer : collections) {
-    fill_collection(map, pointer, sourcemeta::core::get(instance, pointer));
+    map.emplace(pointer, std::move(descriptor));
+
+    if (value.is_array()) {
+      fill_collection(map, accumulator, pointer, value);
+    }
   }
 
   return map;

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -3,6 +3,7 @@
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/langtag.h>
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include <algorithm>     // std::ranges::sort, std::ranges::any_of
@@ -162,28 +163,15 @@ auto placement_error(const sourcemeta::core::WeakPointer &pointer,
         "A JSON-LD direction can only be assigned to a scalar value");
   }
 
-  if (facts.json) {
-    return facet_error(
-        pointer, sourcemeta::blaze::JSONLDFacet::JSON,
-        "A JSON-LD JSON literal can only be assigned to a scalar value");
-  }
-
   return std::nullopt;
 }
 
-// The constraints among literal facts, as an opaque value cannot also be typed
-// or tagged, a datatype excludes a language or direction, and a language or
-// direction needs a string. Returns the first violation, or nothing
+// The constraints among literal facts, as a datatype excludes a language or
+// direction, and a language or direction needs a string. Returns the first
+// violation, or nothing
 auto literal_error(const sourcemeta::core::WeakPointer &pointer,
                    const Facts &facts, const sourcemeta::core::JSON &value)
     -> std::optional<sourcemeta::blaze::JSONLDResolutionError> {
-  if (facts.json && (facts.datatype.has_value() || facts.language.has_value() ||
-                     facts.direction.has_value())) {
-    return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::JSON,
-                       "A JSON-LD JSON literal cannot carry a datatype, "
-                       "language, or direction");
-  }
-
   if (facts.datatype.has_value() &&
       (facts.language.has_value() || facts.direction.has_value())) {
     return facet_error(
@@ -282,13 +270,18 @@ auto resolve(const sourcemeta::core::JSON &instance,
         }
 
         auto &language{accumulator[instance_location].language};
-        if (language.has_value() && language.value() != value.to_string()) {
-          return facet_error(
-              instance_location, sourcemeta::blaze::JSONLDFacet::Language,
-              "A JSON-LD language cannot be assigned more than one value");
+        if (language.has_value()) {
+          // Language tags compare case-insensitively, so the first spelling is
+          // kept and only a genuinely different tag is a conflict
+          if (!sourcemeta::core::equals_ignore_case(language.value(),
+                                                    value.to_string())) {
+            return facet_error(
+                instance_location, sourcemeta::blaze::JSONLDFacet::Language,
+                "A JSON-LD language cannot be assigned more than one value");
+          }
+        } else {
+          language = value.to_string();
         }
-
-        language = value.to_string();
       }
     } else if (keyword == "x-jsonld-direction") {
       for (const auto &value : values) {
@@ -316,8 +309,11 @@ auto resolve(const sourcemeta::core::JSON &instance,
                              "The value of x-jsonld-json must be a boolean");
         }
 
-        accumulator[instance_location].json =
-            accumulator[instance_location].json || value.to_boolean();
+        // A false value leaves the fact unset, so it must stay a no-op and not
+        // create an entry
+        if (value.to_boolean()) {
+          accumulator[instance_location].json = true;
+        }
       }
     } else if (keyword == "x-jsonld-graph") {
       for (const auto &value : values) {
@@ -327,8 +323,9 @@ auto resolve(const sourcemeta::core::JSON &instance,
                              "The value of x-jsonld-graph must be a boolean");
         }
 
-        accumulator[instance_location].graph =
-            accumulator[instance_location].graph || value.to_boolean();
+        if (value.to_boolean()) {
+          accumulator[instance_location].graph = true;
+        }
       }
     }
   }
@@ -345,6 +342,16 @@ auto resolve(const sourcemeta::core::JSON &instance,
     std::ranges::sort(facts.types);
 
     const auto &value{sourcemeta::core::get(instance, pointer)};
+
+    // A JSON literal preserves any value verbatim, so it stands alone and
+    // excludes every other fact
+    if (facts.json &&
+        (!facts.types.empty() || facts.graph || facts.datatype.has_value() ||
+         facts.language.has_value() || facts.direction.has_value())) {
+      return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::JSON,
+                         "A JSON-LD JSON literal cannot be combined with any "
+                         "other JSON-LD annotation");
+    }
 
     if (const auto error{placement_error(pointer, facts, value)};
         error.has_value()) {
@@ -375,11 +382,12 @@ auto resolve(const sourcemeta::core::JSON &instance,
               return edge.reverse;
             })) {
       const bool points_to_node{
-          value.is_object() ||
-          (value.is_array() &&
-           std::ranges::all_of(value.as_array(),
-                               [](const sourcemeta::core::JSON &element)
-                                   -> bool { return element.is_object(); }))};
+          !facts.json &&
+          (value.is_object() ||
+           (value.is_array() &&
+            std::ranges::all_of(value.as_array(),
+                                [](const sourcemeta::core::JSON &element)
+                                    -> bool { return element.is_object(); })))};
       if (!points_to_node) {
         return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Predicate,
                            "A JSON-LD reverse predicate can only point to a "
@@ -389,7 +397,9 @@ auto resolve(const sourcemeta::core::JSON &instance,
 
     sourcemeta::core::JSONLDDescriptor descriptor;
     descriptor.edges = std::move(facts.edges);
-    if (value.is_object()) {
+    if (facts.json) {
+      descriptor.value = sourcemeta::core::JSONLDLiteral{.json = true};
+    } else if (value.is_object()) {
       descriptor.value = sourcemeta::core::JSONLDNode{
           .id = {}, .types = std::move(facts.types), .graph = facts.graph};
     } else if (value.is_array()) {
@@ -398,13 +408,12 @@ auto resolve(const sourcemeta::core::JSON &instance,
       descriptor.value =
           sourcemeta::core::JSONLDLiteral{.datatype = std::move(facts.datatype),
                                           .language = std::move(facts.language),
-                                          .direction = facts.direction,
-                                          .json = facts.json};
+                                          .direction = facts.direction};
     }
 
     map.emplace(pointer, std::move(descriptor));
 
-    if (value.is_array()) {
+    if (value.is_array() && !facts.json) {
       fill_collection(map, accumulator, pointer, value);
     }
   }

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -2042,20 +2042,31 @@ TEST(JSONLD_json_literal) {
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
-TEST(JSONLD_json_on_object_is_a_resolution_error) {
+TEST(JSONLD_json_wraps_object) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-      "obj": { "type": "object", "x-jsonld-json": true }
+      "data": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/data",
+        "x-jsonld-json": true
+      }
     }
   })JSON")};
 
-  const auto instance{sourcemeta::core::parse_json(R"JSON({ "obj": {} })JSON")};
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "data": { "a": 1, "b": [ 2, 3 ] } })JSON")};
 
-  EXPECT_JSON_LD_RESOLUTION_ERROR(
-      schema, instance, "/obj", sourcemeta::blaze::JSONLDFacet::JSON,
-      "A JSON-LD JSON literal can only be assigned to a scalar value");
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/data": [
+        { "@value": { "a": 1, "b": [ 2, 3 ] }, "@type": "@json" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
 TEST(JSONLD_reverse_edge) {
@@ -2499,7 +2510,8 @@ TEST(JSONLD_json_and_datatype_is_a_resolution_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
-      "A JSON-LD JSON literal cannot carry a datatype, language, or direction");
+      "A JSON-LD JSON literal cannot be combined with any other JSON-LD "
+      "annotation");
 }
 
 TEST(JSONLD_json_and_language_is_a_resolution_error) {
@@ -2519,7 +2531,8 @@ TEST(JSONLD_json_and_language_is_a_resolution_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
-      "A JSON-LD JSON literal cannot carry a datatype, language, or direction");
+      "A JSON-LD JSON literal cannot be combined with any other JSON-LD "
+      "annotation");
 }
 
 TEST(JSONLD_json_false_is_a_plain_literal) {
@@ -2580,25 +2593,31 @@ TEST(JSONLD_json_non_boolean_is_a_resolution_error) {
       "The value of x-jsonld-json must be a boolean");
 }
 
-TEST(JSONLD_json_on_array_is_a_resolution_error) {
+TEST(JSONLD_json_wraps_array) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-      "x": {
+      "raw": {
         "type": "array",
-        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-id": "https://schema.org/raw",
         "x-jsonld-json": true
       }
     }
   })JSON")};
 
-  const auto instance{
-      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "raw": [ 1, "two", { "k": true } ] })JSON")};
 
-  EXPECT_JSON_LD_RESOLUTION_ERROR(
-      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
-      "A JSON-LD JSON literal can only be assigned to a scalar value");
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/raw": [
+        { "@value": [ 1, "two", { "k": true } ], "@type": "@json" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
 TEST(JSONLD_graph_false_is_a_plain_node) {
@@ -3616,7 +3635,7 @@ TEST(JSONLD_json_object_value_is_a_resolution_error) {
       "The value of x-jsonld-json must be a boolean");
 }
 
-TEST(JSONLD_language_case_differing_tags_conflict) {
+TEST(JSONLD_language_case_differing_tags_do_not_conflict) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -3634,9 +3653,11 @@ TEST(JSONLD_language_case_differing_tags_conflict) {
 
   const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "hi" })JSON")};
 
-  EXPECT_JSON_LD_RESOLUTION_ERROR(
-      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
-      "A JSON-LD language cannot be assigned more than one value");
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "hi", "@language": "en" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
 TEST(JSONLD_type_object_value_is_a_resolution_error) {
@@ -3768,7 +3789,8 @@ TEST(JSONLD_json_and_graph_on_object_is_a_resolution_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/obj", sourcemeta::blaze::JSONLDFacet::JSON,
-      "A JSON-LD JSON literal can only be assigned to a scalar value");
+      "A JSON-LD JSON literal cannot be combined with any other JSON-LD "
+      "annotation");
 }
 
 TEST(JSONLD_datatype_dedup_via_ref_diamond) {
@@ -3939,6 +3961,116 @@ TEST(JSONLD_two_people_keep_their_own_birth_dates) {
       ]
     }
   ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_false_alone_is_a_noop) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "object", "x-jsonld-graph": false } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_json_false_alone_is_a_noop) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "object", "x-jsonld-json": false } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_region_case_insensitive_no_conflict) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-language": "en-US" },
+          { "x-jsonld-language": "en-us" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "hi" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "hi", "@language": "en-US" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_json_and_type_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-json": true,
+        "x-jsonld-type": "https://schema.org/Thing"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal cannot be combined with any other JSON-LD "
+      "annotation");
+}
+
+TEST(JSONLD_reverse_to_json_literal_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-reverse": "https://schema.org/x",
+        "x-jsonld-json": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_json_object_without_edge_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "object", "x-jsonld-json": true } }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "a": 1 } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
 
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -27,7 +27,10 @@
       sourcemeta::blaze::jsonld(evaluator, schema_template, (instance))};
 
 #define JSON_LD_EVALUATE(schema, instance)                                     \
-  JSON_LD_EVALUATE_WITH(schema, instance, "x-jsonld-id", "x-jsonld-type")
+  JSON_LD_EVALUATE_WITH(schema, instance, "x-jsonld-id", "x-jsonld-type",      \
+                        "x-jsonld-reverse", "x-jsonld-datatype",               \
+                        "x-jsonld-language", "x-jsonld-direction",             \
+                        "x-jsonld-json", "x-jsonld-graph")
 
 #define EXPECT_JSON_LD_VALUE_WITH(schema, instance, expected, ...)             \
   {                                                                            \
@@ -39,8 +42,10 @@
   }
 
 #define EXPECT_JSON_LD_VALUE(schema, instance, expected)                       \
-  EXPECT_JSON_LD_VALUE_WITH(schema, instance, expected, "x-jsonld-id",         \
-                            "x-jsonld-type")
+  EXPECT_JSON_LD_VALUE_WITH(                                                   \
+      schema, instance, expected, "x-jsonld-id", "x-jsonld-type",              \
+      "x-jsonld-reverse", "x-jsonld-datatype", "x-jsonld-language",            \
+      "x-jsonld-direction", "x-jsonld-json", "x-jsonld-graph")
 
 #define EXPECT_JSON_LD_INVALID(schema, instance, destination)                  \
   JSON_LD_EVALUATE(schema, instance)                                           \
@@ -1572,7 +1577,7 @@ TEST(JSONLD_unwhitelisted_keyword_is_ignored) {
     "properties": {
       "d": {
         "x-jsonld-id": "https://schema.org/d",
-        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+        "x-jsonld-context": "https://schema.org/"
       }
     }
   })JSON")};
@@ -1847,4 +1852,2093 @@ TEST(JSONLD_collected_but_unhandled_keyword_creates_no_descriptor) {
 
   EXPECT_JSON_LD_VALUE_WITH(schema, instance, expected, "x-jsonld-id",
                             "x-jsonld-type", "x-jsonld-container");
+}
+
+TEST(JSONLD_datatype_explicit) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "dob": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/birthDate",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "dob": "1990-05-15" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/birthDate": [
+        {
+          "@value": "1990-05-15",
+          "@type": "http://www.w3.org/2001/XMLSchema#date"
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_non_iri_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-datatype": 42 } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_datatype_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "obj": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/o",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "obj": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/obj", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_datatype_conflict_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "allOf": [
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" },
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#string" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype cannot be assigned more than one value");
+}
+
+TEST(JSONLD_language_tagged_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "greeting": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/name",
+        "x-jsonld-language": "en"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "greeting": "hello" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [ { "@value": "hello", "@language": "en" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_invalid_tag_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-language": "en-" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "The value of x-jsonld-language must be a BCP 47 language tag");
+}
+
+TEST(JSONLD_direction_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "text": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/text",
+        "x-jsonld-direction": "rtl"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "text": "abc" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/text": [ { "@value": "abc", "@direction": "rtl" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_direction_invalid_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-direction": "up" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Direction,
+      R"(The value of x-jsonld-direction must be "ltr" or "rtl")");
+}
+
+TEST(JSONLD_json_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "blob": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/data",
+        "x-jsonld-json": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "blob": "raw" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/data": [ { "@value": "raw", "@type": "@json" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_json_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "obj": { "type": "object", "x-jsonld-json": true }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "obj": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/obj", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_reverse_edge) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "parent": {
+        "type": "object",
+        "x-jsonld-reverse": "https://schema.org/children",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "parent": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@reverse": {
+        "https://schema.org/children": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_reverse_non_iri_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-reverse": 42 } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "The value of x-jsonld-reverse must be an absolute IRI");
+}
+
+TEST(JSONLD_reverse_on_root_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-reverse": "https://schema.org/x"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD predicate cannot be assigned to the document root");
+}
+
+TEST(JSONLD_graph_node) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-graph": true,
+    "properties": {
+      "member": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/member",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "member": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@graph": [
+        {
+          "https://schema.org/member": [
+            { "@type": [ "https://schema.org/Person" ] }
+          ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_on_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-graph": true } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Graph,
+      "A JSON-LD graph flag can only be assigned to an object value");
+}
+
+TEST(JSONLD_datatype_without_edge_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "2024-01-01" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_absent_property_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_number_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "n": {
+        "type": "integer",
+        "x-jsonld-id": "https://schema.org/n",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#int"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "n": 5 })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/n": [
+        { "@value": 5, "@type": "http://www.w3.org/2001/XMLSchema#int" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_idempotent_via_allof) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" },
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "2024-01-01" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        {
+          "@value": "2024-01-01",
+          "@type": "http://www.w3.org/2001/XMLSchema#date"
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_datatype_whitespace_iri_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-datatype": " http://example.com/d" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_language_complex_tag) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-language": "zh-Hant-HK"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "text" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [ { "@value": "text", "@language": "zh-Hant-HK" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_empty_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-language": "" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "The value of x-jsonld-language must be a BCP 47 language tag");
+}
+
+TEST(JSONLD_language_non_string_keyword_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-language": 5 } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "The value of x-jsonld-language must be a BCP 47 language tag");
+}
+
+TEST(JSONLD_language_on_number_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "x-jsonld-id": "https://schema.org/x", "x-jsonld-language": "en" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": 5 })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "A JSON-LD language can only be assigned to a string value");
+}
+
+TEST(JSONLD_language_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-language": "en"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "A JSON-LD language can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_direction_uppercase_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-direction": "LTR" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Direction,
+      R"(The value of x-jsonld-direction must be "ltr" or "rtl")");
+}
+
+TEST(JSONLD_direction_on_boolean_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "x-jsonld-id": "https://schema.org/x", "x-jsonld-direction": "rtl" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": true })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Direction,
+      "A JSON-LD direction can only be assigned to a string value");
+}
+
+TEST(JSONLD_language_and_direction_i18n_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-language": "ar",
+        "x-jsonld-direction": "rtl"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "hello" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@value": "hello", "@language": "ar", "@direction": "rtl" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_and_language_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date",
+        "x-jsonld-language": "en"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype cannot carry a language or direction");
+}
+
+TEST(JSONLD_datatype_and_direction_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date",
+        "x-jsonld-direction": "ltr"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype cannot carry a language or direction");
+}
+
+TEST(JSONLD_json_and_datatype_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-json": true,
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal cannot carry a datatype, language, or direction");
+}
+
+TEST(JSONLD_json_and_language_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-json": true,
+        "x-jsonld-language": "en"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal cannot carry a datatype, language, or direction");
+}
+
+TEST(JSONLD_json_false_is_a_plain_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-json": false
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "v" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_json_on_number_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "integer",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-json": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": 5 })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": 5, "@type": "@json" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_json_non_boolean_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-json": "yes" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "The value of x-jsonld-json must be a boolean");
+}
+
+TEST(JSONLD_json_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-json": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_graph_false_is_a_plain_node) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-graph": false,
+    "properties": {
+      "member": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/member",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "member": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/member": [
+        { "@type": [ "https://schema.org/Person" ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_with_type) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-type": "https://schema.org/Dataset",
+    "x-jsonld-graph": true,
+    "properties": {
+      "member": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/member",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "member": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@type": [ "https://schema.org/Dataset" ],
+      "@graph": [
+        {
+          "https://schema.org/member": [
+            { "@type": [ "https://schema.org/Person" ] }
+          ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-graph": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Graph,
+      "A JSON-LD graph flag can only be assigned to an object value");
+}
+
+TEST(JSONLD_graph_non_boolean_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-graph": "true"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Graph,
+      "The value of x-jsonld-graph must be a boolean");
+}
+
+TEST(JSONLD_reverse_and_forward_same_predicate) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "rel": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/knows",
+        "x-jsonld-reverse": "https://schema.org/knows",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "rel": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/knows": [
+        { "@type": [ "https://schema.org/Person" ] }
+      ],
+      "@reverse": {
+        "https://schema.org/knows": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_reverse_dedup_via_allof) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "rel": {
+        "type": "object",
+        "x-jsonld-type": "https://schema.org/Person",
+        "allOf": [
+          { "x-jsonld-reverse": "https://schema.org/knows" },
+          { "x-jsonld-reverse": "https://schema.org/knows" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "rel": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@reverse": {
+        "https://schema.org/knows": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_reverse_on_array_element_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "pair": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/pair",
+        "prefixItems": [ { "x-jsonld-reverse": "https://schema.org/first" } ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "pair": [ {} ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/pair/0", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD predicate cannot be assigned to an array element");
+}
+
+TEST(JSONLD_reverse_to_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "string", "x-jsonld-reverse": "https://schema.org/name" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_reverse_to_array_of_nodes) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "authors": {
+        "type": "array",
+        "x-jsonld-reverse": "https://schema.org/author",
+        "items": {
+          "type": "object",
+          "x-jsonld-type": "https://schema.org/Person"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "authors": [ {}, {} ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@reverse": {
+        "https://schema.org/author": [
+          { "@type": [ "https://schema.org/Person" ] },
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_reverse_to_array_with_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-reverse": "https://schema.org/name" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ {}, "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_reverse_to_array_with_nested_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-reverse": "https://schema.org/name" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ {} ] ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_type_and_datatype_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-type": "https://schema.org/Thing",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_type_and_datatype_on_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-type": "https://schema.org/Thing",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Type,
+      "A JSON-LD type can only be assigned to an object value");
+}
+
+TEST(JSONLD_datatype_under_not_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "v": {
+        "not": {
+          "type": "integer",
+          "x-jsonld-id": "https://schema.org/bad",
+          "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#int"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "v": "hi" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_in_oneof_only_matching_branch) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "v": {
+        "oneOf": [
+          {
+            "type": "integer",
+            "x-jsonld-id": "https://schema.org/count",
+            "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#int"
+          },
+          { "type": "string", "x-jsonld-id": "https://schema.org/name" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "v": "hi" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/name": [ { "@value": "hi" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_in_then_branch) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "v": {
+        "if": { "type": "string" },
+        "then": {
+          "x-jsonld-id": "https://schema.org/name",
+          "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "v": "hi" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        {
+          "@value": "hi",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_and_language_across_allof_branches_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" },
+          { "x-jsonld-language": "en" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype cannot carry a language or direction");
+}
+
+TEST(JSONLD_type_and_datatype_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-type": "https://schema.org/Thing",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Type,
+      "A JSON-LD type can only be assigned to an object value");
+}
+
+TEST(JSONLD_id_and_reverse_different_predicates) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "rel": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/a",
+        "x-jsonld-reverse": "https://schema.org/b",
+        "x-jsonld-type": "https://schema.org/Person"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "rel": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/a": [
+        { "@type": [ "https://schema.org/Person" ] }
+      ],
+      "@reverse": {
+        "https://schema.org/b": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_reverse_to_empty_object) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "object", "x-jsonld-reverse": "https://schema.org/name" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "@reverse": { "https://schema.org/name": [ {} ] } }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_nested_under_edge) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "dataset": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/dataset",
+        "x-jsonld-graph": true,
+        "properties": {
+          "member": {
+            "type": "object",
+            "x-jsonld-id": "https://schema.org/member",
+            "x-jsonld-type": "https://schema.org/Person"
+          }
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "dataset": { "member": {} } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/dataset": [
+        {
+          "@graph": [
+            {
+              "https://schema.org/member": [
+                { "@type": [ "https://schema.org/Person" ] }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_on_null_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "x-jsonld-id": "https://schema.org/x", "x-jsonld-language": "en" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": null })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "A JSON-LD language can only be assigned to a string value");
+}
+
+TEST(JSONLD_datatype_relative_iri_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-datatype": "date" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_datatype_on_collection_elements) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/keywords",
+        "items": {
+          "type": "string",
+          "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#token"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/keywords": [
+        { "@value": "a", "@type": "http://www.w3.org/2001/XMLSchema#token" },
+        { "@value": "b", "@type": "http://www.w3.org/2001/XMLSchema#token" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_on_collection_elements) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "names": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/name",
+        "items": { "type": "string", "x-jsonld-language": "fr" }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "names": [ "Jean", "Marie" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        { "@value": "Jean", "@language": "fr" },
+        { "@value": "Marie", "@language": "fr" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_mixed_collection_element_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/items",
+        "items": {
+          "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "items": [ "a", {} ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/items/1", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_reverse_to_empty_array_yields_empty_document) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-reverse": "https://schema.org/name" }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": [] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_conflict_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-language": "en" },
+          { "x-jsonld-language": "fr" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "A JSON-LD language cannot be assigned more than one value");
+}
+
+TEST(JSONLD_direction_conflict_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-direction": "ltr" },
+          { "x-jsonld-direction": "rtl" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Direction,
+      "A JSON-LD direction cannot be assigned more than one value");
+}
+
+TEST(JSONLD_language_idempotent_via_allof) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-language": "en" },
+          { "x-jsonld-language": "en" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "hi" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "hi", "@language": "en" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_array_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-datatype": [ "http://www.w3.org/2001/XMLSchema#date" ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_datatype_keyword_iri_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-datatype": "@json" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_datatype_urn_scheme_accepted) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "urn:example:kind"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "v", "@type": "urn:example:kind" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_private_use_tag_accepted) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-language": "x-private"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "v", "@language": "x-private" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_root_scalar_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON("v")JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_type_on_root_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "x-jsonld-type": "https://schema.org/Thing"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON("v")JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Type,
+      "A JSON-LD type can only be assigned to an object value");
+}
+
+TEST(JSONLD_datatype_on_root_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_json_on_null_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "x-jsonld-id": "https://schema.org/x", "x-jsonld-json": true }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": null })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_null_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": null })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_falsy_zero) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#int"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": 0 })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@value": 0, "@type": "http://www.w3.org/2001/XMLSchema#int" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_anyof_datatype_conflict_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "anyOf": [
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" },
+          { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#string" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "A JSON-LD datatype cannot be assigned more than one value");
+}
+
+TEST(JSONLD_two_reverse_predicates) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "rel": {
+        "type": "object",
+        "x-jsonld-type": "https://schema.org/Person",
+        "allOf": [
+          { "x-jsonld-reverse": "https://schema.org/a" },
+          { "x-jsonld-reverse": "https://schema.org/b" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "rel": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@reverse": {
+        "https://schema.org/a": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ],
+        "https://schema.org/b": [
+          { "@type": [ "https://schema.org/Person" ] }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_datatype_on_nested_array_element_flattens) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "m": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/m",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#token"
+          }
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "m": [ [ "a" ], [ "b" ] ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/m": [
+        { "@value": "a", "@type": "http://www.w3.org/2001/XMLSchema#token" },
+        { "@value": "b", "@type": "http://www.w3.org/2001/XMLSchema#token" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_null_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-graph": null
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Graph,
+      "The value of x-jsonld-graph must be a boolean");
+}
+
+TEST(JSONLD_json_object_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-json": {} } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::JSON,
+      "The value of x-jsonld-json must be a boolean");
+}
+
+TEST(JSONLD_language_case_differing_tags_conflict) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-language": "en" },
+          { "x-jsonld-language": "EN" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "hi" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "A JSON-LD language cannot be assigned more than one value");
+}
+
+TEST(JSONLD_type_object_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-type": {}
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Type,
+      "The value of x-jsonld-type must be an absolute IRI");
+}
+
+TEST(JSONLD_type_array_with_number_element_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-type": [ "https://schema.org/A", 42 ]
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "", sourcemeta::blaze::JSONLDFacet::Type,
+      "The value of x-jsonld-type must be an absolute IRI");
+}
+
+TEST(JSONLD_id_empty_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-id": "" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "The value of x-jsonld-id must be an absolute IRI");
+}
+
+TEST(JSONLD_id_array_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-id": [ "https://schema.org/x" ] } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "The value of x-jsonld-id must be an absolute IRI");
+}
+
+TEST(JSONLD_id_boolean_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-id": true } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "The value of x-jsonld-id must be an absolute IRI");
+}
+
+TEST(JSONLD_datatype_empty_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-datatype": "" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Datatype,
+      "The value of x-jsonld-datatype must be an absolute IRI");
+}
+
+TEST(JSONLD_reverse_empty_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "object", "x-jsonld-reverse": "" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "The value of x-jsonld-reverse must be an absolute IRI");
+}
+
+TEST(JSONLD_direction_number_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-direction": 5 } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Direction,
+      R"(The value of x-jsonld-direction must be "ltr" or "rtl")");
+}
+
+TEST(JSONLD_json_and_graph_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "obj": {
+        "type": "object",
+        "x-jsonld-json": true,
+        "x-jsonld-graph": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "obj": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/obj", sourcemeta::blaze::JSONLDFacet::JSON,
+      "A JSON-LD JSON literal can only be assigned to a scalar value");
+}
+
+TEST(JSONLD_datatype_dedup_via_ref_diamond) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "dated": { "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date" }
+    },
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "$ref": "#/$defs/dated" },
+          { "$ref": "#/$defs/dated" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "2024-01-01" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        {
+          "@value": "2024-01-01",
+          "@type": "http://www.w3.org/2001/XMLSchema#date"
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_variant_subtag_accepted) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-language": "de-DE-1996"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": "hallo" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [ { "@value": "hallo", "@language": "de-DE-1996" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_graph_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "x-jsonld-graph": true
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({})JSON")};
+
+  const auto expected{
+      sourcemeta::core::parse_json(R"JSON([ { "@graph": [] } ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_language_leading_whitespace_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "x-jsonld-language": " en" } }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Language,
+      "The value of x-jsonld-language must be a BCP 47 language tag");
+}
+
+TEST(JSONLD_property_name_is_replaced_by_the_predicate) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "c": { "type": "string", "x-jsonld-id": "https://schema.org/color" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "c": "red" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/color": [ { "@value": "red" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_two_people_keep_their_own_birth_dates) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "people": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/member",
+        "items": {
+          "type": "object",
+          "x-jsonld-type": "https://schema.org/Person",
+          "properties": {
+            "name": {
+              "type": "string",
+              "x-jsonld-id": "https://schema.org/name"
+            },
+            "dob": {
+              "type": "string",
+              "x-jsonld-id": "https://schema.org/birthDate",
+              "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#date"
+            }
+          }
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({
+    "people": [
+      { "name": "Ada", "dob": "1815-12-10" },
+      { "name": "Bob", "dob": "1990-05-15" }
+    ]
+  })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/member": [
+        {
+          "@type": [ "https://schema.org/Person" ],
+          "https://schema.org/name": [ { "@value": "Ada" } ],
+          "https://schema.org/birthDate": [
+            {
+              "@value": "1815-12-10",
+              "@type": "http://www.w3.org/2001/XMLSchema#date"
+            }
+          ]
+        },
+        {
+          "@type": [ "https://schema.org/Person" ],
+          "https://schema.org/name": [ { "@value": "Bob" } ],
+          "https://schema.org/birthDate": [
+            {
+              "@value": "1990-05-15",
+              "@type": "http://www.w3.org/2001/XMLSchema#date"
+            }
+          ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -13,10 +13,9 @@
 #include <unordered_set> // std::unordered_set
 #include <variant>       // std::get, std::holds_alternative
 
-#define JSON_LD_EVALUATE_WITH(schema, instance, ...)                           \
+#define JSON_LD_EVALUATE_SET(schema, instance, annotation_set)                 \
   sourcemeta::blaze::Tweaks tweaks;                                            \
-  tweaks.annotations =                                                         \
-      std::unordered_set<sourcemeta::core::JSON::StringView>{__VA_ARGS__};     \
+  tweaks.annotations = (annotation_set);                                       \
   const auto schema_template{sourcemeta::blaze::compile(                       \
       (schema), sourcemeta::blaze::schema_walker,                              \
       sourcemeta::blaze::schema_resolver,                                      \
@@ -27,10 +26,16 @@
       sourcemeta::blaze::jsonld(evaluator, schema_template, (instance))};
 
 #define JSON_LD_EVALUATE(schema, instance)                                     \
-  JSON_LD_EVALUATE_WITH(schema, instance, "x-jsonld-id", "x-jsonld-type",      \
-                        "x-jsonld-reverse", "x-jsonld-datatype",               \
-                        "x-jsonld-language", "x-jsonld-direction",             \
-                        "x-jsonld-json", "x-jsonld-graph")
+  JSON_LD_EVALUATE_SET(                                                        \
+      schema, instance,                                                        \
+      (std::unordered_set<sourcemeta::core::JSON::StringView>(                 \
+          sourcemeta::blaze::JSONLD_KEYWORDS.begin(),                          \
+          sourcemeta::blaze::JSONLD_KEYWORDS.end())))
+
+#define JSON_LD_EVALUATE_WITH(schema, instance, ...)                           \
+  JSON_LD_EVALUATE_SET(                                                        \
+      schema, instance,                                                        \
+      (std::unordered_set<sourcemeta::core::JSON::StringView>{__VA_ARGS__}))
 
 #define EXPECT_JSON_LD_VALUE_WITH(schema, instance, expected, ...)             \
   {                                                                            \
@@ -42,10 +47,13 @@
   }
 
 #define EXPECT_JSON_LD_VALUE(schema, instance, expected)                       \
-  EXPECT_JSON_LD_VALUE_WITH(                                                   \
-      schema, instance, expected, "x-jsonld-id", "x-jsonld-type",              \
-      "x-jsonld-reverse", "x-jsonld-datatype", "x-jsonld-language",            \
-      "x-jsonld-direction", "x-jsonld-json", "x-jsonld-graph")
+  {                                                                            \
+    JSON_LD_EVALUATE(schema, instance)                                         \
+    EXPECT_TRUE(std::holds_alternative<sourcemeta::core::JSON>(outcome));      \
+    const auto &document{std::get<sourcemeta::core::JSON>(outcome)};           \
+    EXPECT_EQ(document, (expected));                                           \
+    EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));               \
+  }
 
 #define EXPECT_JSON_LD_INVALID(schema, instance, destination)                  \
   JSON_LD_EVALUATE(schema, instance)                                           \


### PR DESCRIPTION
- `x-jsonld-datatype`
- `x-jsonld-language`
- `x-jsonld-direction`
- `x-jsonld-json`
- `x-jsonld-graph`
- `x-jsonld-reverse`

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

