### PR TITLE
Support an `x-jsonld-container` keyword

### DIFF
--- a/src/output/include/sourcemeta/blaze/output_jsonld.h
+++ b/src/output/include/sourcemeta/blaze/output_jsonld.h
@@ -22,10 +22,11 @@ namespace sourcemeta::blaze {
 /// @ingroup output
 /// The x-jsonld-* keywords that jsonld() resolves. Use these as the annotation
 /// whitelist when compiling a schema so that its annotations are collected.
-inline constexpr std::array<sourcemeta::core::JSON::StringView, 8>
+inline constexpr std::array<sourcemeta::core::JSON::StringView, 9>
     JSONLD_KEYWORDS{{"x-jsonld-id", "x-jsonld-type", "x-jsonld-reverse",
                      "x-jsonld-datatype", "x-jsonld-language",
-                     "x-jsonld-direction", "x-jsonld-json", "x-jsonld-graph"}};
+                     "x-jsonld-direction", "x-jsonld-json", "x-jsonld-graph",
+                     "x-jsonld-container"}};
 
 /// @ingroup output
 /// The descriptor facet that a JSON-LD resolution error is about
@@ -36,7 +37,8 @@ enum class JSONLDFacet : std::uint8_t {
   Language,
   Direction,
   Graph,
-  JSON
+  JSON,
+  Container
 };
 
 /// @ingroup output

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -512,6 +512,20 @@ auto resolve(const sourcemeta::core::JSON &instance,
               : "A JSON-LD predicate cannot be assigned to an array element");
     }
 
+    // A container member belongs to a collection, not a node, so it has no
+    // parent to attach a predicate to
+    if (!facts.edges.empty() && !pointer.empty()) {
+      auto parent{pointer};
+      parent.pop_back();
+      const auto parent_facts{accumulator.find(parent)};
+      if (parent_facts != accumulator.cend() &&
+          parent_facts->second.container.has_value()) {
+        return facet_error(
+            pointer, sourcemeta::blaze::JSONLDFacet::Predicate,
+            "A JSON-LD predicate cannot be assigned to a container member");
+      }
+    }
+
     // A reverse predicate makes its value the subject, so the value must be a
     // node or an array of nodes. A literal cannot be a subject
     if (std::ranges::any_of(

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -204,18 +204,20 @@ auto container_placement_error(
             "A JSON-LD language container requires BCP 47 language tag keys");
       }
 
+      // A null member, or a null item in an array member, is treated as absent
       const auto &member{entry.second};
-      const bool usable{member.is_string() ||
-                        (member.is_array() &&
-                         std::ranges::all_of(
-                             member.as_array(),
-                             [](const sourcemeta::core::JSON &element) -> bool {
-                               return element.is_string();
-                             }))};
+      const bool usable{
+          member.is_null() || member.is_string() ||
+          (member.is_array() &&
+           std::ranges::all_of(
+               member.as_array(),
+               [](const sourcemeta::core::JSON &element) -> bool {
+                 return element.is_string() || element.is_null();
+               }))};
       if (!usable) {
         return facet_error(
             pointer, sourcemeta::blaze::JSONLDFacet::Container,
-            "A JSON-LD language container requires string members");
+            "A JSON-LD language container requires string or null members");
       }
     }
   }

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -25,6 +25,7 @@ struct Facts {
   std::optional<sourcemeta::core::JSON::String> datatype;
   std::optional<sourcemeta::core::JSON::String> language;
   std::optional<sourcemeta::core::JSONLDDirection> direction;
+  std::optional<sourcemeta::core::JSONLDContainer> container;
   bool json{false};
   bool graph{false};
 };
@@ -32,30 +33,52 @@ struct Facts {
 using Accumulator = std::unordered_map<sourcemeta::core::WeakPointer, Facts,
                                        sourcemeta::core::WeakPointer::Hasher>;
 
-// Give the undescribed elements of a collection a default kind so they still
-// materialize, a scalar as a literal and a nested array as an inner collection
 auto fill_collection(sourcemeta::core::JSONLDWeakAnnotationMap &map,
                      const Accumulator &accumulator,
                      const sourcemeta::core::WeakPointer &pointer,
-                     const sourcemeta::core::JSON &array) -> void {
-  for (std::size_t index = 0; index < array.size(); index += 1) {
-    auto element_pointer{pointer};
-    element_pointer.push_back(index);
-    if (accumulator.contains(element_pointer)) {
-      continue;
-    }
+                     const sourcemeta::core::JSON &value) -> void;
 
-    const auto &element{array.at(index)};
-    if (element.is_array()) {
-      map.emplace(
-          element_pointer,
-          sourcemeta::core::JSONLDDescriptor{
-              .edges = {}, .value = sourcemeta::core::JSONLDCollection{}});
-      fill_collection(map, accumulator, element_pointer, element);
-    } else if (!element.is_object()) {
-      map.emplace(std::move(element_pointer),
-                  sourcemeta::core::JSONLDDescriptor{
-                      .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+// Give an undescribed collection member a default kind so it still
+// materializes, a scalar as a literal and a nested array as an inner collection
+auto fill_element(sourcemeta::core::JSONLDWeakAnnotationMap &map,
+                  const Accumulator &accumulator,
+                  sourcemeta::core::WeakPointer element_pointer,
+                  const sourcemeta::core::JSON &element) -> void {
+  if (accumulator.contains(element_pointer)) {
+    return;
+  }
+
+  if (element.is_array()) {
+    map.emplace(
+        element_pointer,
+        sourcemeta::core::JSONLDDescriptor{
+            .edges = {}, .value = sourcemeta::core::JSONLDCollection{}});
+    fill_collection(map, accumulator, element_pointer, element);
+  } else if (!element.is_object()) {
+    map.emplace(std::move(element_pointer),
+                sourcemeta::core::JSONLDDescriptor{
+                    .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  }
+}
+
+// Default the undescribed members of a collection, whether it ranges over an
+// array or over an object
+auto fill_collection(sourcemeta::core::JSONLDWeakAnnotationMap &map,
+                     const Accumulator &accumulator,
+                     const sourcemeta::core::WeakPointer &pointer,
+                     const sourcemeta::core::JSON &value) -> void {
+  if (value.is_array()) {
+    for (std::size_t index = 0; index < value.size(); index += 1) {
+      auto element_pointer{pointer};
+      element_pointer.push_back(index);
+      fill_element(map, accumulator, std::move(element_pointer),
+                   value.at(index));
+    }
+  } else {
+    for (const auto &entry : value.as_object()) {
+      auto element_pointer{pointer};
+      element_pointer.push_back(std::cref(entry.first));
+      fill_element(map, accumulator, std::move(element_pointer), entry.second);
     }
   }
 }
@@ -117,6 +140,84 @@ auto parse_direction(const sourcemeta::core::JSON &value)
   }
   if (text == "rtl") {
     return sourcemeta::core::JSONLDDirection::RTL;
+  }
+
+  return std::nullopt;
+}
+
+auto parse_container(const sourcemeta::core::JSON &value)
+    -> std::optional<sourcemeta::core::JSONLDContainer> {
+  if (!value.is_string()) {
+    return std::nullopt;
+  }
+
+  const auto &text{value.to_string()};
+  if (text == "@list") {
+    return sourcemeta::core::JSONLDContainer::List;
+  }
+  if (text == "@set") {
+    return sourcemeta::core::JSONLDContainer::Set;
+  }
+  if (text == "@language") {
+    return sourcemeta::core::JSONLDContainer::Language;
+  }
+  if (text == "@index") {
+    return sourcemeta::core::JSONLDContainer::Index;
+  }
+
+  return std::nullopt;
+}
+
+// A container overrides the value shape, as a list or set ranges over an array
+// and a language or index map ranges over an object. A language map only holds
+// string members, which is what the materializer requires
+auto container_placement_error(
+    const sourcemeta::core::WeakPointer &pointer,
+    const sourcemeta::core::JSONLDContainer container,
+    const sourcemeta::core::JSON &value)
+    -> std::optional<sourcemeta::blaze::JSONLDResolutionError> {
+  if (container == sourcemeta::core::JSONLDContainer::List ||
+      container == sourcemeta::core::JSONLDContainer::Set) {
+    if (!value.is_array()) {
+      return facet_error(
+          pointer, sourcemeta::blaze::JSONLDFacet::Container,
+          "A JSON-LD list or set container can only be assigned to an array "
+          "value");
+    }
+
+    return std::nullopt;
+  }
+
+  if (!value.is_object()) {
+    return facet_error(
+        pointer, sourcemeta::blaze::JSONLDFacet::Container,
+        "A JSON-LD language or index container can only be assigned to an "
+        "object value");
+  }
+
+  if (container == sourcemeta::core::JSONLDContainer::Language) {
+    for (const auto &entry : value.as_object()) {
+      if (entry.first != "@none" &&
+          !sourcemeta::core::is_langtag(entry.first)) {
+        return facet_error(
+            pointer, sourcemeta::blaze::JSONLDFacet::Container,
+            "A JSON-LD language container requires BCP 47 language tag keys");
+      }
+
+      const auto &member{entry.second};
+      const bool usable{member.is_string() ||
+                        (member.is_array() &&
+                         std::ranges::all_of(
+                             member.as_array(),
+                             [](const sourcemeta::core::JSON &element) -> bool {
+                               return element.is_string();
+                             }))};
+      if (!usable) {
+        return facet_error(
+            pointer, sourcemeta::blaze::JSONLDFacet::Container,
+            "A JSON-LD language container requires string members");
+      }
+    }
   }
 
   return std::nullopt;
@@ -327,6 +428,24 @@ auto resolve(const sourcemeta::core::JSON &instance,
           accumulator[instance_location].graph = true;
         }
       }
+    } else if (keyword == "x-jsonld-container") {
+      for (const auto &value : values) {
+        const auto parsed{parse_container(value)};
+        if (!parsed.has_value()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Container,
+              R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+        }
+
+        auto &container{accumulator[instance_location].container};
+        if (container.has_value() && container.value() != parsed.value()) {
+          return facet_error(
+              instance_location, sourcemeta::blaze::JSONLDFacet::Container,
+              "A JSON-LD container cannot be assigned more than one value");
+        }
+
+        container = parsed;
+      }
     }
   }
 
@@ -342,6 +461,24 @@ auto resolve(const sourcemeta::core::JSON &instance,
     std::ranges::sort(facts.types);
 
     const auto &value{sourcemeta::core::get(instance, pointer)};
+
+    // A container sets the collection shape and stands alone, excluding every
+    // other fact and choosing the value shape it ranges over
+    if (facts.container.has_value()) {
+      if (!facts.types.empty() || facts.graph || facts.datatype.has_value() ||
+          facts.language.has_value() || facts.direction.has_value() ||
+          facts.json) {
+        return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Container,
+                           "A JSON-LD container cannot be combined with any "
+                           "other JSON-LD annotation");
+      }
+
+      if (const auto error{container_placement_error(
+              pointer, facts.container.value(), value)};
+          error.has_value()) {
+        return error.value();
+      }
+    }
 
     // A JSON literal preserves any value verbatim, so it stands alone and
     // excludes every other fact
@@ -382,7 +519,7 @@ auto resolve(const sourcemeta::core::JSON &instance,
               return edge.reverse;
             })) {
       const bool points_to_node{
-          !facts.json &&
+          !facts.json && !facts.container.has_value() &&
           (value.is_object() ||
            (value.is_array() &&
             std::ranges::all_of(value.as_array(),
@@ -399,6 +536,9 @@ auto resolve(const sourcemeta::core::JSON &instance,
     descriptor.edges = std::move(facts.edges);
     if (facts.json) {
       descriptor.value = sourcemeta::core::JSONLDLiteral{.json = true};
+    } else if (facts.container.has_value()) {
+      descriptor.value = sourcemeta::core::JSONLDCollection{
+          .container = facts.container.value()};
     } else if (value.is_object()) {
       descriptor.value = sourcemeta::core::JSONLDNode{
           .id = {}, .types = std::move(facts.types), .graph = facts.graph};
@@ -413,7 +553,14 @@ auto resolve(const sourcemeta::core::JSON &instance,
 
     map.emplace(pointer, std::move(descriptor));
 
-    if (value.is_array() && !facts.json) {
+    // A language container reads its object members directly, but every other
+    // collection needs its undescribed members defaulted so they materialize
+    if (facts.container.has_value()) {
+      if (facts.container.value() !=
+          sourcemeta::core::JSONLDContainer::Language) {
+        fill_collection(map, accumulator, pointer, value);
+      }
+    } else if (value.is_array() && !facts.json) {
       fill_collection(map, accumulator, pointer, value);
     }
   }

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -206,14 +206,13 @@ auto container_placement_error(
 
       // A null member, or a null item in an array member, is treated as absent
       const auto &member{entry.second};
-      const bool usable{
-          member.is_null() || member.is_string() ||
-          (member.is_array() &&
-           std::ranges::all_of(
-               member.as_array(),
-               [](const sourcemeta::core::JSON &element) -> bool {
-                 return element.is_string() || element.is_null();
-               }))};
+      const bool usable{member.is_null() || member.is_string() ||
+                        (member.is_array() &&
+                         std::ranges::all_of(
+                             member.as_array(),
+                             [](const sourcemeta::core::JSON &element) -> bool {
+                               return element.is_string() || element.is_null();
+                             }))};
       if (!usable) {
         return facet_error(
             pointer, sourcemeta::blaze::JSONLDFacet::Container,

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -1848,7 +1848,7 @@ TEST(JSONLD_collected_but_unhandled_keyword_creates_no_descriptor) {
     "properties": {
       "meta": {
         "type": "object",
-        "x-jsonld-container": "@index"
+        "x-jsonld-self": "https://example.com/{id}"
       }
     }
   })JSON")};
@@ -1859,7 +1859,7 @@ TEST(JSONLD_collected_but_unhandled_keyword_creates_no_descriptor) {
   const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
 
   EXPECT_JSON_LD_VALUE_WITH(schema, instance, expected, "x-jsonld-id",
-                            "x-jsonld-type", "x-jsonld-container");
+                            "x-jsonld-type", "x-jsonld-self");
 }
 
 TEST(JSONLD_datatype_explicit) {
@@ -4081,4 +4081,830 @@ TEST(JSONLD_json_object_without_edge_is_dropped) {
   const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
 
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_set_over_array) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/keywords",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/keywords": [ { "@value": "a" }, { "@value": "b" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_over_array) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "steps": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/step",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "steps": [ 1, 2, 3 ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/step": [
+        {
+          "@list": [ { "@value": 1 }, { "@value": 2 }, { "@value": 3 } ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_over_object) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/name",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "label": { "en": "Hello", "fr": "Bonjour" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        { "@value": "Hello", "@language": "en" },
+        { "@value": "Bonjour", "@language": "fr" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_array_members) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/name",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "label": { "en": [ "Hi", "Hello" ] } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        { "@value": "Hi", "@language": "en" },
+        { "@value": "Hello", "@language": "en" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_plain_values) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "data": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/data",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "data": { "a": "foo", "b": "bar" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/data": [ { "@value": "foo" }, { "@value": "bar" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_annotated_members) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "items": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/items",
+        "x-jsonld-container": "@index",
+        "additionalProperties": {
+          "type": "object",
+          "x-jsonld-type": "https://schema.org/Item"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "items": { "x": {}, "y": {} } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/items": [
+        { "@type": [ "https://schema.org/Item" ] },
+        { "@type": [ "https://schema.org/Item" ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_unknown_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-container": "@graph" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+}
+
+TEST(JSONLD_container_non_string_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "array", "x-jsonld-container": 5 } }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+}
+
+TEST(JSONLD_container_conflict_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-container": "@list" },
+          { "x-jsonld-container": "@set" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be assigned more than one value");
+}
+
+TEST(JSONLD_container_list_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD list or set container can only be assigned to an array value");
+}
+
+TEST(JSONLD_container_language_on_array_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language or index container can only be assigned to an object "
+      "value");
+}
+
+TEST(JSONLD_container_language_non_string_member_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": 5 } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires string members");
+}
+
+TEST(JSONLD_container_and_type_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set",
+        "x-jsonld-type": "https://schema.org/Thing"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be combined with any other JSON-LD "
+      "annotation");
+}
+
+TEST(JSONLD_container_and_datatype_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set",
+        "x-jsonld-datatype": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be combined with any other JSON-LD "
+      "annotation");
+}
+
+TEST(JSONLD_container_with_reverse_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-reverse": "https://schema.org/x",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ {} ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_container_without_edge_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-container": "@list" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_empty_array) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": [] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@list": [] } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_set_empty_array_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": [] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_none_key) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/name",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "label": { "@none": "plain", "en": "Hello" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        { "@value": "plain" },
+        { "@value": "Hello", "@language": "en" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_set_explicit_matches_default) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ "a" ], "b" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "a" }, { "@value": "b" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_in_oneof_only_matching_branch) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "v": {
+        "x-jsonld-id": "https://schema.org/v",
+        "oneOf": [
+          { "type": "array", "x-jsonld-container": "@list" },
+          { "type": "object", "x-jsonld-container": "@index" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "v": [ "a", "b" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/v": [
+        { "@list": [ { "@value": "a" }, { "@value": "b" } ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_under_not_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "v": {
+        "not": {
+          "type": "object",
+          "x-jsonld-id": "https://schema.org/bad",
+          "x-jsonld-container": "@index"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "v": [ "a" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_over_array_of_nodes) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list",
+        "items": {
+          "type": "object",
+          "x-jsonld-type": "https://schema.org/Person"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ {}, {} ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        {
+          "@list": [
+            { "@type": [ "https://schema.org/Person" ] },
+            { "@type": [ "https://schema.org/Person" ] }
+          ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_null_member_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "a": null, "b": "keep" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "keep" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_on_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD list or set container can only be assigned to an array value");
+}
+
+TEST(JSONLD_container_index_on_scalar_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": "v" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language or index container can only be assigned to an object "
+      "value");
+}
+
+TEST(JSONLD_container_idempotent_via_allof) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "allOf": [
+          { "x-jsonld-container": "@list" },
+          { "x-jsonld-container": "@list" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@list": [ { "@value": "a" } ] } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_nested_in_node) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "profile": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/profile",
+        "x-jsonld-type": "https://schema.org/Person",
+        "properties": {
+          "label": {
+            "type": "object",
+            "x-jsonld-id": "https://schema.org/name",
+            "x-jsonld-container": "@language"
+          }
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "profile": { "label": { "en": "Ada" } } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/profile": [
+        {
+          "@type": [ "https://schema.org/Person" ],
+          "https://schema.org/name": [ { "@value": "Ada", "@language": "en" } ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_and_graph_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index",
+        "x-jsonld-graph": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "a": 1 } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be combined with any other JSON-LD "
+      "annotation");
+}
+
+TEST(JSONLD_container_and_json_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set",
+        "x-jsonld-json": true
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ "a" ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be combined with any other JSON-LD "
+      "annotation");
+}
+
+TEST(JSONLD_container_index_empty_object_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": {} })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_empty_array_member_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": [] } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_at_root_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+    "x-jsonld-container": "@list"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON([ "a", "b" ])JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_nested_arrays_flatten) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ "a" ], "b" ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@list": [ { "@value": "a" }, { "@value": "b" } ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_invalid_key_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "not a tag": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires BCP 47 language tag keys");
 }

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -4366,7 +4366,7 @@ TEST(JSONLD_container_language_non_string_member_is_a_resolution_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
-      "A JSON-LD language container requires string members");
+      "A JSON-LD language container requires string or null members");
 }
 
 TEST(JSONLD_container_and_type_is_a_resolution_error) {
@@ -4847,6 +4847,54 @@ TEST(JSONLD_container_language_empty_array_member_is_dropped) {
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
+TEST(JSONLD_container_language_null_member_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": null } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_null_in_array_member_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "label": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/name",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "label": { "en": [ "Hi", null ] } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/name": [
+        { "@value": "Hi", "@language": "en" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
 TEST(JSONLD_container_at_root_is_dropped) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -5171,7 +5219,7 @@ TEST(JSONLD_container_language_array_with_nonstring_member_is_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
-      "A JSON-LD language container requires string members");
+      "A JSON-LD language container requires string or null members");
 }
 
 TEST(JSONLD_container_language_nested_array_member_is_error) {
@@ -5192,7 +5240,7 @@ TEST(JSONLD_container_language_nested_array_member_is_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
-      "A JSON-LD language container requires string members");
+      "A JSON-LD language container requires string or null members");
 }
 
 TEST(JSONLD_container_uppercase_value_is_a_resolution_error) {
@@ -5424,7 +5472,7 @@ TEST(JSONLD_container_language_object_member_is_error) {
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
-      "A JSON-LD language container requires string members");
+      "A JSON-LD language container requires string or null members");
 }
 
 TEST(JSONLD_container_set_single_nested_array_flattens) {

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -4908,3 +4908,651 @@ TEST(JSONLD_container_language_invalid_key_is_a_resolution_error) {
       schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
       "A JSON-LD language container requires BCP 47 language tag keys");
 }
+
+TEST(JSONLD_container_set_of_lists) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set",
+        "items": { "type": "array", "x-jsonld-container": "@list" }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ 1, 2 ], [ 3 ] ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@list": [ { "@value": 1 }, { "@value": 2 } ] },
+        { "@list": [ { "@value": 3 } ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_array_member_flattens) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "a": [ 1, 2 ], "b": "c" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@value": 1 }, { "@value": 2 }, { "@value": "c" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_undescribed_object_member_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "a": { "k": 1 } } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_edge_on_index_member_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index",
+        "additionalProperties": { "x-jsonld-id": "https://schema.org/inner" }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "a": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x/a", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD predicate cannot be assigned to a container member");
+}
+
+TEST(JSONLD_edge_on_language_member_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language",
+        "additionalProperties": { "x-jsonld-id": "https://schema.org/inner" }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x/en", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD predicate cannot be assigned to a container member");
+}
+
+TEST(JSONLD_container_language_key_case_preserved) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "EN": "hi" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "hi", "@language": "EN" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_empty_string_member) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": "" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "", "@language": "en" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_key_not_validated) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "!weird key!": "v" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "v" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_of_index_nested) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index",
+        "additionalProperties": {
+          "type": "object",
+          "x-jsonld-container": "@index"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "a": { "b": "v" } } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "v" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_with_null_element) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1, null, 2 ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@list": [ { "@value": 1 }, { "@value": 2 } ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_language_array_with_nonstring_member_is_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": [ "a", 5 ] } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires string members");
+}
+
+TEST(JSONLD_container_language_nested_array_member_is_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "en": [ [ "a" ] ] } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires string members");
+}
+
+TEST(JSONLD_container_uppercase_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": { "type": "array", "x-jsonld-container": "@LIST" }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1 ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+}
+
+TEST(JSONLD_container_language_with_reverse_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-reverse": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Predicate,
+      "A JSON-LD reverse predicate can only point to a node or an array of "
+      "nodes");
+}
+
+TEST(JSONLD_container_language_complex_tag_key) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "x": { "zh-Hant-HK": "y" } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [ { "@value": "y", "@language": "zh-Hant-HK" } ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_conflict_via_anyof_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "anyOf": [
+          { "x-jsonld-container": "@list" },
+          { "x-jsonld-container": "@set" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1 ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD container cannot be assigned more than one value");
+}
+
+TEST(JSONLD_container_set_with_null_element) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1, null ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": 1 } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_boolean_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "array", "x-jsonld-container": true } }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1 ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+}
+
+TEST(JSONLD_container_empty_string_value_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "x": { "type": "array", "x-jsonld-container": "" } }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ 1 ] })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      R"(The value of x-jsonld-container must be "@list", "@set", "@language", or "@index")");
+}
+
+TEST(JSONLD_container_list_of_nested_arrays_flatten) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ 1 ], [ 2 ] ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@list": [ { "@value": 1 }, { "@value": 2 } ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_scalar_member_with_type_is_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@index",
+        "additionalProperties": { "x-jsonld-type": "https://schema.org/Foo" }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "a": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x/a", sourcemeta::blaze::JSONLDFacet::Type,
+      "A JSON-LD type can only be assigned to an object value");
+}
+
+TEST(JSONLD_container_language_numeric_key_is_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "123": "v" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires BCP 47 language tag keys");
+}
+
+TEST(JSONLD_container_language_object_member_is_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": { "en": {} } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language container requires string members");
+}
+
+TEST(JSONLD_container_set_single_nested_array_flattens) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ [ "a" ] ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/x": [ { "@value": "a" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_index_recursive_ref_nodes) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "node": {
+        "type": "object",
+        "x-jsonld-type": "https://schema.org/Node",
+        "properties": {
+          "kids": {
+            "type": "object",
+            "x-jsonld-id": "https://schema.org/child",
+            "x-jsonld-container": "@index",
+            "additionalProperties": { "$ref": "#/$defs/node" }
+          }
+        }
+      }
+    },
+    "$ref": "#/$defs/node"
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "kids": { "a": {}, "b": {} } })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@type": [ "https://schema.org/Node" ],
+      "https://schema.org/child": [
+        { "@type": [ "https://schema.org/Node" ] },
+        { "@type": [ "https://schema.org/Node" ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_container_list_on_null_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@list"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": null })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD list or set container can only be assigned to an array value");
+}
+
+TEST(JSONLD_container_language_on_null_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@language"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(R"JSON({ "x": null })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/x", sourcemeta::blaze::JSONLDFacet::Container,
+      "A JSON-LD language or index container can only be assigned to an object "
+      "value");
+}
+
+TEST(JSONLD_container_set_over_array_of_nodes) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "x": {
+        "type": "array",
+        "x-jsonld-id": "https://schema.org/x",
+        "x-jsonld-container": "@set",
+        "items": {
+          "type": "object",
+          "x-jsonld-type": "https://schema.org/Person"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "x": [ {}, {} ] })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/x": [
+        { "@type": [ "https://schema.org/Person" ] },
+        { "@type": [ "https://schema.org/Person" ] }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

