### PR TITLE
Fix empty `if` to incorrect instance location hoisting on `then`

### DIFF
--- a/ports/javascript/describe.mjs
+++ b/ports/javascript/describe.mjs
@@ -471,6 +471,12 @@ export function describe(valid, instruction, evaluatePath,
     if (keyword === '$ref') {
       return describeReference(target);
     }
+    // For the wrapper instruction we emit when hoisting `then` subschemas
+    // whose `if` condition compiles to nothing
+    if (keyword === 'then') {
+      return 'The ' + typeName(targetType) +
+        ' value was expected to validate against the given conditional';
+    }
     return '<unknown>';
   }
 

--- a/ports/javascript/index.mjs
+++ b/ports/javascript/index.mjs
@@ -697,6 +697,22 @@ function evaluateInstructionFastCallback(instruction, instance, depth, template,
   return handler(instruction, instance, depth, template, evaluator);
 }
 
+// Evaluate an entire subtree without emitting callbacks, while still
+// maintaining the schema resources stack for dynamic anchor resolution,
+// mirroring `evaluate_instruction_without_callback` from the C++ evaluator
+function evaluateInstructionWithoutCallback(instruction, instance, depth, template, evaluator) {
+  const previousDispatch = evaluateInstruction;
+  const previousCallbackMode = evaluator.callbackMode;
+  evaluateInstruction = (evaluator.trackMode || evaluator.dynamicMode)
+    ? evaluateInstructionTracked
+    : evaluateInstructionFast;
+  evaluator.callbackMode = false;
+  const result = evaluateInstruction(instruction, instance, depth, template, evaluator);
+  evaluateInstruction = previousDispatch;
+  evaluator.callbackMode = previousCallbackMode;
+  return result;
+}
+
 function evaluateInstructionTrackedCallback(instruction, instance, depth, template, evaluator) {
   if (depth > DEPTH_LIMIT) {
     throw new Error('The evaluation path depth limit was reached likely due to infinite recursion');
@@ -1551,7 +1567,7 @@ function AssertionObjectPropertiesSimple(instruction, instance, depth, template,
       continue;
     }
     if (index < children.length) {
-      if (!evaluateInstructionFast(children[index], target[name], depth + 1, template, evaluator)) {
+      if (!evaluateInstructionWithoutCallback(children[index], target[name], depth + 1, template, evaluator)) {
         if (evaluator.callbackMode) evaluator.callbackPop(instruction, false);
         return false;
       }
@@ -3455,7 +3471,10 @@ function AssertionObjectPropertiesSimple_fast(instruction, instance, depth, temp
       continue;
     }
     if (index < children.length) {
-      if (!evaluateInstructionFast(children[index], target[name], depth + 1, template, evaluator)) return false;
+      // Note that we don't hardcode the fast dispatcher here, as the fused
+      // children may require schema resource tracking for dynamic anchor
+      // resolution, which the current dispatcher takes care of
+      if (!evaluateInstruction(children[index], target[name], depth + 1, template, evaluator)) return false;
     }
   }
   return true;

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -2380,12 +2380,11 @@ auto compiler_draft3_applicator_extends(const Context &context,
                                         const SchemaContext &schema_context,
                                         const DynamicContext &dynamic_context,
                                         const Instructions &) -> Instructions {
-  assert(!context.uses_dynamic_scopes);
-
   const auto &value{schema_context.schema.at(dynamic_context.keyword)};
 
   if (value.is_object()) {
-    if (context.mode == Mode::FastValidation) {
+    // TODO: Make this work with `$dynamicRef`
+    if (context.mode == Mode::FastValidation && !context.uses_dynamic_scopes) {
       return compile(context, schema_context, dynamic_context,
                      sourcemeta::core::empty_weak_pointer,
                      sourcemeta::core::empty_weak_pointer);
@@ -2413,7 +2412,8 @@ auto compiler_draft3_applicator_extends(const Context &context,
 
   Instructions children;
 
-  if (context.mode == Mode::FastValidation) {
+  // TODO: Make this work with `$dynamicRef`
+  if (context.mode == Mode::FastValidation && !context.uses_dynamic_scopes) {
     for (std::uint64_t index = 0; index < value.size(); index++) {
       for (auto &&step : compile(
                context, schema_context, dynamic_context,

--- a/src/compiler/default_compiler_draft7.h
+++ b/src/compiler/default_compiler_draft7.h
@@ -29,10 +29,47 @@ auto compiler_draft7_applicator_if(const Context &context,
             .recompose()};
     assert(context.frame.locations().contains(
         {sourcemeta::blaze::SchemaReferenceType::Static, destination}));
+
+    // If `if` compiled to nothing, the `then` children will be hoisted to the
+    // current level without the `LogicalCondition` wrapper. When the schema
+    // uses dynamic scoping, we still need a wrapper instruction that keeps the
+    // current schema resource on the evaluation path for dynamic anchor
+    // resolution, as the omitted `LogicalCondition` instruction would have
+    // otherwise done it
+    if (then_cursor == 0 && context.uses_dynamic_scopes) {
+      Instructions substeps{
+          compile(context, schema_context, relative_dynamic_context(),
+                  sourcemeta::core::empty_weak_pointer,
+                  sourcemeta::core::empty_weak_pointer, destination)};
+      if (substeps.empty()) {
+        return children;
+      }
+
+      const auto then_pointer{schema_context.relative_pointer.initial().concat(
+          make_weak_pointer(KEYWORD_THEN))};
+      const SchemaContext then_schema_context{
+          .relative_pointer = then_pointer,
+          .schema = schema_context.schema,
+          .vocabularies = schema_context.vocabularies,
+          .base = schema_context.base,
+          .is_property_name = schema_context.is_property_name};
+      return {make(
+          sourcemeta::blaze::InstructionIndex::LogicalAnd, context,
+          then_schema_context,
+          {.keyword = KEYWORD_THEN,
+           .base_schema_location = dynamic_context.base_schema_location,
+           .base_instance_location = dynamic_context.base_instance_location},
+          ValueNone{}, std::move(substeps))};
+    }
+
+    // When hoisting, the `then` children must carry the instance navigation
+    // that the omitted `LogicalCondition` wrapper would have performed
     DynamicContext new_dynamic_context{
         .keyword = KEYWORD_THEN,
         .base_schema_location = dynamic_context.base_schema_location,
-        .base_instance_location = sourcemeta::core::empty_weak_pointer};
+        .base_instance_location = then_cursor == 0
+                                      ? dynamic_context.base_instance_location
+                                      : sourcemeta::core::empty_weak_pointer};
     for (auto &&step :
          compile(context, schema_context, new_dynamic_context,
                  sourcemeta::core::empty_weak_pointer,
@@ -44,6 +81,14 @@ auto compiler_draft7_applicator_if(const Context &context,
     if (then_cursor == 0) {
       return children;
     }
+  }
+
+  // If `if` compiled to nothing, it always succeeds, so in the absence of
+  // `then`, the `else` subschema can never apply and the entire conditional
+  // is a no-op
+  if (then_cursor == 0) {
+    assert(children.empty());
+    return {};
   }
 
   // `else`

--- a/src/evaluator/evaluator_describe.cc
+++ b/src/evaluator/evaluator_describe.cc
@@ -385,6 +385,16 @@ auto describe(const bool valid, const Instruction &step,
       return describe_reference(target);
     }
 
+    // For the wrapper instruction we emit when hoisting `then` subschemas
+    // whose `if` condition compiles to nothing
+    if (keyword == "then") {
+      std::ostringstream message;
+      message << "The " << type_name(target.type())
+              << " value was expected to validate against the given "
+                 "conditional";
+      return message.str();
+    }
+
     return unknown();
   }
 

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -4645,5 +4645,575 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "if_empty_then_hoisting_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": { "if": { "$comment": "always true" }, "then": { "type": "null" } }
+      }
+    },
+    "instance": { "value": null },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The value was expected to be of type null",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_then_hoisting_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": {
+          "if": { "$comment": "always true" },
+          "then": { "type": "string", "pattern": "^f" }
+        }
+      }
+    },
+    "instance": { "value": "foo" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
+        [ "AssertionPropertyTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The string value \"foo\" was expected to match the regular expression \"^f\"",
+        "The value was expected to be of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The string value \"foo\" was expected to match the regular expression \"^f\"",
+        "The value was expected to be of type string",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_then_hoisting_dynamic_scope_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": {
+          "$id": "https://example.com/dynamic-wrapper",
+          "if": {
+            "$id": "first_scope",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+          },
+          "then": {
+            "$id": "second_scope",
+            "$ref": "start",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+          },
+          "$defs": {
+            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "thingy": {
+              "$id": "inner_scope",
+              "$dynamicAnchor": "thingy",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "instance": { "value": null },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
+        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The value was expected to be of type null",
+        "The null value was expected to validate against the first subschema in scope that declared the dynamic anchor \"thingy\"",
+        "The null value was expected to validate against the referenced schema",
+        "The null value was expected to validate against the given conditional",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_then_hoisting_dynamic_scope_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": {
+          "$id": "https://example.com/dynamic-wrapper",
+          "if": { "$comment": "always true" },
+          "then": { "$id": "second_scope", "$ref": "start" },
+          "$defs": {
+            "outer_thingy": { "$dynamicAnchor": "thingy", "type": "null" },
+            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "thingy": {
+              "$id": "inner_scope",
+              "$dynamicAnchor": "thingy",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "instance": { "value": null },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type", "/value" ],
+        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The value was expected to be of type null",
+        "The null value was expected to validate against the first subschema in scope that declared the dynamic anchor \"thingy\"",
+        "The null value was expected to validate against the referenced schema",
+        "The null value was expected to validate against the given conditional",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_then_hoisting_static_scope_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value" ],
+      "properties": {
+        "value": {
+          "$id": "https://example.com/static-wrapper",
+          "if": { "$comment": "always true" },
+          "then": { "$id": "second_scope", "$ref": "start" },
+          "$defs": { "start": { "$id": "start", "type": "null" } }
+        }
+      }
+    },
+    "instance": { "value": null },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The value was expected to be of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ],
+        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"value\"",
+        "The value was expected to be of type null",
+        "The null value was expected to validate against the referenced schema",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_else_only_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "$comment": "always true" },
+      "else": { "properties": { "x": true } },
+      "unevaluatedProperties": false
+    },
+    "instance": { "x": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was not expected to define the property \"x\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was not expected to define the property \"x\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "if_empty_else_only_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "$comment": "always true" },
+      "else": { "type": "string" }
+    },
+    "instance": 1,
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
+  },
+  {
+    "description": "extends_dynamic_scope_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value", "legacy" ],
+      "properties": {
+        "value": {
+          "$id": "https://example.com/dynamic-wrapper",
+          "if": {
+            "$id": "first_scope",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+          },
+          "then": {
+            "$id": "second_scope",
+            "$ref": "start",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+          },
+          "$defs": {
+            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "thingy": {
+              "$id": "inner_scope",
+              "$dynamicAnchor": "thingy",
+              "type": "string"
+            }
+          }
+        },
+        "legacy": { "$ref": "https://example.com/legacy" }
+      },
+      "$defs": {
+        "legacy": {
+          "$schema": "http://json-schema.org/draft-03/schema#",
+          "id": "https://example.com/legacy",
+          "extends": [ { "type": "string" }, { "minLength": 2 } ]
+        }
+      }
+    },
+    "instance": { "value": null, "legacy": "ab" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ true, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ true, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ true, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
+        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
+        "The value was expected to be of type string",
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The string value was expected to validate against the 2 given subschemas",
+        "The string value was expected to validate against the referenced schema",
+        "The value was expected to be of type null",
+        "The null value was expected to validate against the first subschema in scope that declared the dynamic anchor \"thingy\"",
+        "The null value was expected to validate against the referenced schema",
+        "The null value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ true, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ true, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ true, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "legacy" ],
+        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
+        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
+        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
+        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
+        "The value was expected to be of type string",
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The string value was expected to validate against the 2 given subschemas",
+        "The string value was expected to validate against the referenced schema",
+        "The object property \"legacy\" successfully validated against its property subschema",
+        "The value was expected to be of type null",
+        "The null value was expected to validate against the first subschema in scope that declared the dynamic anchor \"thingy\"",
+        "The null value was expected to validate against the referenced schema",
+        "The null value was expected to validate against the given conditional",
+        "The object property \"value\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "extends_dynamic_scope_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "value", "legacy" ],
+      "properties": {
+        "value": {
+          "$id": "https://example.com/dynamic-wrapper",
+          "if": {
+            "$id": "first_scope",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+          },
+          "then": {
+            "$id": "second_scope",
+            "$ref": "start",
+            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+          },
+          "$defs": {
+            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "thingy": {
+              "$id": "inner_scope",
+              "$dynamicAnchor": "thingy",
+              "type": "string"
+            }
+          }
+        },
+        "legacy": { "$ref": "https://example.com/legacy" }
+      },
+      "$defs": {
+        "legacy": {
+          "$schema": "http://json-schema.org/draft-03/schema#",
+          "id": "https://example.com/legacy",
+          "extends": [ { "type": "string" }, { "minLength": 2 } ]
+        }
+      }
+    },
+    "instance": { "value": null, "legacy": "a" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ false, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ false, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ false, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
+        "The value was expected to be of type string",
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character",
+        "The string value was expected to validate against the 2 given subschemas",
+        "The string value was expected to validate against the referenced schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
+        [ false, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
+        [ false, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
+        [ false, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
+        "The value was expected to be of type string",
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character",
+        "The string value was expected to validate against the 2 given subschemas",
+        "The string value was expected to validate against the referenced schema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

