### PR TITLE
Turn `SimpleOutput` annotations into a vector

### DIFF
--- a/src/output/include/sourcemeta/blaze/output_simple.h
+++ b/src/output/include/sourcemeta/blaze/output_simple.h
@@ -16,7 +16,6 @@
 #include <map>     // std::map
 #include <ostream> // std::ostream
 #include <string>  // std::string
-#include <tuple>   // std::tie
 #include <utility> // std::pair
 #include <vector>  // std::vector
 
@@ -83,6 +82,14 @@ public:
     std::reference_wrapper<const std::string> schema_location;
   };
 
+  /// A single collected annotation, in evaluation order
+  struct AnnotationEntry {
+    sourcemeta::core::WeakPointer instance_location;
+    sourcemeta::core::WeakPointer evaluate_path;
+    std::reference_wrapper<const std::string> schema_location;
+    sourcemeta::core::JSON value;
+  };
+
   auto operator()(const EvaluationType type, const bool result,
                   const Instruction &step,
                   const InstructionExtra &step_metadata,
@@ -97,12 +104,6 @@ public:
   [[nodiscard]] auto cbegin() const -> const_iterator;
   [[nodiscard]] auto cend() const -> const_iterator;
 
-  /// Access annotations that were collected during evaluation, indexed by
-  /// instance location and evaluation path
-  [[nodiscard]] auto annotations() const -> const auto & {
-    return this->annotations_;
-  }
-
   /// Move out the collected error entries, leaving this output empty. Useful to
   /// take ownership of the trace without copying when the output is no longer
   /// needed
@@ -114,22 +115,12 @@ public:
     return result;
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  struct Location {
-    auto operator<(const Location &other) const noexcept -> bool {
-      // Perform a lexicographical comparison
-      return std::tie(this->instance_location, this->evaluate_path,
-                      this->schema_location.get()) <
-             std::tie(other.instance_location, other.evaluate_path,
-                      other.schema_location.get());
-    }
-
-    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
-    const sourcemeta::core::WeakPointer instance_location;
-    const sourcemeta::core::WeakPointer evaluate_path;
-    const std::reference_wrapper<const std::string> schema_location;
-    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
-  };
+  /// Access the annotations collected during evaluation, as a flat log in
+  /// evaluation order. Consumers that need them grouped by location index this
+  /// log themselves
+  [[nodiscard]] auto annotations() const -> const auto & {
+    return this->annotations_;
+  }
 
 private:
 // Exporting symbols that depends on the standard C++ library is considered
@@ -148,7 +139,7 @@ private:
       std::pair<sourcemeta::core::WeakPointer, sourcemeta::core::WeakPointer>,
       std::vector<Entry>>
       masked_traces;
-  std::map<Location, std::vector<sourcemeta::core::JSON>> annotations_;
+  std::vector<AnnotationEntry> annotations_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/output/include/sourcemeta/blaze/output_simple.h
+++ b/src/output/include/sourcemeta/blaze/output_simple.h
@@ -116,8 +116,10 @@ public:
   }
 
   /// Access the annotations collected during evaluation, as a flat log in
-  /// evaluation order. Consumers that need them grouped by location index this
-  /// log themselves
+  /// evaluation order. The log records every emission as-is, so a location may
+  /// repeat and hold the same value more than once. Consumers that need them
+  /// grouped by location, or collapsed to distinct values, index this log
+  /// themselves
   [[nodiscard]] auto annotations() const -> const auto & {
     return this->annotations_;
   }

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -9,7 +9,8 @@
 
 #include <algorithm>     // std::ranges::sort, std::ranges::any_of
 #include <deque>         // std::deque
-#include <functional>    // std::ref
+#include <functional>    // std::ref, std::reference_wrapper
+#include <map>           // std::map
 #include <optional>      // std::optional
 #include <sstream>       // std::ostringstream
 #include <string>        // std::string
@@ -400,6 +401,35 @@ auto array_of_nodes(const Accumulator &accumulator,
   return true;
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
+struct AnnotationLocation {
+  auto operator<(const AnnotationLocation &other) const noexcept -> bool {
+    return std::tie(this->instance_location, this->evaluate_path,
+                    this->schema_location.get()) <
+           std::tie(other.instance_location, other.evaluate_path,
+                    other.schema_location.get());
+  }
+
+  sourcemeta::core::WeakPointer instance_location;
+  sourcemeta::core::WeakPointer evaluate_path;
+  std::reference_wrapper<const std::string> schema_location;
+};
+
+auto group_annotations(const sourcemeta::blaze::SimpleOutput &output)
+    -> std::map<AnnotationLocation, std::vector<sourcemeta::core::JSON>> {
+  std::map<AnnotationLocation, std::vector<sourcemeta::core::JSON>> result;
+  for (const auto &entry : output.annotations()) {
+    auto &values{result[{.instance_location = entry.instance_location,
+                         .evaluate_path = entry.evaluate_path,
+                         .schema_location = entry.schema_location}]};
+    if (values.empty() || values.back() != entry.value) {
+      values.push_back(entry.value);
+    }
+  }
+
+  return result;
+}
+
 // Turn the JSON-LD annotations into a resolved map, or the first error found.
 // The first pass groups the facts by location, the second derives each kind
 // from the value shape and validates the facts against it
@@ -409,7 +439,7 @@ auto resolve(const sourcemeta::core::JSON &instance,
                     sourcemeta::blaze::JSONLDResolutionError> {
   Accumulator accumulator;
 
-  for (const auto &[location, values] : output.annotations()) {
+  for (const auto &[location, values] : group_annotations(output)) {
     if (location.evaluate_path.empty()) {
       continue;
     }

--- a/src/output/output_simple.cc
+++ b/src/output/output_simple.cc
@@ -66,18 +66,11 @@ auto SimpleOutput::operator()(
 
   if (is_annotation(step.type)) {
     if (type == EvaluationType::Post) {
-      Location location{.instance_location = instance_location,
-                        .evaluate_path = std::move(effective_evaluate_path),
-                        .schema_location = step_metadata.keyword_location};
-      const auto match{this->annotations_.find(location)};
-      if (match == this->annotations_.cend()) {
-        this->annotations_[std::move(location)].push_back(annotation);
-
-        // To avoid emitting the exact same annotation more than once
-        // This is right now mostly because of `unevaluatedItems`
-      } else if (match->second.back() != annotation) {
-        match->second.push_back(annotation);
-      }
+      this->annotations_.push_back(
+          {.instance_location = instance_location,
+           .evaluate_path = std::move(effective_evaluate_path),
+           .schema_location = step_metadata.keyword_location,
+           .value = annotation});
     }
 
     return;
@@ -122,15 +115,11 @@ auto SimpleOutput::operator()(
   }
 
   if (type == EvaluationType::Post && !this->annotations_.empty()) {
-    for (auto iterator = this->annotations_.begin();
-         iterator != this->annotations_.end();) {
-      if (iterator->first.evaluate_path.starts_with_initial(evaluate_path) &&
-          iterator->first.instance_location == instance_location) {
-        iterator = this->annotations_.erase(iterator);
-      } else {
-        ++iterator;
-      }
-    }
+    std::erase_if(
+        this->annotations_, [&](const AnnotationEntry &entry) -> bool {
+          return entry.evaluate_path.starts_with_initial(evaluate_path) &&
+                 entry.instance_location == instance_location;
+        });
   }
 
   if (keyword == "if") {

--- a/src/output/output_standard.cc
+++ b/src/output/output_standard.cc
@@ -1,14 +1,48 @@
 #include <sourcemeta/blaze/output_simple.h>
 #include <sourcemeta/blaze/output_standard.h>
 
+#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
 #include <cassert>    // assert
-#include <functional> // std::ref
+#include <functional> // std::ref, std::reference_wrapper
+#include <map>        // std::map
+#include <string>     // std::string
+#include <tuple>      // std::tie
+#include <vector>     // std::vector
 
 namespace sourcemeta::blaze {
 
 namespace {
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+struct AnnotationLocation {
+  auto operator<(const AnnotationLocation &other) const noexcept -> bool {
+    return std::tie(this->instance_location, this->evaluate_path,
+                    this->schema_location.get()) <
+           std::tie(other.instance_location, other.evaluate_path,
+                    other.schema_location.get());
+  }
+
+  sourcemeta::core::WeakPointer instance_location;
+  sourcemeta::core::WeakPointer evaluate_path;
+  std::reference_wrapper<const std::string> schema_location;
+};
+
+auto group_annotations(const SimpleOutput &output)
+    -> std::map<AnnotationLocation, std::vector<sourcemeta::core::JSON>> {
+  std::map<AnnotationLocation, std::vector<sourcemeta::core::JSON>> result;
+  for (const auto &entry : output.annotations()) {
+    auto &values{result[{.instance_location = entry.instance_location,
+                         .evaluate_path = entry.evaluate_path,
+                         .schema_location = entry.schema_location}]};
+    if (values.empty() || values.back() != entry.value) {
+      values.push_back(entry.value);
+    }
+  }
+
+  return result;
+}
 
 auto handle_standard(Evaluator &evaluator, const Template &schema,
                      const sourcemeta::core::JSON &instance,
@@ -30,7 +64,7 @@ auto handle_standard(Evaluator &evaluator, const Template &schema,
       auto result{sourcemeta::core::JSON::make_object()};
       result.assign_assume_new("valid", sourcemeta::core::JSON{valid});
       auto annotations{sourcemeta::core::JSON::make_array()};
-      for (const auto &annotation : output.annotations()) {
+      for (const auto &annotation : group_annotations(output)) {
         auto unit{sourcemeta::core::JSON::make_object()};
         unit.assign_assume_new(
             "keywordLocation",

--- a/test/evaluator/annotationsuite.cc
+++ b/test/evaluator/annotationsuite.cc
@@ -9,7 +9,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <functional>
@@ -61,16 +60,15 @@ has_annotation(const sourcemeta::blaze::SimpleOutput &output,
 
   for (const auto &annotation : output.annotations()) {
     std::cerr << "Checking against annotations for instance location \""
-              << sourcemeta::core::to_string(annotation.first.instance_location)
-              << "\" and schema location \""
-              << annotation.first.schema_location.get() << "\"" << "\n";
+              << sourcemeta::core::to_string(annotation.instance_location)
+              << "\" and schema location \"" << annotation.schema_location.get()
+              << "\"" << "\n";
 
-    if (annotation.first.instance_location != instance_location ||
-        !schema_location_matches(annotation.first.schema_location.get(),
+    if (annotation.instance_location != instance_location ||
+        !schema_location_matches(annotation.schema_location.get(),
                                  schema_location, frame)) {
       continue;
-    } else if (std::find(annotation.second.cbegin(), annotation.second.cend(),
-                         value) != annotation.second.cend()) {
+    } else if (annotation.value == value) {
       return true;
     }
   }
@@ -88,15 +86,15 @@ has_matching_annotations(const sourcemeta::blaze::SimpleOutput &output,
 
   for (const auto &annotation : output.annotations()) {
     std::cerr << "Checking against annotations for instance location \""
-              << sourcemeta::core::to_string(annotation.first.instance_location)
+              << sourcemeta::core::to_string(annotation.instance_location)
               << "\" and evaluate path \""
-              << sourcemeta::core::to_string(annotation.first.evaluate_path)
-              << "\"" << "\n";
+              << sourcemeta::core::to_string(annotation.evaluate_path) << "\""
+              << "\n";
 
-    if (annotation.first.instance_location == instance_location &&
-        !annotation.first.evaluate_path.empty() &&
-        annotation.first.evaluate_path.back().is_property() &&
-        annotation.first.evaluate_path.back().to_property() == keyword) {
+    if (annotation.instance_location == instance_location &&
+        !annotation.evaluate_path.empty() &&
+        annotation.evaluate_path.back().is_property() &&
+        annotation.evaluate_path.back().to_property() == keyword) {
       return true;
     }
   }

--- a/test/output/output_simple_test.cc
+++ b/test/output/output_simple_test.cc
@@ -5,9 +5,12 @@
 #include <sourcemeta/blaze/output.h>
 
 #include <sourcemeta/blaze/foundation.h>
+#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-#include <unordered_set>
+#include <string>        // std::string
+#include <unordered_set> // std::unordered_set
+#include <vector>        // std::vector
 
 #define EXPECT_OUTPUT(traces, index, expected_instance_location,               \
                       expected_evaluate_path, expected_schema_location,        \
@@ -24,37 +27,18 @@
 #define EXPECT_ANNOTATION_COUNT(output, expected_count)                        \
   EXPECT_EQ(output.annotations().size(), (expected_count));
 
-#define EXPECT_ANNOTATION_ENTRY(                                               \
-    output, expected_instance_location, expected_evaluate_path,                \
-    expected_schema_location, expected_entry_count)                            \
+#define EXPECT_ANNOTATION(output, index, expected_instance_location,           \
+                          expected_evaluate_path, expected_schema_location,    \
+                          expected_value)                                      \
   {                                                                            \
-    const auto instance_location{                                              \
-        sourcemeta::core::to_pointer(expected_instance_location)};             \
-    const auto evaluate_path{                                                  \
-        sourcemeta::core::to_pointer(expected_evaluate_path)};                 \
-    const std::string schema_location{expected_schema_location};               \
-    const sourcemeta::blaze::SimpleOutput::Location location{                  \
-        sourcemeta::core::to_weak_pointer(instance_location),                  \
-        sourcemeta::core::to_weak_pointer(evaluate_path), schema_location};    \
-    EXPECT_TRUE(output.annotations().contains(location));                      \
-    EXPECT_EQ(output.annotations().at(location).size(),                        \
-              (expected_entry_count));                                         \
-  }
-
-#define EXPECT_ANNOTATION_VALUE(                                               \
-    output, expected_instance_location, expected_evaluate_path,                \
-    expected_schema_location, expected_entry_index, expected_value)            \
-  {                                                                            \
-    const auto instance_location{                                              \
-        sourcemeta::core::to_pointer(expected_instance_location)};             \
-    const auto evaluate_path{                                                  \
-        sourcemeta::core::to_pointer(expected_evaluate_path)};                 \
-    const std::string schema_location{expected_schema_location};               \
-    const sourcemeta::blaze::SimpleOutput::Location location{                  \
-        sourcemeta::core::to_weak_pointer(instance_location),                  \
-        sourcemeta::core::to_weak_pointer(evaluate_path), schema_location};    \
-    EXPECT_EQ(output.annotations().at(location).at(expected_entry_index),      \
-              (expected_value));                                               \
+    EXPECT_TRUE(output.annotations().size() > (index));                        \
+    const auto &annotation{output.annotations().at(index)};                    \
+    EXPECT_EQ(sourcemeta::core::to_string(annotation.instance_location),       \
+              (expected_instance_location));                                   \
+    EXPECT_EQ(sourcemeta::core::to_string(annotation.evaluate_path),           \
+              (expected_evaluate_path));                                       \
+    EXPECT_EQ(annotation.schema_location.get(), (expected_schema_location));   \
+    EXPECT_EQ(annotation.value, (expected_value));                             \
   }
 
 TEST(success_string_1) {
@@ -1043,11 +1027,8 @@ TEST(annotations_failure_2) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "/bar", "/properties/bar/title",
-                          "#/properties/bar/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "/bar", "/properties/bar/title",
-                          "#/properties/bar/title", 0,
-                          sourcemeta::core::JSON{"Bar"});
+  EXPECT_ANNOTATION(output, 0, "/bar", "/properties/bar/title",
+                    "#/properties/bar/title", sourcemeta::core::JSON{"Bar"});
 }
 
 TEST(annotations_success_oneof_1) {
@@ -1078,9 +1059,8 @@ TEST(annotations_success_oneof_1) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/oneOf/1/title", "#/oneOf/1/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/oneOf/1/title", "#/oneOf/1/title", 0,
-                          sourcemeta::core::JSON{"Second"});
+  EXPECT_ANNOTATION(output, 0, "", "/oneOf/1/title", "#/oneOf/1/title",
+                    sourcemeta::core::JSON{"Second"});
 }
 
 TEST(annotations_success_whitelist_oneof_within_object_property) {
@@ -1120,13 +1100,9 @@ TEST(annotations_success_whitelist_oneof_within_object_property) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "/value",
-                          "/properties/value/oneOf/0/x-custom",
-                          "#/properties/value/oneOf/0/x-custom", 1);
-  EXPECT_ANNOTATION_VALUE(output, "/value",
-                          "/properties/value/oneOf/0/x-custom",
-                          "#/properties/value/oneOf/0/x-custom", 0,
-                          sourcemeta::core::JSON{"First"});
+  EXPECT_ANNOTATION(output, 0, "/value", "/properties/value/oneOf/0/x-custom",
+                    "#/properties/value/oneOf/0/x-custom",
+                    sourcemeta::core::JSON{"First"});
 }
 
 TEST(annotations_success_if_then_1) {
@@ -1155,9 +1131,8 @@ TEST(annotations_success_if_then_1) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/then/title", "#/then/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/then/title", "#/then/title", 0,
-                          sourcemeta::core::JSON{"Then Title"});
+  EXPECT_ANNOTATION(output, 0, "", "/then/title", "#/then/title",
+                    sourcemeta::core::JSON{"Then Title"});
 }
 
 TEST(annotations_success_if_else_1) {
@@ -1186,9 +1161,8 @@ TEST(annotations_success_if_else_1) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/else/title", "#/else/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/else/title", "#/else/title", 0,
-                          sourcemeta::core::JSON{"Else Title"});
+  EXPECT_ANNOTATION(output, 0, "", "/else/title", "#/else/title",
+                    sourcemeta::core::JSON{"Else Title"});
 }
 
 TEST(annotations_failure_oneof_1) {
@@ -1336,35 +1310,21 @@ TEST(annotations_success_1) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 5);
+  EXPECT_ANNOTATION_COUNT(output, 6);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/properties", "#/properties", 2);
-  EXPECT_ANNOTATION_VALUE(output, "", "/properties", "#/properties", 0,
-                          sourcemeta::core::JSON{"bar"});
-  EXPECT_ANNOTATION_VALUE(output, "", "/properties", "#/properties", 1,
-                          sourcemeta::core::JSON{"foo"});
-
-  EXPECT_ANNOTATION_ENTRY(output, "", "/title", "#/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/title", "#/title", 0,
-                          sourcemeta::core::JSON{"My Schema"});
-
-  EXPECT_ANNOTATION_ENTRY(output, "/foo", "/properties/foo/$ref/title",
-                          "#/$defs/test/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "/foo", "/properties/foo/$ref/title",
-                          "#/$defs/test/title", 0,
-                          sourcemeta::core::JSON{"Test"});
-
-  EXPECT_ANNOTATION_ENTRY(output, "/foo", "/properties/foo/title",
-                          "#/properties/foo/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "/foo", "/properties/foo/title",
-                          "#/properties/foo/title", 0,
-                          sourcemeta::core::JSON{"Foo"});
-
-  EXPECT_ANNOTATION_ENTRY(output, "/foo", "/properties/foo/deprecated",
-                          "#/properties/foo/deprecated", 1);
-  EXPECT_ANNOTATION_VALUE(output, "/foo", "/properties/foo/deprecated",
-                          "#/properties/foo/deprecated", 0,
-                          sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 0, "", "/title", "#/title",
+                    sourcemeta::core::JSON{"My Schema"});
+  EXPECT_ANNOTATION(output, 1, "", "/properties", "#/properties",
+                    sourcemeta::core::JSON{"bar"});
+  EXPECT_ANNOTATION(output, 2, "/foo", "/properties/foo/$ref/title",
+                    "#/$defs/test/title", sourcemeta::core::JSON{"Test"});
+  EXPECT_ANNOTATION(output, 3, "/foo", "/properties/foo/deprecated",
+                    "#/properties/foo/deprecated",
+                    sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 4, "/foo", "/properties/foo/title",
+                    "#/properties/foo/title", sourcemeta::core::JSON{"Foo"});
+  EXPECT_ANNOTATION(output, 5, "", "/properties", "#/properties",
+                    sourcemeta::core::JSON{"foo"});
 }
 
 TEST(annotations_success_2) {
@@ -1396,13 +1356,10 @@ TEST(annotations_success_2) {
 
   EXPECT_ANNOTATION_COUNT(output, 2);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/anyOf/0/title", "#/anyOf/0/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/anyOf/0/title", "#/anyOf/0/title", 0,
-                          sourcemeta::core::JSON{"First branch"});
-
-  EXPECT_ANNOTATION_ENTRY(output, "", "/anyOf/2/title", "#/anyOf/2/title", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/anyOf/2/title", "#/anyOf/2/title", 0,
-                          sourcemeta::core::JSON{"Third branch"});
+  EXPECT_ANNOTATION(output, 0, "", "/anyOf/0/title", "#/anyOf/0/title",
+                    sourcemeta::core::JSON{"First branch"});
+  EXPECT_ANNOTATION(output, 1, "", "/anyOf/2/title", "#/anyOf/2/title",
+                    sourcemeta::core::JSON{"Third branch"});
 }
 
 TEST(annotations_success_3) {
@@ -1458,13 +1415,12 @@ TEST(annotations_success_4) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 1);
+  EXPECT_ANNOTATION_COUNT(output, 2);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 2);
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
-                          sourcemeta::core::JSON{0});
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 1,
-                          sourcemeta::core::JSON{2});
+  EXPECT_ANNOTATION(output, 0, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION(output, 1, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{2});
 }
 
 TEST(annotations_success_5) {
@@ -1491,13 +1447,12 @@ TEST(annotations_success_5) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 1);
+  EXPECT_ANNOTATION_COUNT(output, 2);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 2);
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
-                          sourcemeta::core::JSON{0});
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 1,
-                          sourcemeta::core::JSON{2});
+  EXPECT_ANNOTATION(output, 0, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION(output, 1, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{2});
 }
 
 TEST(annotations_success_6) {
@@ -1524,13 +1479,12 @@ TEST(annotations_success_6) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 1);
+  EXPECT_ANNOTATION_COUNT(output, 2);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 2);
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
-                          sourcemeta::core::JSON{0});
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 1,
-                          sourcemeta::core::JSON{1});
+  EXPECT_ANNOTATION(output, 0, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION(output, 1, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{1});
 }
 
 TEST(annotations_success_7) {
@@ -1559,9 +1513,8 @@ TEST(annotations_success_7) {
 
   EXPECT_ANNOTATION_COUNT(output, 1);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
-                          sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION(output, 0, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{0});
 }
 
 TEST(annotations_success_8) {
@@ -1588,12 +1541,16 @@ TEST(annotations_success_8) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 1);
+  EXPECT_ANNOTATION_COUNT(output, 4);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/unevaluatedItems", "#/unevaluatedItems",
-                          1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/unevaluatedItems", "#/unevaluatedItems",
-                          0, sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 0, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 1, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 2, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 3, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
 }
 
 TEST(annotations_success_9) {
@@ -1621,18 +1578,16 @@ TEST(annotations_success_9) {
                                                              output.cend()};
   EXPECT_TRUE(traces.empty());
 
-  EXPECT_ANNOTATION_COUNT(output, 2);
+  EXPECT_ANNOTATION_COUNT(output, 4);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 2);
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 0,
-                          sourcemeta::core::JSON{0});
-  EXPECT_ANNOTATION_VALUE(output, "", "/contains", "#/contains", 1,
-                          sourcemeta::core::JSON{2});
-
-  EXPECT_ANNOTATION_ENTRY(output, "", "/unevaluatedItems", "#/unevaluatedItems",
-                          1);
-  EXPECT_ANNOTATION_VALUE(output, "", "/unevaluatedItems", "#/unevaluatedItems",
-                          0, sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 0, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{0});
+  EXPECT_ANNOTATION(output, 1, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{2});
+  EXPECT_ANNOTATION(output, 2, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
+  EXPECT_ANNOTATION(output, 3, "", "/unevaluatedItems", "#/unevaluatedItems",
+                    sourcemeta::core::JSON{true});
 }
 
 TEST(annotations_success_10) {
@@ -1661,11 +1616,10 @@ TEST(annotations_success_10) {
 
   EXPECT_ANNOTATION_COUNT(output, 2);
 
-  EXPECT_ANNOTATION_ENTRY(output, "", "/contains", "#/contains", 1);
-  EXPECT_ANNOTATION_ENTRY(output, "/1", "/contains/title", "#/contains/title",
-                          1);
-  EXPECT_ANNOTATION_VALUE(output, "/1", "/contains/title", "#/contains/title",
-                          0, sourcemeta::core::JSON{"Test"});
+  EXPECT_ANNOTATION(output, 0, "/1", "/contains/title", "#/contains/title",
+                    sourcemeta::core::JSON{"Test"});
+  EXPECT_ANNOTATION(output, 1, "", "/contains", "#/contains",
+                    sourcemeta::core::JSON{1});
 }
 
 TEST(annotations_failure_1) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

