### PR TITLE
Allow `SchemaRule` to be customised with a scope

### DIFF
--- a/src/alterschema/include/sourcemeta/blaze/alterschema.h
+++ b/src/alterschema/include/sourcemeta/blaze/alterschema.h
@@ -88,14 +88,14 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void;
 
 /// @ingroup alterschema
 ///
-/// A linter rule driven by a JSON Schema. Every subschema in the document
-/// under inspection is validated as a JSON instance against the provided
-/// rule schema. When a subschema does not conform, the rule fires and
-/// reports the validation errors. The rule name is extracted from the
-/// `title` keyword of the rule schema, and the rule description from the
-/// `description` keyword. The title must consist only of lowercase ASCII
-/// letters, digits, underscores, or slashes. A rule may be scoped to only
-/// run against the document root.
+/// A linter rule driven by a JSON Schema. By default, every subschema in
+/// the document under inspection is validated as a JSON instance against
+/// the provided rule schema, though a rule may be scoped to only run
+/// against the document root. When a subschema does not conform, the rule
+/// fires and reports the validation errors. The rule name is extracted
+/// from the `title` keyword of the rule schema, and the rule description
+/// from the `description` keyword. The title must consist only of
+/// lowercase ASCII letters, digits, underscores, or slashes.
 class SOURCEMETA_BLAZE_ALTERSCHEMA_EXPORT SchemaRule final
     : public SchemaTransformRule {
 public:

--- a/src/alterschema/include/sourcemeta/blaze/alterschema.h
+++ b/src/alterschema/include/sourcemeta/blaze/alterschema.h
@@ -94,10 +94,20 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void;
 /// reports the validation errors. The rule name is extracted from the
 /// `title` keyword of the rule schema, and the rule description from the
 /// `description` keyword. The title must consist only of lowercase ASCII
-/// letters, digits, underscores, or slashes.
+/// letters, digits, underscores, or slashes. A rule may be scoped to only
+/// run against the document root.
 class SOURCEMETA_BLAZE_ALTERSCHEMA_EXPORT SchemaRule final
     : public SchemaTransformRule {
 public:
+  /// The locations of the schema that the rule applies to
+  enum class Scope : std::uint8_t {
+    /// Every subschema of the document under inspection
+    All,
+
+    /// Only the document root
+    TopLevel
+  };
+
   using mutates = std::false_type;
   using reframe_after_transform = std::false_type;
   SchemaRule(const sourcemeta::core::JSON &schema,
@@ -105,7 +115,8 @@ public:
              const sourcemeta::blaze::SchemaResolver &resolver,
              const Compiler &compiler,
              const std::string_view default_dialect = "",
-             const std::optional<Tweaks> &tweaks = std::nullopt);
+             const std::optional<Tweaks> &tweaks = std::nullopt,
+             const Scope scope = Scope::All);
   [[nodiscard]] auto
   condition(const sourcemeta::core::JSON &, const sourcemeta::core::JSON &,
             const sourcemeta::blaze::Vocabularies &,
@@ -117,6 +128,7 @@ public:
 
 private:
   Template template_;
+  Scope scope_;
 };
 
 #if defined(_MSC_VER)

--- a/src/alterschema/schema_rule.cc
+++ b/src/alterschema/schema_rule.cc
@@ -68,19 +68,24 @@ SchemaRule::SchemaRule(const sourcemeta::core::JSON &schema,
                        const sourcemeta::blaze::SchemaResolver &resolver,
                        const Compiler &compiler,
                        const std::string_view default_dialect,
-                       const std::optional<Tweaks> &tweaks)
+                       const std::optional<Tweaks> &tweaks, const Scope scope)
     : SchemaTransformRule{extract_title(schema), extract_description(schema)},
       template_{compile(schema, walker, resolver, compiler, Mode::Exhaustive,
-                        default_dialect, "", "", tweaks)} {};
+                        default_dialect, "", "", tweaks)},
+      scope_{scope} {};
 
-auto SchemaRule::condition(const sourcemeta::core::JSON &schema,
-                           const sourcemeta::core::JSON &,
-                           const sourcemeta::blaze::Vocabularies &,
-                           const sourcemeta::blaze::SchemaFrame &,
-                           const sourcemeta::blaze::SchemaFrame::Location &,
-                           const sourcemeta::blaze::SchemaWalker &,
-                           const sourcemeta::blaze::SchemaResolver &,
-                           const bool) const -> SchemaTransformRule::Result {
+auto SchemaRule::condition(
+    const sourcemeta::core::JSON &schema, const sourcemeta::core::JSON &,
+    const sourcemeta::blaze::Vocabularies &,
+    const sourcemeta::blaze::SchemaFrame &,
+    const sourcemeta::blaze::SchemaFrame::Location &location,
+    const sourcemeta::blaze::SchemaWalker &,
+    const sourcemeta::blaze::SchemaResolver &, const bool) const
+    -> SchemaTransformRule::Result {
+  if (this->scope_ == Scope::TopLevel && !location.pointer.empty()) {
+    return false;
+  }
+
   SimpleOutput output{schema};
   Evaluator evaluator;
   const auto result{

--- a/test/alterschema/alterschema_schema_rule_test.cc
+++ b/test/alterschema/alterschema_schema_rule_test.cc
@@ -1083,6 +1083,309 @@ TEST(schema_rule_property_names_pattern_fail) {
   EXPECT_FALSE(std::get<4>(entries.at(0)));
 }
 
+TEST(schema_rule_top_level_root_violates) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "test/require_type",
+    "description": "The document root must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler, "", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::TopLevel);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "type": "string"
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      });
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "test/require_type");
+  EXPECT_EQ(std::get<2>(entries.at(0)), "The document root must define a type");
+  EXPECT_TRUE(std::get<3>(entries.at(0)).description.has_value());
+  EXPECT_EQ(std::get<3>(entries.at(0)).description.value(),
+            "The value was expected to be an object that defines the property "
+            "\"type\"");
+  EXPECT_EQ(std::get<3>(entries.at(0)).locations.size(), 0);
+  EXPECT_FALSE(std::get<4>(entries.at(0)));
+}
+
+TEST(schema_rule_top_level_subschemas_skipped) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "test/require_type",
+    "description": "The document root must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler, "", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::TopLevel);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "type": "string"
+      },
+      "bar": {
+        "minLength": 1
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      });
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST(schema_rule_top_level_root_and_subschema_violate) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "test/require_type",
+    "description": "The document root must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler, "", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::TopLevel);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "type": "string"
+      },
+      "bar": {
+        "minLength": 1
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      });
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "test/require_type");
+  EXPECT_EQ(std::get<2>(entries.at(0)), "The document root must define a type");
+  EXPECT_TRUE(std::get<3>(entries.at(0)).description.has_value());
+  EXPECT_EQ(std::get<3>(entries.at(0)).description.value(),
+            "The value was expected to be an object that defines the property "
+            "\"type\"");
+  EXPECT_EQ(std::get<3>(entries.at(0)).locations.size(), 0);
+  EXPECT_FALSE(std::get<4>(entries.at(0)));
+}
+
+TEST(schema_rule_explicit_all_scope_root_and_nested_subschema) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "test/require_type",
+    "description": "Every subschema must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler, "", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::All);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "type": "string"
+      },
+      "bar": {
+        "minLength": 1
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      });
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(entries.size(), 2);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "test/require_type");
+  EXPECT_EQ(std::get<2>(entries.at(0)), "Every subschema must define a type");
+  EXPECT_TRUE(std::get<3>(entries.at(0)).description.has_value());
+  EXPECT_EQ(std::get<3>(entries.at(0)).description.value(),
+            "The value was expected to be an object that defines the property "
+            "\"type\"");
+  EXPECT_EQ(std::get<3>(entries.at(0)).locations.size(), 0);
+  EXPECT_FALSE(std::get<4>(entries.at(0)));
+
+  EXPECT_EQ(std::get<0>(entries.at(1)),
+            sourcemeta::core::Pointer({"properties", "bar"}));
+  EXPECT_EQ(std::get<1>(entries.at(1)), "test/require_type");
+  EXPECT_EQ(std::get<2>(entries.at(1)), "Every subschema must define a type");
+  EXPECT_TRUE(std::get<3>(entries.at(1)).description.has_value());
+  EXPECT_EQ(std::get<3>(entries.at(1)).description.value(),
+            "The value was expected to be an object that defines the property "
+            "\"type\"");
+  EXPECT_EQ(std::get<3>(entries.at(1)).locations.size(), 0);
+  EXPECT_FALSE(std::get<4>(entries.at(1)));
+}
+
+TEST(schema_rule_top_level_embedded_resource_skipped) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "test/require_type",
+    "description": "The document root must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler, "", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::TopLevel);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "$defs": {
+      "embedded": {
+        "$id": "https://www.example.com/embedded",
+        "minLength": 1
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      });
+
+  EXPECT_TRUE(result.first);
+  EXPECT_EQ(entries.size(), 0);
+}
+
+TEST(schema_rule_top_level_with_default_dialect) {
+  const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
+    "title": "test/require_type",
+    "description": "The document root must define a type",
+    "type": "object",
+    "required": [ "type" ]
+  })JSON")};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  bundle.add<sourcemeta::blaze::SchemaRule>(
+      rule_schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt,
+      sourcemeta::blaze::SchemaRule::Scope::TopLevel);
+
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "properties": {
+      "foo": {
+        "minLength": 1
+      }
+    }
+  })JSON")};
+
+  std::vector<std::tuple<sourcemeta::core::Pointer, std::string, std::string,
+                         sourcemeta::blaze::SchemaTransformRule::Result, bool>>
+      entries;
+  const auto result = bundle.check(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      [&entries](const auto &pointer, const auto &name, const auto &message,
+                 const auto &outcome, const auto mutable_) {
+        entries.emplace_back(pointer, name, message, outcome, mutable_);
+      },
+      "https://json-schema.org/draft/2020-12/schema");
+
+  EXPECT_FALSE(result.first);
+  EXPECT_EQ(entries.size(), 1);
+
+  EXPECT_EQ(std::get<0>(entries.at(0)), sourcemeta::core::Pointer({}));
+  EXPECT_EQ(std::get<1>(entries.at(0)), "test/require_type");
+  EXPECT_EQ(std::get<2>(entries.at(0)), "The document root must define a type");
+  EXPECT_TRUE(std::get<3>(entries.at(0)).description.has_value());
+  EXPECT_EQ(std::get<3>(entries.at(0)).description.value(),
+            "The value was expected to be an object that defines the property "
+            "\"type\"");
+  EXPECT_EQ(std::get<3>(entries.at(0)).locations.size(), 0);
+  EXPECT_FALSE(std::get<4>(entries.at(0)));
+}
+
 TEST(schema_rule_non_empty_instance_location) {
   const auto rule_schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

