### PR TITLE
Allow tweaking linter rule scope in Configuration

### DIFF
--- a/src/configuration/include/sourcemeta/blaze/configuration.h
+++ b/src/configuration/include/sourcemeta/blaze/configuration.h
@@ -69,7 +69,12 @@ struct SOURCEMETA_BLAZE_CONFIGURATION_EXPORT Configuration {
   std::vector<std::filesystem::path> ignore;
 
   struct Lint {
-    std::vector<std::filesystem::path> rules;
+    struct Rule {
+      std::filesystem::path path;
+      bool top_level{false};
+    };
+
+    std::vector<Rule> rules;
   };
 
   Lint lint;

--- a/src/configuration/json.cc
+++ b/src/configuration/json.cc
@@ -105,8 +105,16 @@ auto Configuration::to_json() const -> sourcemeta::core::JSON {
     auto lint_object{sourcemeta::core::JSON::make_object()};
     auto rules_array{sourcemeta::core::JSON::make_array()};
     for (const auto &rule : this->lint.rules) {
-      rules_array.push_back(
-          sourcemeta::core::JSON{relative_display_path(rule, this->base_path)});
+      if (rule.top_level) {
+        auto rule_object{sourcemeta::core::JSON::make_object()};
+        rule_object.assign("path", sourcemeta::core::JSON{relative_display_path(
+                                       rule.path, this->base_path)});
+        rule_object.assign("topLevel", sourcemeta::core::JSON{true});
+        rules_array.push_back(std::move(rule_object));
+      } else {
+        rules_array.push_back(sourcemeta::core::JSON{
+            relative_display_path(rule.path, this->base_path)});
+      }
     }
 
     lint_object.assign("rules", std::move(rules_array));

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -200,15 +200,33 @@ auto Configuration::from_json(const sourcemeta::core::JSON &value,
       std::size_t index{0};
       for (const auto &element : lint_value.at("rules").as_array()) {
         CONFIGURATION_ENSURE(
-            element.is_string(),
-            "The values in the lint rules array must be strings",
+            element.is_string() || element.is_object(),
+            "The values in the lint rules array must be strings or objects",
             sourcemeta::core::Pointer({"lint", "rules", index}));
 
-        const std::filesystem::path path{element.to_string()};
+        bool top_level{false};
+        if (element.is_object()) {
+          CONFIGURATION_ENSURE(
+              element.defines("path") && element.at("path").is_string(),
+              "The lint rule path property must be a string",
+              sourcemeta::core::Pointer({"lint", "rules", index, "path"}));
+          CONFIGURATION_ENSURE(
+              !element.defines("topLevel") ||
+                  element.at("topLevel").is_boolean(),
+              "The lint rule topLevel property must be a boolean",
+              sourcemeta::core::Pointer({"lint", "rules", index, "topLevel"}));
+          top_level = element.defines("topLevel") &&
+                      element.at("topLevel").to_boolean();
+        }
+
+        const std::filesystem::path path{element.is_string()
+                                             ? element.to_string()
+                                             : element.at("path").to_string()};
         result.lint.rules.push_back(
-            path.is_absolute()
-                ? sourcemeta::core::weakly_canonical(path)
-                : sourcemeta::core::weakly_canonical(base_path / path));
+            {.path = path.is_absolute()
+                         ? sourcemeta::core::weakly_canonical(path)
+                         : sourcemeta::core::weakly_canonical(base_path / path),
+             .top_level = top_level});
         index += 1;
       }
     }

--- a/test/configuration/configuration_from_json_test.cc
+++ b/test/configuration/configuration_from_json_test.cc
@@ -578,10 +578,12 @@ TEST(lint_rules_single) {
       sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
 
   EXPECT_EQ(manifest.lint.rules.size(), 1);
-  EXPECT_TRUE(manifest.lint.rules[0].is_absolute());
-  EXPECT_EQ(manifest.lint.rules[0], std::filesystem::weakly_canonical(
-                                        std::filesystem::path{TEST_DIRECTORY} /
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
                                         "rules" / "my-rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
 }
 
 TEST(lint_rules_multiple) {
@@ -593,14 +595,16 @@ TEST(lint_rules_multiple) {
       sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
 
   EXPECT_EQ(manifest.lint.rules.size(), 2);
-  EXPECT_TRUE(manifest.lint.rules[0].is_absolute());
-  EXPECT_TRUE(manifest.lint.rules[1].is_absolute());
-  EXPECT_EQ(manifest.lint.rules[0],
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_TRUE(manifest.lint.rules[1].path.is_absolute());
+  EXPECT_EQ(manifest.lint.rules[0].path,
             std::filesystem::weakly_canonical(
                 std::filesystem::path{TEST_DIRECTORY} / "rules" / "a.json"));
-  EXPECT_EQ(manifest.lint.rules[1],
+  EXPECT_EQ(manifest.lint.rules[1].path,
             std::filesystem::weakly_canonical(
                 std::filesystem::path{TEST_DIRECTORY} / "rules" / "b.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
+  EXPECT_FALSE(manifest.lint.rules[1].top_level);
 }
 
 TEST(lint_rules_absolute_path) {
@@ -612,10 +616,12 @@ TEST(lint_rules_absolute_path) {
       sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
 
   EXPECT_EQ(manifest.lint.rules.size(), 1);
-  EXPECT_TRUE(manifest.lint.rules[0].is_absolute());
-  EXPECT_EQ(manifest.lint.rules[0], std::filesystem::weakly_canonical(
-                                        std::filesystem::path{TEST_DIRECTORY} /
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
                                         "/absolute/path/rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
 }
 
 TEST(lint_rules_with_other_fields) {
@@ -634,9 +640,11 @@ TEST(lint_rules_with_other_fields) {
   EXPECT_EQ(manifest.title.value(), "Test");
   EXPECT_EQ(manifest.dependencies.size(), 1);
   EXPECT_EQ(manifest.lint.rules.size(), 1);
-  EXPECT_EQ(manifest.lint.rules[0], std::filesystem::weakly_canonical(
-                                        std::filesystem::path{TEST_DIRECTORY} /
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
                                         "rules" / "my-rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
 }
 
 TEST(lint_rules_resolved_from_config_location) {
@@ -653,10 +661,12 @@ TEST(lint_rules_resolved_from_config_location) {
                 std::filesystem::path{TEST_DIRECTORY} / "foo" / "bar"));
   EXPECT_TRUE(manifest.absolute_path_explicit);
   EXPECT_EQ(manifest.lint.rules.size(), 1);
-  EXPECT_TRUE(manifest.lint.rules[0].is_absolute());
-  EXPECT_EQ(manifest.lint.rules[0], std::filesystem::weakly_canonical(
-                                        std::filesystem::path{TEST_DIRECTORY} /
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
                                         "rules" / "my-rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
 }
 
 TEST(lint_rules_multiple_resolved_from_config_location) {
@@ -673,12 +683,14 @@ TEST(lint_rules_multiple_resolved_from_config_location) {
                 std::filesystem::path{TEST_DIRECTORY} / "foo" / "bar"));
   EXPECT_TRUE(manifest.absolute_path_explicit);
   EXPECT_EQ(manifest.lint.rules.size(), 2);
-  EXPECT_EQ(manifest.lint.rules[0],
+  EXPECT_EQ(manifest.lint.rules[0].path,
             std::filesystem::weakly_canonical(
                 std::filesystem::path{TEST_DIRECTORY} / "rules" / "a.json"));
-  EXPECT_EQ(manifest.lint.rules[1],
+  EXPECT_EQ(manifest.lint.rules[1].path,
             std::filesystem::weakly_canonical(
                 std::filesystem::path{TEST_DIRECTORY} / "rules" / "b.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
+  EXPECT_FALSE(manifest.lint.rules[1].top_level);
 }
 
 TEST(lint_not_object) {
@@ -707,7 +719,8 @@ TEST(lint_rules_element_not_string) {
 
   EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
       input, TEST_DIRECTORY,
-      "The values in the lint rules array must be strings", "/lint/rules/0");
+      "The values in the lint rules array must be strings or objects",
+      "/lint/rules/0");
 }
 
 TEST(lint_rules_mixed_types) {
@@ -717,7 +730,220 @@ TEST(lint_rules_mixed_types) {
 
   EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
       input, TEST_DIRECTORY,
-      "The values in the lint rules array must be strings", "/lint/rules/1");
+      "The values in the lint rules array must be strings or objects",
+      "/lint/rules/1");
+}
+
+TEST(lint_rules_object_with_path_only) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ { "path": "./rules/my-rule.json" } ] }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "rules" / "my-rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_object_with_top_level_true) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": true } ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "rules" / "my-rule.json"));
+  EXPECT_TRUE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_object_with_top_level_false) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": false } ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "rules" / "my-rule.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_object_absolute_path) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [ { "path": "/absolute/path/rule.json", "topLevel": true } ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "/absolute/path/rule.json"));
+  EXPECT_TRUE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_mixed_string_and_object) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [
+        "./rules/a.json",
+        { "path": "./rules/b.json", "topLevel": true },
+        { "path": "./rules/c.json" }
+      ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 3);
+  EXPECT_EQ(manifest.lint.rules[0].path,
+            std::filesystem::weakly_canonical(
+                std::filesystem::path{TEST_DIRECTORY} / "rules" / "a.json"));
+  EXPECT_EQ(manifest.lint.rules[1].path,
+            std::filesystem::weakly_canonical(
+                std::filesystem::path{TEST_DIRECTORY} / "rules" / "b.json"));
+  EXPECT_EQ(manifest.lint.rules[2].path,
+            std::filesystem::weakly_canonical(
+                std::filesystem::path{TEST_DIRECTORY} / "rules" / "c.json"));
+  EXPECT_FALSE(manifest.lint.rules[0].top_level);
+  EXPECT_TRUE(manifest.lint.rules[1].top_level);
+  EXPECT_FALSE(manifest.lint.rules[2].top_level);
+}
+
+TEST(lint_rules_object_unknown_properties_ignored) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [
+        { "path": "./rules/my-rule.json", "topLevel": true, "foo": "bar" }
+      ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "rules" / "my-rule.json"));
+  EXPECT_TRUE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_object_resolved_from_config_location) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "path": "./foo/bar",
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": true } ]
+    }
+  })JSON")};
+
+  const auto manifest{
+      sourcemeta::blaze::Configuration::from_json(input, TEST_DIRECTORY)};
+
+  EXPECT_EQ(manifest.absolute_path,
+            std::filesystem::weakly_canonical(
+                std::filesystem::path{TEST_DIRECTORY} / "foo" / "bar"));
+  EXPECT_TRUE(manifest.absolute_path_explicit);
+  EXPECT_EQ(manifest.lint.rules.size(), 1);
+  EXPECT_TRUE(manifest.lint.rules[0].path.is_absolute());
+  EXPECT_EQ(
+      manifest.lint.rules[0].path,
+      std::filesystem::weakly_canonical(std::filesystem::path{TEST_DIRECTORY} /
+                                        "rules" / "my-rule.json"));
+  EXPECT_TRUE(manifest.lint.rules[0].top_level);
+}
+
+TEST(lint_rules_element_null) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ null ] }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY,
+      "The values in the lint rules array must be strings or objects",
+      "/lint/rules/0");
+}
+
+TEST(lint_rules_element_array) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ [ "./rules/my-rule.json" ] ] }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY,
+      "The values in the lint rules array must be strings or objects",
+      "/lint/rules/0");
+}
+
+TEST(lint_rules_object_missing_path) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ { "topLevel": true } ] }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY, "The lint rule path property must be a string",
+      "/lint/rules/0/path");
+}
+
+TEST(lint_rules_object_path_not_string) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ { "path": 1 } ] }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY, "The lint rule path property must be a string",
+      "/lint/rules/0/path");
+}
+
+TEST(lint_rules_object_top_level_not_boolean) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": 1 } ]
+    }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY,
+      "The lint rule topLevel property must be a boolean",
+      "/lint/rules/0/topLevel");
+}
+
+TEST(lint_rules_object_missing_path_second_entry) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "lint": { "rules": [ "./rules/a.json", { "topLevel": true } ] }
+  })JSON")};
+
+  EXPECT_CONFIGURATION_FROM_JSON_PARSE_ERROR(
+      input, TEST_DIRECTORY, "The lint rule path property must be a string",
+      "/lint/rules/1/path");
 }
 
 TEST(ignore_empty) {

--- a/test/configuration/configuration_json_test.cc
+++ b/test/configuration/configuration_json_test.cc
@@ -373,6 +373,97 @@ TEST(to_json_roundtrip_with_lint_rules) {
   EXPECT_EQ(output, input);
 }
 
+TEST(to_json_with_top_level_lint_rule) {
+  sourcemeta::blaze::Configuration config;
+  config.absolute_path = "/test";
+  config.absolute_path_explicit = true;
+  config.base_path = "/test";
+  config.base = "https://example.com";
+  config.base_uri = sourcemeta::core::URI{config.base};
+  config.lint.rules.push_back(
+      {.path = "/test/rules/my-rule.json", .top_level = true});
+
+  const auto result{config.to_json()};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "path": "/test",
+    "baseUri": "https://example.com",
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": true } ]
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(to_json_with_mixed_lint_rules) {
+  sourcemeta::blaze::Configuration config;
+  config.absolute_path = "/test";
+  config.absolute_path_explicit = true;
+  config.base_path = "/test";
+  config.base = "https://example.com";
+  config.base_uri = sourcemeta::core::URI{config.base};
+  config.lint.rules.push_back(
+      {.path = "/test/rules/my-rule.json", .top_level = false});
+  config.lint.rules.push_back(
+      {.path = "/test/rules/other-rule.json", .top_level = true});
+
+  const auto result{config.to_json()};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "path": "/test",
+    "baseUri": "https://example.com",
+    "lint": {
+      "rules": [
+        "./rules/my-rule.json",
+        { "path": "./rules/other-rule.json", "topLevel": true }
+      ]
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(to_json_roundtrip_with_top_level_lint_rule) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "baseUri": "https://schemas.sourcemeta.com",
+    "path": "/test",
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json", "topLevel": true } ]
+    }
+  })JSON")};
+
+  const auto config{
+      sourcemeta::blaze::Configuration::from_json(input, "/test")};
+  const auto output{config.to_json()};
+
+  EXPECT_EQ(output, input);
+}
+
+TEST(to_json_object_lint_rule_without_top_level_as_string) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "baseUri": "https://schemas.sourcemeta.com",
+    "path": "/test",
+    "lint": {
+      "rules": [ { "path": "./rules/my-rule.json" } ]
+    }
+  })JSON")};
+
+  const auto config{
+      sourcemeta::blaze::Configuration::from_json(input, "/test")};
+  const auto output{config.to_json()};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "baseUri": "https://schemas.sourcemeta.com",
+    "path": "/test",
+    "lint": {
+      "rules": [ "./rules/my-rule.json" ]
+    }
+  })JSON")};
+
+  EXPECT_EQ(output, expected);
+}
+
 TEST(to_json_roundtrip_with_lint_and_dependencies) {
   const auto input{sourcemeta::core::parse_json(R"JSON({
     "baseUri": "https://schemas.sourcemeta.com",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

