### PR TITLE
Fix fast-mode compilation of type and size-bound keywords

### DIFF
--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -11,6 +11,7 @@
 #include <iterator>   // std::distance
 #include <optional>   // std::optional
 #include <regex>      // std::regex, std::regex_match, std::smatch
+#include <stdexcept>  // std::out_of_range
 #include <utility>    // std::declval, std::move
 
 namespace sourcemeta::blaze {
@@ -167,9 +168,16 @@ unsigned_integer_property(const sourcemeta::core::JSON &document,
                           const sourcemeta::core::JSON::String &property)
     -> std::optional<std::size_t> {
   if (document.defines(property) && document.at(property).is_integral()) {
-    const auto value{document.at(property).as_integer()};
-    assert(value >= 0);
-    return static_cast<std::size_t>(value);
+    // A real or decimal may spell an integer too large to represent, and such a
+    // bound sits so far beyond any instance that we ignore it, just as a
+    // non-integral bound is ignored, rather than let the conversion raise
+    try {
+      const auto value{document.at(property).as_integer()};
+      assert(value >= 0);
+      return static_cast<std::size_t>(value);
+    } catch (const std::out_of_range &) {
+      return std::nullopt;
+    }
   }
 
   return std::nullopt;

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -159,12 +159,15 @@ inline auto rephrase(const Context &context, const InstructionIndex type,
           .extra_index = extra_index};
 }
 
+// Note that the size keywords that let the type level fuse their bound accept
+// any integral number, including reals with no fractional part like `2.0`, so
+// this must recognise those too or the fused bound would be silently dropped
 inline auto
 unsigned_integer_property(const sourcemeta::core::JSON &document,
                           const sourcemeta::core::JSON::String &property)
     -> std::optional<std::size_t> {
-  if (document.defines(property) && document.at(property).is_integer()) {
-    const auto value{document.at(property).to_integer()};
+  if (document.defines(property) && document.at(property).is_integral()) {
+    const auto value{document.at(property).as_integer()};
     assert(value >= 0);
     return static_cast<std::size_t>(value);
   }

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -1758,8 +1758,11 @@ auto compiler_draft3_validation_maxlength(const Context &context,
     return {};
   }
 
-  // We'll handle it at the type level as an optimization
+  // We'll handle it at the type level as an optimization. Note that the type
+  // compiler bails out before it reads these bounds when it is compiling a
+  // property name, so there we must still emit them ourselves
   if (context.mode == Mode::FastValidation &&
+      !schema_context.is_property_name &&
       schema_context.schema.defines("type") &&
       schema_context.schema.at("type").is_string() &&
       schema_context.schema.at("type").to_string() == "string") {
@@ -1792,8 +1795,11 @@ auto compiler_draft3_validation_minlength(const Context &context,
     return {};
   }
 
-  // We'll handle it at the type level as an optimization
+  // We'll handle it at the type level as an optimization. Note that the type
+  // compiler bails out before it reads these bounds when it is compiling a
+  // property name, so there we must still emit them ourselves
   if (context.mode == Mode::FastValidation &&
+      !schema_context.is_property_name &&
       schema_context.schema.defines("type") &&
       schema_context.schema.at("type").is_string() &&
       schema_context.schema.at("type").to_string() == "string") {
@@ -2092,6 +2098,12 @@ auto compiler_draft3_validation_type(const Context &context,
             unsigned_integer_property(schema_context.schema, "maxProperties")};
 
         if (context.mode == Mode::FastValidation) {
+          if (maximum.has_value() && minimum > maximum.value()) {
+            return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                         context, schema_context, dynamic_context,
+                         ValueNone{})};
+          }
+
           if (maximum.has_value() && minimum == 0) {
             return {make(
                 sourcemeta::blaze::InstructionIndex::AssertionTypeObjectUpper,
@@ -2131,6 +2143,11 @@ auto compiler_draft3_validation_type(const Context &context,
           unsigned_integer_property(schema_context.schema, "maxItems")};
 
       if (context.mode == Mode::FastValidation) {
+        if (maximum.has_value() && minimum > maximum.value()) {
+          return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                       context, schema_context, dynamic_context, ValueNone{})};
+        }
+
         if (maximum.has_value() && minimum == 0) {
           return {
               make(sourcemeta::blaze::InstructionIndex::AssertionTypeArrayUpper,
@@ -2195,6 +2212,11 @@ auto compiler_draft3_validation_type(const Context &context,
           unsigned_integer_property(schema_context.schema, "maxLength")};
 
       if (context.mode == Mode::FastValidation) {
+        if (maximum.has_value() && minimum > maximum.value()) {
+          return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                       context, schema_context, dynamic_context, ValueNone{})};
+        }
+
         if (maximum.has_value() && minimum == 0) {
           return {make(
               sourcemeta::blaze::InstructionIndex::AssertionTypeStringUpper,
@@ -2286,8 +2308,16 @@ auto compiler_draft3_validation_type(const Context &context,
     }
 
     if (!types.any()) {
-      return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
-                   schema_context, dynamic_context, ValueNone{})};
+      // An empty array names no type at all, so no value can match it. A
+      // non-empty one that named only unrecognised types is an invalid but
+      // legitimate use of the keyword that we ignore, constraining nothing,
+      // exactly as the scalar form does for a single unrecognised name
+      if (value.empty()) {
+        return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                     context, schema_context, dynamic_context, ValueNone{})};
+      }
+
+      return {};
     }
 
     return {make(sourcemeta::blaze::InstructionIndex::AssertionTypeStrictAny,

--- a/src/compiler/default_compiler_draft6.h
+++ b/src/compiler/default_compiler_draft6.h
@@ -30,8 +30,24 @@ auto compiler_draft6_validation_type(const Context &context,
       return {};
     }
 
-    return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
-                 schema_context, dynamic_context, ValueNone{})};
+    // A set that names known types, none of them a string, can never match a
+    // property name, so every name fails
+    if (types.any()) {
+      return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
+                   schema_context, dynamic_context, ValueNone{})};
+    }
+
+    // No known type was named. An empty array names nothing at all, so no name
+    // can match it, whereas an unrecognised name is an invalid but legitimate
+    // use that constrains nothing and is ignored, matching how the forms below
+    // treat both outside `propertyNames`
+    if (schema_context.schema.at(dynamic_context.keyword).is_array() &&
+        schema_context.schema.at(dynamic_context.keyword).empty()) {
+      return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
+                   schema_context, dynamic_context, ValueNone{})};
+    }
+
+    return {};
   }
 
   if (schema_context.schema.at(dynamic_context.keyword).is_string()) {

--- a/src/compiler/default_compiler_draft6.h
+++ b/src/compiler/default_compiler_draft6.h
@@ -16,6 +16,24 @@ auto compiler_draft6_validation_type(const Context &context,
                                      const DynamicContext &dynamic_context,
                                      const Instructions &current)
     -> Instructions {
+  // Every property name is a string, so inside `propertyNames` this keyword
+  // is decidable at compile time. Note that the evaluator applies such a
+  // subschema to a null placeholder and carries the name out of band, so a
+  // type assertion emitted here would test that placeholder rather than the
+  // name. The failure is emitted per name, as these instructions become the
+  // children of the loop over the keys, so an object with no properties
+  // still passes
+  if (schema_context.is_property_name) {
+    const auto types{sourcemeta::blaze::parse_schema_type(
+        schema_context.schema.at(dynamic_context.keyword))};
+    if (types.test(std::to_underlying(sourcemeta::core::JSON::Type::String))) {
+      return {};
+    }
+
+    return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
+                 schema_context, dynamic_context, ValueNone{})};
+  }
+
   if (schema_context.schema.at(dynamic_context.keyword).is_string()) {
     const auto &type{
         schema_context.schema.at(dynamic_context.keyword).to_string()};
@@ -64,6 +82,11 @@ auto compiler_draft6_validation_type(const Context &context,
           unsigned_integer_property(schema_context.schema, "maxProperties")};
 
       if (context.mode == Mode::FastValidation) {
+        if (maximum.has_value() && minimum > maximum.value()) {
+          return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                       context, schema_context, dynamic_context, ValueNone{})};
+        }
+
         if (maximum.has_value() && minimum == 0) {
           return {make(
               sourcemeta::blaze::InstructionIndex::AssertionTypeObjectUpper,
@@ -101,15 +124,25 @@ auto compiler_draft6_validation_type(const Context &context,
                    context, schema_context, dynamic_context,
                    sourcemeta::core::JSON::Type::Object)};
     } else if (type == "array") {
-      if (context.mode == Mode::FastValidation && !current.empty() &&
+      const auto minimum{
+          unsigned_integer_property(schema_context.schema, "minItems", 0)};
+      const auto maximum{
+          unsigned_integer_property(schema_context.schema, "maxItems")};
+
+      // A preceding array loop at this location already rejects a non-array,
+      // so the type assertion is redundant. The array size bounds are only
+      // redundant when there are none to enforce, as the loops other than the
+      // sized one do not check the item count. Only a loop that truly rejects
+      // a non-array qualifies: some item loops instead pass a non-array
+      // untouched, so they are deliberately excluded below
+      if (context.mode == Mode::FastValidation && minimum == 0 &&
+          !maximum.has_value() && !current.empty() &&
           (current.back().type ==
                sourcemeta::blaze::InstructionIndex::
                    LoopItemsPropertiesExactlyTypeStrictHash ||
            current.back().type ==
                sourcemeta::blaze::InstructionIndex::
                    LoopItemsPropertiesExactlyTypeStrictHash3 ||
-           current.back().type ==
-               sourcemeta::blaze::InstructionIndex::LoopItemsIntegerBounded ||
            current.back().type == sourcemeta::blaze::InstructionIndex::
                                       LoopItemsIntegerBoundedSized) &&
           current.back().relative_instance_location ==
@@ -117,12 +150,12 @@ auto compiler_draft6_validation_type(const Context &context,
         return {};
       }
 
-      const auto minimum{
-          unsigned_integer_property(schema_context.schema, "minItems", 0)};
-      const auto maximum{
-          unsigned_integer_property(schema_context.schema, "maxItems")};
-
       if (context.mode == Mode::FastValidation) {
+        if (maximum.has_value() && minimum > maximum.value()) {
+          return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                       context, schema_context, dynamic_context, ValueNone{})};
+        }
+
         if (maximum.has_value() && minimum == 0) {
           return {
               make(sourcemeta::blaze::InstructionIndex::AssertionTypeArrayUpper,
@@ -196,16 +229,17 @@ auto compiler_draft6_validation_type(const Context &context,
                    schema_context, dynamic_context,
                    sourcemeta::core::JSON::Type::Integer)};
     } else if (type == "string") {
-      if (schema_context.is_property_name) {
-        return {};
-      }
-
       const auto minimum{
           unsigned_integer_property(schema_context.schema, "minLength", 0)};
       const auto maximum{
           unsigned_integer_property(schema_context.schema, "maxLength")};
 
       if (context.mode == Mode::FastValidation) {
+        if (maximum.has_value() && minimum > maximum.value()) {
+          return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                       context, schema_context, dynamic_context, ValueNone{})};
+        }
+
         if (maximum.has_value() && minimum == 0) {
           return {make(
               sourcemeta::blaze::InstructionIndex::AssertionTypeStringUpper,
@@ -275,10 +309,6 @@ auto compiler_draft6_validation_type(const Context &context,
                    schema_context, dynamic_context,
                    sourcemeta::core::JSON::Type::Integer)};
     } else if (type == "string") {
-      if (schema_context.is_property_name) {
-        return {};
-      }
-
       return {make(sourcemeta::blaze::InstructionIndex::AssertionTypeStrict,
                    context, schema_context, dynamic_context,
                    sourcemeta::core::JSON::Type::String)};
@@ -306,15 +336,23 @@ auto compiler_draft6_validation_type(const Context &context,
       } else if (type_string == "integer") {
         types.set(std::to_underlying(sourcemeta::core::JSON::Type::Integer));
       } else if (type_string == "string") {
-        if (schema_context.is_property_name) {
-          continue;
-        }
-
         types.set(std::to_underlying(sourcemeta::core::JSON::Type::String));
       }
     }
 
-    assert(types.any());
+    if (types.none()) {
+      // An empty array names no type at all, so no value can match it. A
+      // non-empty one that named only unrecognised types is an invalid but
+      // legitimate use of the keyword that we ignore, constraining nothing,
+      // exactly as the scalar form does for a single unrecognised name
+      if (schema_context.schema.at(dynamic_context.keyword).empty()) {
+        return {make(sourcemeta::blaze::InstructionIndex::AssertionFail,
+                     context, schema_context, dynamic_context, ValueNone{})};
+      }
+
+      return {};
+    }
+
     return {make(sourcemeta::blaze::InstructionIndex::AssertionTypeAny, context,
                  schema_context, dynamic_context, types)};
   }

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -6292,5 +6292,27 @@
       "post": [],
       "descriptions": []
     }
+  },
+  {
+    "description": "property_names_type_unknown_names",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": [ "foo" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
+  },
+  {
+    "description": "property_names_type_unknown_name_scalar",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "foo" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
   }
 ]

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -5260,5 +5260,1037 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
+  },
+  {
+    "description": "object_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "minProperties": 3,
+      "maxProperties": 1
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2, "c": 3 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items but it contained 1 item"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "a",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null_empty_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_string_or_boolean",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": [ "string", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_number_or_boolean",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": [ "number", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_or_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": [ "string", "null" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_not_type_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "not": { "type": "null" } }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "abcdefgh": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "ab": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_min_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "propertyNames": { "type": "string", "minLength": 4 }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": "hello",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "LogicalWhenType", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenType", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 5",
+        "The integer value 2 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 5",
+        "The integer value 3 was expected to be greater than or equal to the integer 1",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The value was expected to be of type array",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_out_of_range",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 99 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 99 was expected to be less than or equal to the integer 5",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_unknown_names",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": [ "foo", "bar" ]
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -5215,5 +5215,1068 @@
         "The object value was expected to validate against the defined properties subschemas"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
+  },
+  {
+    "description": "object_inverted_bounds",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "minProperties": 3,
+      "maxProperties": 1
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2, "c": 3 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items but it contained 1 item"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "a",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null_empty_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_string_or_boolean",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": [ "string", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_number_or_boolean",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": [ "number", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_or_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": [ "string", "null" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_not_type_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "not": { "type": "null" } }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "abcdefgh": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length_within",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "ab": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_min_length",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "string", "minLength": 4 }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": "hello",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItemsFrom", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 5",
+        "The integer value 2 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 5",
+        "The integer value 3 was expected to be greater than or equal to the integer 1",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 2 additional items not described by related keywords",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_out_of_range",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 99 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItemsFrom", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 99 was expected to be less than or equal to the integer 5",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_partially_unknown_names",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": [ "string", "foo" ]
+    },
+    "instance": "x",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeAny", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeAny", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_unknown_names",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": [ "foo", "bar" ]
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -6278,5 +6278,27 @@
       "post": [],
       "descriptions": []
     }
+  },
+  {
+    "description": "property_names_type_unknown_names",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": [ "foo" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
+  },
+  {
+    "description": "property_names_type_unknown_name_scalar",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "propertyNames": { "type": "foo" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
   }
 ]

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -5618,3 +5618,19 @@ TEST(type_array_partially_unknown_names_invalid) {
                                "The value was expected to be of type string "
                                "but it was of type integer");
 }
+
+TEST(type_object_oversized_max_properties_ignored) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "maxProperties": 1e308
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("{}")};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1, "");
+
+  EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type object");
+}

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -5602,3 +5602,19 @@ TEST(annotation_exhaustive_empty_whitelist_no_short_circuit) {
       "The array value was expected to contain at least 1 item that validates "
       "against the given subschema");
 }
+
+TEST(type_array_partially_unknown_names_invalid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": [ "string", "foo" ]
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("5")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 1, "");
+
+  EVALUATE_TRACE_PRE(0, AssertionTypeAny, "/type", "#/type", "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionTypeAny, "/type", "#/type", "");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string "
+                               "but it was of type integer");
+}

--- a/test/evaluator/evaluator_draft3.json
+++ b/test/evaluator/evaluator_draft3.json
@@ -12787,5 +12787,71 @@
         "The object value was expected to validate against the defined properties subschemas"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft4.json
+++ b/test/evaluator/evaluator_draft4.json
@@ -12059,5 +12059,525 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
+  },
+  {
+    "description": "object_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "minProperties": 3,
+      "maxProperties": 1
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2, "c": 3 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items but it contained 1 item"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "a",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_unknown_names",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": [ "foo", "bar" ]
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -6328,5 +6328,27 @@
       "post": [],
       "descriptions": []
     }
+  },
+  {
+    "description": "property_names_type_unknown_names",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": [ "foo" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
+  },
+  {
+    "description": "property_names_type_unknown_name_scalar",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "foo" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
   }
 ]

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -5305,5 +5305,1028 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
+  },
+  {
+    "description": "object_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "minProperties": 3,
+      "maxProperties": 1
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2, "c": 3 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items but it contained 1 item"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "a",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null_empty_object",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_string_or_boolean",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": [ "string", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_number_or_boolean",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": [ "number", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_or_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": [ "string", "null" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_not_type_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "not": { "type": "null" } }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "abcdefgh": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "ab": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_min_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "propertyNames": { "type": "string", "minLength": 4 }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_string",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": "hello",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_object",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to be less than or equal to the integer 5",
+        "The integer value 2 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 5",
+        "The integer value 3 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_out_of_range",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 99 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The integer value 99 was expected to be less than or equal to the integer 5",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_unknown_names",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": [ "foo", "bar" ]
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -1861,5 +1861,27 @@
         "Every item in the array value was expected to validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "property_names_type_unknown_names",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": [ "foo" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
+  },
+  {
+    "description": "property_names_type_unknown_name_scalar",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "foo" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {},
+    "exhaustive": {}
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -857,5 +857,1009 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "string_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "array_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 1 item but it contained 2 items"
+      ]
+    }
+  },
+  {
+    "description": "object_inverted_bounds",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "minProperties": 3,
+      "maxProperties": 1
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2, "c": 3 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_max_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "maxProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at most 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
+      ]
+    }
+  },
+  {
+    "description": "type_object_real_min_properties_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "minProperties": 2.0
+    },
+    "instance": { "a": 1, "b": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an object of at least 2 properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_max_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "maxItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at most 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items but it contained 1 item"
+      ]
+    }
+  },
+  {
+    "description": "type_array_real_min_items_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 2.0
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of at least 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "abcd",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_max_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "maxLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at most 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "a",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+      ],
+      "descriptions": [
+        "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
+      ]
+    }
+  },
+  {
+    "description": "type_string_real_min_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "minLength": 2.0
+    },
+    "instance": "ab",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of a string of at least 2 characters"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
+        "The value was expected to be of type string"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_null_empty_object",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "null" }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "post": [
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object is empty and no properties were expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_string_or_boolean",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": [ "string", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_type_number_or_boolean",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": [ "number", "boolean" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_or_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": [ "string", "null" ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "property_names_not_type_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "not": { "type": "null" } }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
+        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to not validate against the given subschema",
+        "The object property \"a\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "abcdefgh": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
+        "The object property \"abcdefgh\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_max_length_within",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "string", "maxLength": 3 }
+    },
+    "instance": { "ab": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
+        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "property_names_type_string_min_length",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "propertyNames": { "type": "string", "minLength": 4 }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
+        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
+        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+      ],
+      "descriptions": [
+        "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
+        "The object property \"ab\" was expected to validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_string",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": "hello",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type string"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_object",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type object"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to be less than or equal to the integer 5",
+        "The integer value 2 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 5",
+        "The integer value 3 was expected to be greater than or equal to the integer 1",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "type_array_items_bounded_out_of_range",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+    },
+    "instance": [ 99 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The integer value 99 was expected to be less than or equal to the integer 5",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

