### PR TITLE
Tighten fast-mode `additionalProperties` and `required` elision preconditions

### DIFF
--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -1195,14 +1195,28 @@ auto compiler_draft3_applicator_additionalproperties_with_options(
     return {};
   }
 
-  // When `additionalProperties: false` with only `properties` (no
-  // patternProperties), and `properties` is compiled as a loop
-  // (LoopPropertiesMatchClosed), that loop already handles rejecting unknown
-  // properties, so we don't need to emit anything for `additionalProperties`
-  if (context.mode == Mode::FastValidation && children.size() == 1 &&
+  // The closed forms that the elisions below rely on are only emitted when
+  // `additionalProperties` is the boolean `false`. Testing the compiled shape
+  // alone is not enough, as other subschemas that reject everything, like an
+  // empty `enum`, also reduce to an unconditional failure without closing
+  // anything
+  const auto rejects_with_boolean_false{
+      schema_context.schema.at(dynamic_context.keyword).is_boolean() &&
+      !schema_context.schema.at(dynamic_context.keyword).to_boolean()};
+
+  // When `additionalProperties: false` sits with `properties` alone and
+  // `properties` compiles to its closed form, that form already rejects
+  // unknown properties, so `additionalProperties` need emit nothing. Both
+  // evaluation tracking and a defined `patternProperties` hold `properties`
+  // back to its non-closed form, in which case the closure must still be
+  // emitted here. An empty `patternProperties` contributes no property filters
+  // yet still counts as defined, so its mere presence, not the filters it
+  // yields, is what matters
+  if (context.mode == Mode::FastValidation && !track_evaluation &&
+      rejects_with_boolean_false && children.size() == 1 &&
       children.front().type == InstructionIndex::AssertionFail &&
-      !filter_strings.empty() && filter_prefixes.empty() &&
-      filter_regexes.empty() &&
+      !filter_strings.empty() &&
+      !schema_context.schema.defines("patternProperties") &&
       properties_as_loop(context, schema_context,
                          schema_context.schema.at("properties"))) {
     return {};
@@ -1229,9 +1243,12 @@ auto compiler_draft3_applicator_additionalproperties_with_options(
     }
   }
 
+  // Similarly, `patternProperties` only compiles to its closed form, which
+  // rejects unmatched properties on its own, when `additionalProperties` is
+  // the boolean `false`
   if (context.mode == Mode::FastValidation && filter_strings.empty() &&
       filter_prefixes.empty() && filter_regexes.size() == 1 &&
-      !track_evaluation && !children.empty() &&
+      !track_evaluation && rejects_with_boolean_false && !children.empty() &&
       children.front().type == InstructionIndex::AssertionFail) {
     return {};
   }
@@ -2128,8 +2145,13 @@ auto compiler_draft3_validation_type(const Context &context,
         return {};
       }
 
+      // A non-empty `required` rejects a non-object on its own, so the type
+      // assertion is redundant. An empty `required` asserts nothing, so the
+      // type check must stay
       if (!is_draft3 && context.mode == Mode::FastValidation &&
-          schema_context.schema.defines("required")) {
+          schema_context.schema.defines("required") &&
+          schema_context.schema.at("required").is_array() &&
+          !schema_context.schema.at("required").empty()) {
         return {};
       }
 

--- a/src/compiler/default_compiler_draft6.h
+++ b/src/compiler/default_compiler_draft6.h
@@ -131,8 +131,13 @@ auto compiler_draft6_validation_type(const Context &context,
         return {};
       }
 
+      // A non-empty `required` rejects a non-object on its own, so the type
+      // assertion is redundant. An empty `required` asserts nothing, so the
+      // type check must stay
       if (context.mode == Mode::FastValidation &&
-          schema_context.schema.defines("required")) {
+          schema_context.schema.defines("required") &&
+          schema_context.schema.at("required").is_array() &&
+          !schema_context.schema.at("required").empty()) {
         return {};
       }
 

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -6314,5 +6314,401 @@
     "valid": true,
     "fast": {},
     "exhaustive": {}
+  },
+  {
+    "description": "type_object_empty_required_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": []
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_object_empty_required_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": []
+    },
+    "instance": { "k": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_matching",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "ab": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "Annotation", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "Annotation", "/patternProperties", "#/patternProperties", "", "ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"ab\" successfully validated against its pattern property subschema",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_bad_type",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional_known",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x", "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties_known",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -6300,5 +6300,401 @@
     "valid": true,
     "fast": {},
     "exhaustive": {}
+  },
+  {
+    "description": "type_object_empty_required_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": []
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_object_empty_required_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": []
+    },
+    "instance": { "k": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_matching",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "ab": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "Annotation", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "Annotation", "/patternProperties", "#/patternProperties", "", "ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"ab\" successfully validated against its pattern property subschema",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_bad_type",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The integer value was not expected to validate against the empty enumeration",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional_known",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "enum": [] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x", "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties_known",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -6350,5 +6350,331 @@
     "valid": true,
     "fast": {},
     "exhaustive": {}
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x", "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties_known",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "No instance is expected to succeed against the false schema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to validate against the given subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_matching",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "ab": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_bad_type",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "No instance is expected to succeed against the false schema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to validate against the given subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional_known",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -1883,5 +1883,395 @@
     "valid": true,
     "fast": {},
     "exhaustive": {}
+  },
+  {
+    "description": "type_object_empty_required_null",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": []
+    },
+    "instance": null,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type null"
+      ]
+    }
+  },
+  {
+    "description": "type_object_empty_required_object",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": []
+    },
+    "instance": { "k": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x", "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define additional properties"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_empty_pattern_properties_known",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "integer" },
+        "c": { "type": "boolean" }
+      },
+      "patternProperties": {},
+      "additionalProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the 3 defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "No instance is expected to succeed against the false schema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to validate against the given subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_matching",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "ab": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "pattern_properties_nonboolean_additional_bad_type",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "patternProperties": { "^a.$": { "type": "string" } },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "ab": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "zzz": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "No instance is expected to succeed against the false schema",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
+        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
+        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
+        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "No instance is expected to succeed against the false schema",
+        "The integer value was expected to validate against the given subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "closed_properties_nonboolean_additional_known",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
+      "additionalProperties": { "allOf": [ false ] }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object value was not expected to define additional properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "post": [
+        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the 6 defined properties subschemas",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

