### PR TITLE
Fix fast-mode post-processing subsumption and positional child ownership

### DIFF
--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <string> // std::string
+#include <tuple>  // std::tuple
 #include <unordered_map>
 #include <unordered_set> // std::unordered_set
 #include <vector>
@@ -156,8 +157,12 @@ transform_instruction(Instruction &instruction, Instructions &output,
                       const std::vector<Instructions> &targets,
                       const std::vector<TargetStatistics> &statistics,
                       TargetStatistics &current_stats, const Tweaks &tweaks,
-                      const bool uses_dynamic_scopes) -> bool {
-  if (instruction.type == InstructionIndex::ControlJump) {
+                      const bool uses_dynamic_scopes, const bool positional)
+    -> bool {
+  // A positional owner pairs each child with an entry of its own data by
+  // index, and inlining a jump expands one child into many, which would
+  // re-pair the rest
+  if (!positional && instruction.type == InstructionIndex::ControlJump) {
     const auto jump_target_index{
         std::get<ValueUnsignedInteger>(instruction.value)};
     const auto &jump_target_stats{statistics[jump_target_index]};
@@ -380,13 +385,12 @@ inline auto postprocess(std::vector<Instructions> &targets,
       auto &target{targets[current_target_index]};
       auto &current_stats{statistics[current_target_index]};
 
-      std::vector<Instructions *> worklist;
-      std::vector<std::pair<Instructions *, std::size_t>> stack;
-      stack.emplace_back(&target, 0);
+      std::vector<std::pair<Instructions *, Instruction *>> worklist;
+      std::vector<std::tuple<Instructions *, std::size_t, Instruction *>> stack;
+      stack.emplace_back(&target, 0, nullptr);
 
       while (!stack.empty()) {
-        auto current{stack.back().first};
-        auto index{stack.back().second};
+        auto [current, index, owner] = stack.back();
         stack.pop_back();
 
         while (index < current->size() && (*current)[index].children.empty()) {
@@ -394,38 +398,100 @@ inline auto postprocess(std::vector<Instructions> &targets,
         }
 
         if (index < current->size()) {
-          stack.emplace_back(current, index + 1);
-          stack.emplace_back(&(*current)[index].children, 0);
+          stack.emplace_back(current, index + 1, owner);
+          stack.emplace_back(&(*current)[index].children, 0,
+                             &(*current)[index]);
         } else {
-          worklist.push_back(current);
+          worklist.emplace_back(current, owner);
         }
       }
 
-      for (auto *current : worklist) {
+      for (const auto &[current, owner] : worklist) {
         Instructions result;
         result.reserve(current->size());
 
-        std::unordered_set<std::string> fusion_covered_properties;
-        for (const auto &instruction : *current) {
-          if (instruction.type ==
-              InstructionIndex::AssertionObjectPropertiesSimple) {
-            const auto &entries{
-                std::get<ValueObjectProperties>(instruction.value)};
-            for (const auto &entry : entries) {
-              fusion_covered_properties.insert(std::get<0>(entry));
+        // The children of a conditional span its mutually exclusive
+        // condition, consequence, and alternative segments, and the children
+        // of a disjunction are alternative branches, so an instruction in one
+        // of them cannot subsume an instruction in another. Every other
+        // children list is a conjunction evaluated as a whole, where
+        // subsumption holds
+        // A fused simple-properties instruction pairs its entries with its
+        // children by index, so its children may neither be dropped, expanded,
+        // nor subsumed by each other, as each one applies to a different
+        // property despite them all sharing an empty instance location
+        const bool positional{
+            owner != nullptr &&
+            owner->type == InstructionIndex::AssertionObjectPropertiesSimple};
+
+        const bool disjoint{
+            positional || (owner != nullptr &&
+                           (owner->type == InstructionIndex::LogicalCondition ||
+                            owner->type == InstructionIndex::LogicalOr ||
+                            owner->type == InstructionIndex::LogicalXor))};
+
+        // A fused simple-properties instruction only enforces that a property
+        // is present for the entries it marks as required, so only those may
+        // subsume a sibling presence assertion. Every fused instruction, on
+        // the other hand, rejects a non-object outright, so any of them can
+        // subsume a sibling object type assertion. None of that says anything
+        // about the rest of the instance, so a fused instruction may only
+        // subsume siblings that apply to the very same instance location
+        std::vector<std::pair<sourcemeta::core::Pointer,
+                              std::unordered_set<std::string>>>
+            fusions;
+        if (!disjoint) {
+          for (const auto &instruction : *current) {
+            if (instruction.type !=
+                InstructionIndex::AssertionObjectPropertiesSimple) {
+              continue;
+            }
+
+            auto match{std::ranges::find_if(
+                fusions, [&instruction](const auto &entry) -> bool {
+                  return entry.first == instruction.relative_instance_location;
+                })};
+            if (match == fusions.end()) {
+              fusions.emplace_back(instruction.relative_instance_location,
+                                   std::unordered_set<std::string>{});
+              match = std::prev(fusions.end());
+            }
+
+            for (const auto &entry :
+                 std::get<ValueObjectProperties>(instruction.value)) {
+              if (std::get<2>(entry)) {
+                match->second.insert(std::get<0>(entry));
+              }
             }
           }
         }
 
+        // A positional owner pairs child N with entry N of its own data, and
+        // every entry past the last child only carries a presence requirement.
+        // Dropping a child therefore means moving its entry onto that tail, so
+        // the entries left in front stay paired with the children that survived
+        std::vector<std::size_t> surviving;
+        std::vector<std::size_t> dropped;
+        std::size_t child_index{0};
+
         for (auto &instruction : *current) {
-          if (!fusion_covered_properties.empty()) {
+          const auto result_size{result.size()};
+          const auto positional_index{child_index};
+          child_index += 1;
+
+          const auto fusion{std::ranges::find_if(
+              fusions, [&instruction](const auto &entry) -> bool {
+                return entry.first == instruction.relative_instance_location;
+              })};
+
+          if (fusion != fusions.cend()) {
             switch (instruction.type) {
               case InstructionIndex::AssertionDefinesAllStrict:
               case InstructionIndex::AssertionDefinesAll: {
                 const auto &value{std::get<ValueStringSet>(instruction.value)};
                 bool all_covered{true};
                 for (const auto &property : value) {
-                  if (!fusion_covered_properties.contains(property.first)) {
+                  if (!fusion->second.contains(property.first)) {
                     all_covered = false;
                     break;
                   }
@@ -439,7 +505,7 @@ inline auto postprocess(std::vector<Instructions> &targets,
               case InstructionIndex::AssertionDefinesStrict:
               case InstructionIndex::AssertionDefines: {
                 const auto &value{std::get<ValueProperty>(instruction.value)};
-                if (fusion_covered_properties.contains(value.first)) {
+                if (fusion->second.contains(value.first)) {
                   changed = true;
                   continue;
                 }
@@ -460,8 +526,34 @@ inline auto postprocess(std::vector<Instructions> &targets,
 
           if (transform_instruction(instruction, result, extra, targets,
                                     statistics, current_stats, tweaks,
-                                    uses_dynamic_scopes))
+                                    uses_dynamic_scopes, positional))
             changed = true;
+
+          if (positional) {
+            if (result.size() == result_size) {
+              dropped.push_back(positional_index);
+            } else {
+              surviving.push_back(positional_index);
+            }
+          }
+        }
+
+        if (positional && !dropped.empty()) {
+          auto &entries{std::get<ValueObjectProperties>(owner->value)};
+          ValueObjectProperties reordered;
+          for (const auto index : surviving) {
+            reordered.push_back(entries[index]);
+          }
+
+          for (const auto index : dropped) {
+            reordered.push_back(entries[index]);
+          }
+
+          for (auto index = child_index; index < entries.size(); index++) {
+            reordered.push_back(entries[index]);
+          }
+
+          entries = std::move(reordered);
         }
 
         *current = std::move(result);

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -6836,5 +6836,458 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "fusion_required_flag_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ true, "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "", "foo" ],
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"foo\" successfully validated against its property subschema",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ false, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_under_not",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "not": {
+        "allOf": [
+          { "type": "object", "properties": { "foo": { "type": "string" } } },
+          { "required": [ "foo" ] }
+        ]
+      }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": 5, "b": { "x": "s" } },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": { "x": "s" } },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ true, "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b", "x" ],
+        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The value was expected to be of type string",
+        "The object property \"x\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_nested",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": {} },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location_missing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "post": [
+        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\""
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -7111,5 +7111,677 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "fusion_required_flag_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ true, "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "", "foo" ],
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"foo\" successfully validated against its property subschema",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ false, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_under_not",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "not": {
+        "allOf": [
+          { "type": "object", "properties": { "foo": { "type": "string" } } },
+          { "required": [ "foo" ] }
+        ]
+      }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": 5, "b": { "x": "s" } },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": { "x": "s" } },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ true, "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b", "x" ],
+        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The value was expected to be of type string",
+        "The object property \"x\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_nested",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": {} },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location_missing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "post": [
+        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\""
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_dropped_child",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/$defs/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "b": [ "x" ] },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ false, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The string value \"x\" was expected to consist of at least 3 characters but it consisted of 1 character",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_other_property",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/$defs/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "a": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "Annotation", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ true, "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "Annotation", "/properties/a/items", "#/properties/a/items", "/a", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 1 additional item not described by related keywords",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/$defs/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "b": [ "xxx" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "Annotation", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ true, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "Annotation", "/properties/b/items", "#/properties/b/items", "/b", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"xxx\" was expected to consist of at least 3 characters and it consisted of 3 characters",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 1 additional item not described by related keywords",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_both",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/$defs/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "a": [ "x" ], "b": [ "xxx" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "Annotation", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "Annotation", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ true, "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "Annotation", "/properties/a/items", "#/properties/a/items", "/a", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
+        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ true, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "Annotation", "/properties/b/items", "#/properties/b/items", "/b", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 1 additional item not described by related keywords",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The string value \"xxx\" was expected to consist of at least 3 characters and it consisted of 3 characters",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 1 additional item not described by related keywords",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft4.json
+++ b/test/evaluator/evaluator_draft4.json
@@ -12579,5 +12579,251 @@
       "post": [],
       "descriptions": []
     }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": 5, "b": { "x": "s" } },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": { "x": "s" } },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_nested",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": {} },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location_missing",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "post": [
+        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\""
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -6676,5 +6676,251 @@
         "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
       ]
     }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": 5, "b": { "x": "s" } },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": { "x": "s" } },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_nested",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": {} },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location_missing",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "post": [
+        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\""
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -2670,5 +2670,623 @@
         "The value was expected to be of type object"
       ]
     }
+  },
+  {
+    "description": "fusion_required_flag_1",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_2",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
+        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
+        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_3",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "allOf": [
+        { "type": "object", "properties": { "foo": { "type": "string" } } },
+        { "required": [ "foo" ] }
+      ]
+    },
+    "instance": { "foo": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
+        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
+        [ false, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
+        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the 3 given subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_required_flag_under_not",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "not": {
+        "allOf": [
+          { "type": "object", "properties": { "foo": { "type": "string" } } },
+          { "required": [ "foo" ] }
+        ]
+      }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalNot", "/not", "#/not", "" ],
+        [ "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
+        [ true, "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
+        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
+        [ false, "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
+        [ true, "LogicalNot", "/not", "#/not", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to define the property \"foo\"",
+        "The object value was expected to validate against the 3 given subschemas",
+        "The object value was expected to not validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": 5, "b": { "x": "s" } },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": { "x": "s" } },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
+        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
+        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_distinct_instance_location_nested",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "object" },
+        "b": {
+          "type": "object",
+          "properties": { "x": { "type": "string" } },
+          "required": [ "x" ]
+        }
+      }
+    },
+    "instance": { "a": {}, "b": {} },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines properties \"a\", and \"b\"",
+        "The value was expected to be of type object",
+        "The value was expected to be an object that defines the property \"x\"",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": { "a": "x" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
+        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\"",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_subsumption_same_instance_location_missing",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [ "a" ],
+      "properties": { "a": { "type": "string" } }
+    },
+    "instance": {},
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "post": [
+        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be an object that defines the property \"a\""
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_dropped_child",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/definitions/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "b": [ "x" ] },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ false, "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The string value \"x\" was expected to consist of at least 3 characters but it consisted of 1 character",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_other_property",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/definitions/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "a": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ true, "LoopItems", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_valid",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/definitions/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "b": [ "xxx" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ true, "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value \"xxx\" was expected to consist of at least 3 characters and it consisted of 3 characters",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
+  },
+  {
+    "description": "fusion_positional_children_both",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": { "empty": { "$comment": "x" } },
+      "type": "object",
+      "properties": {
+        "a": { "items": { "$ref": "#/definitions/empty" } },
+        "b": { "items": { "minLength": 3 } }
+      }
+    },
+    "instance": { "a": [ "x" ], "b": [ "xxx" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
+        [ true, "LoopItems", "/properties/a/items", "#/properties/a/items", "/a" ],
+        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
+        [ true, "LoopItems", "/properties/b/items", "#/properties/b/items", "/b" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The string value \"xxx\" was expected to consist of at least 3 characters and it consisted of 3 characters",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

