### PR TITLE
Guard `describe` against keyword-named properties and mistyped annotations

### DIFF
--- a/ports/javascript/describe.mjs
+++ b/ports/javascript/describe.mjs
@@ -135,6 +135,12 @@ function resolveTarget(instance, instanceLocation) {
   return current;
 }
 
+function instanceParent(instance, instanceLocation) {
+  if (instanceLocation === '') return undefined;
+  const lastSlash = instanceLocation.lastIndexOf('/');
+  return resolveTarget(instance, instanceLocation.slice(0, lastSlash));
+}
+
 function extractKeyword(evaluatePath) {
   if (evaluatePath === '') return '';
   const lastSlash = evaluatePath.lastIndexOf('/');
@@ -430,13 +436,20 @@ export function describe(valid, instruction, evaluatePath,
     if (keyword === 'contains') {
       return 'The constraints declared for this keyword were not satisfiable';
     }
-    if (keyword === 'additionalProperties' ||
-        keyword === 'unevaluatedProperties') {
+    // A `false` subschema declares no keyword of its own, so a property named
+    // after one of these must not be described as if it were that keyword.
+    // The instance location agrees only when it sits under an object for the
+    // property cases, or under an array for the item case
+    const parent = instanceParent(instance, instanceLocation);
+    if ((keyword === 'additionalProperties' ||
+         keyword === 'unevaluatedProperties') &&
+        parent !== undefined && parent !== null && typeof parent === 'object' &&
+        !Array.isArray(parent)) {
       const property = lastInstanceToken(instanceLocation);
       return 'The object value was not expected to define the property ' +
         escapeString(property);
     }
-    if (keyword === 'unevaluatedItems') {
+    if (keyword === 'unevaluatedItems' && Array.isArray(parent)) {
       const tokenValue = lastInstanceToken(instanceLocation);
       return 'The array value was not expected to define the item at index ' +
         tokenValue;
@@ -560,7 +573,11 @@ export function describe(valid, instruction, evaluatePath,
         'positional subschemas';
     }
 
-    if (keyword === 'title' || keyword === 'description') {
+    // Annotation values come from the schema as written, so they need not have
+    // the type their keyword expects. When they do not, the generic fallthrough
+    // below describes them instead
+    if ((keyword === 'title' || keyword === 'description') &&
+        typeof annotation === 'string') {
       let message = 'The ' + keyword + ' of the';
       if (instanceLocation === '') {
         message += ' instance';
@@ -621,7 +638,7 @@ export function describe(valid, instruction, evaluatePath,
       return message;
     }
 
-    if (keyword === 'examples') {
+    if (keyword === 'examples' && Array.isArray(annotation)) {
       let message = '';
       if (instanceLocation === '') {
         message += 'Examples of the instance';
@@ -640,7 +657,7 @@ export function describe(valid, instruction, evaluatePath,
       return message;
     }
 
-    if (keyword === 'contentEncoding') {
+    if (keyword === 'contentEncoding' && typeof annotation === 'string') {
       let message = 'The content encoding of the';
       if (instanceLocation === '') {
         message += ' instance';
@@ -651,7 +668,7 @@ export function describe(valid, instruction, evaluatePath,
       return message;
     }
 
-    if (keyword === 'contentMediaType') {
+    if (keyword === 'contentMediaType' && typeof annotation === 'string') {
       let message = 'The content media type of the';
       if (instanceLocation === '') {
         message += ' instance';

--- a/src/evaluator/evaluator_describe.cc
+++ b/src/evaluator/evaluator_describe.cc
@@ -329,20 +329,23 @@ auto describe(const bool valid, const Instruction &step,
       return "The constraints declared for this keyword were not satisfiable";
     }
 
-    if (keyword == "additionalProperties" ||
-        keyword == "unevaluatedProperties") {
+    // A `false` subschema declares no keyword of its own, so its evaluation
+    // path ends at whatever declared it, which under `properties` and its
+    // relatives is a name the author chose. A name that happens to read like
+    // one of the keywords below must not be taken for the keyword itself, so
+    // each of these only applies when the instance location agrees with it
+    if ((keyword == "additionalProperties" ||
+         keyword == "unevaluatedProperties") &&
+        !instance_location.empty() && instance_location.back().is_property()) {
       std::ostringstream message;
-      assert(!instance_location.empty());
-      assert(instance_location.back().is_property());
       message << "The object value was not expected to define the property "
               << escape_string(instance_location.back().to_property());
       return message.str();
     }
 
-    if (keyword == "unevaluatedItems") {
+    if (keyword == "unevaluatedItems" && !instance_location.empty() &&
+        instance_location.back().is_index()) {
       std::ostringstream message;
-      assert(!instance_location.empty());
-      assert(instance_location.back().is_index());
       message << "The array value was not expected to define the item at index "
               << instance_location.back().to_index();
       return message.str();
@@ -524,8 +527,10 @@ auto describe(const bool valid, const Instruction &step,
       return message.str();
     }
 
-    if (keyword == "title" || keyword == "description") {
-      assert(annotation.is_string());
+    // Note that these annotation values come from the schema as they are
+    // written, and nothing forces them to have the type their keyword expects
+    if ((keyword == "title" || keyword == "description") &&
+        annotation.is_string()) {
       std::ostringstream message;
       message << "The " << keyword << " of the";
       if (instance_location.empty()) {
@@ -613,8 +618,7 @@ auto describe(const bool valid, const Instruction &step,
       return message.str();
     }
 
-    if (keyword == "examples") {
-      assert(annotation.is_array());
+    if (keyword == "examples" && annotation.is_array()) {
       std::ostringstream message;
       if (instance_location.empty()) {
         message << "Examples of the instance";
@@ -639,8 +643,7 @@ auto describe(const bool valid, const Instruction &step,
       return message.str();
     }
 
-    if (keyword == "contentEncoding") {
-      assert(annotation.is_string());
+    if (keyword == "contentEncoding" && annotation.is_string()) {
       std::ostringstream message;
       message << "The content encoding of the";
       if (instance_location.empty()) {
@@ -655,8 +658,7 @@ auto describe(const bool valid, const Instruction &step,
       return message.str();
     }
 
-    if (keyword == "contentMediaType") {
-      assert(annotation.is_string());
+    if (keyword == "contentMediaType" && annotation.is_string()) {
       std::ostringstream message;
       message << "The content media type of the";
       if (instance_location.empty()) {

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -7834,5 +7834,242 @@
         "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
       ]
     }
+  },
+  {
+    "description": "false_subschema_named_after_keyword",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": { "unevaluatedItems": false }
+    },
+    "instance": { "unevaluatedItems": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
+  },
+  {
+    "description": "false_subschema_named_after_keyword_pattern",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "patternProperties": { "unevaluatedItems": false }
+    },
+    "instance": { "unevaluatedItems": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object properties that match the regular expression \"unevaluatedItems\" were expected to validate against the defined pattern property subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
+        [ "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ],
+        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object properties that match the regular expression \"unevaluatedItems\" were expected to validate against the defined pattern property subschema"
+      ]
+    }
+  },
+  {
+    "description": "false_subschema_named_after_keyword_dependent",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "dependentSchemas": { "additionalProperties": false }
+    },
+    "instance": { "additionalProperties": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ],
+        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object value defined the property \"additionalProperties\"",
+        "Because the object value defined the property \"additionalProperties\", it was also expected to validate against the corresponding subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ],
+        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
+        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object value defined the property \"additionalProperties\"",
+        "Because the object value defined the property \"additionalProperties\", it was also expected to validate against the corresponding subschema"
+      ]
+    }
+  },
+  {
+    "description": "false_subschema_named_after_keyword_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": { "unevaluatedItems": false }
+    },
+    "instance": { "other": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
+  },
+  {
+    "description": "annotation_title_not_a_string",
+    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "title": 42 },
+    "instance": 1,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "Annotation", "/title", "#/title", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/title", "#/title", "", 42 ]
+      ],
+      "descriptions": [
+        "The unrecognized keyword \"title\" was collected as the annotation 42"
+      ]
+    }
+  },
+  {
+    "description": "annotation_examples_not_an_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "examples": "x"
+    },
+    "instance": 1,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "Annotation", "/examples", "#/examples", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/examples", "#/examples", "", "x" ]
+      ],
+      "descriptions": [
+        "The unrecognized keyword \"examples\" was collected as the annotation \"x\""
+      ]
+    }
+  },
+  {
+    "description": "annotation_content_encoding_not_a_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contentEncoding": 42,
+      "contentMediaType": "text/plain"
+    },
+    "instance": "x",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "Annotation", "/contentEncoding", "#/contentEncoding", "" ],
+        [ "Annotation", "/contentMediaType", "#/contentMediaType", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contentEncoding", "#/contentEncoding", "", 42 ],
+        [ true, "Annotation", "/contentMediaType", "#/contentMediaType", "", "text/plain" ]
+      ],
+      "descriptions": [
+        "The unrecognized keyword \"contentEncoding\" was collected as the annotation 42",
+        "The content media type of the instance was \"text/plain\""
+      ]
+    }
+  },
+  {
+    "description": "annotation_title_a_string",
+    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "x" },
+    "instance": 1,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "Annotation", "/title", "#/title", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/title", "#/title", "", "x" ]
+      ],
+      "descriptions": [
+        "The title of the instance was \"x\""
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -3336,5 +3336,42 @@
         "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
       ]
     }
+  },
+  {
+    "description": "false_subschema_named_after_keyword_dependencies",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "dependencies": { "unevaluatedProperties": false }
+    },
+    "instance": { "unevaluatedProperties": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
+        [ "AssertionFail", "/dependencies/unevaluatedProperties", "#/dependencies/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/dependencies/unevaluatedProperties", "#/dependencies/unevaluatedProperties", "" ],
+        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object value defined the property \"unevaluatedProperties\""
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
+        [ "AssertionFail", "/dependencies/unevaluatedProperties", "#/dependencies/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ false, "AssertionFail", "/dependencies/unevaluatedProperties", "#/dependencies/unevaluatedProperties", "" ],
+        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+      ],
+      "descriptions": [
+        "No instance is expected to succeed against the false schema",
+        "The object value defined the property \"unevaluatedProperties\""
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

