### PR TITLE
Enforce `maxItems` in the sized integer-bounded items loop

### DIFF
--- a/ports/javascript/index.mjs
+++ b/ports/javascript/index.mjs
@@ -2465,9 +2465,11 @@ function LoopItemsIntegerBoundedSized(instruction, instance, depth, template, ev
   const minimum = value[0][0];
   const maximum = value[0][1];
   const minimumSize = value[1][0];
+  const maximumSize = value[1][1];
   const target = resolveInstance(instance, instruction[2]);
   if (evaluator.callbackMode) evaluator.callbackPush(instruction);
-  if (!Array.isArray(target) || target.length < minimumSize) {
+  if (!Array.isArray(target) || target.length < minimumSize ||
+      (maximumSize !== null && maximumSize !== undefined && target.length > maximumSize)) {
     if (evaluator.callbackMode) evaluator.callbackPop(instruction, false);
     return false;
   }
@@ -3881,8 +3883,10 @@ function LoopItemsIntegerBoundedSized_fast(instruction, instance, depth, templat
   const minimum = value[0][0];
   const maximum = value[0][1];
   const minimumSize = value[1][0];
+  const maximumSize = value[1][1];
   const target = resolveInstance(instance, instruction[2]);
-  if (!Array.isArray(target) || target.length < minimumSize) return false;
+  if (!Array.isArray(target) || target.length < minimumSize ||
+      (maximumSize !== null && maximumSize !== undefined && target.length > maximumSize)) return false;
   for (let index = 0; index < target.length; index++) {
     const element = target[index];
     const elementType = typeof element;

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -2543,8 +2543,11 @@ INSTRUCTION_HANDLER(LoopItemsIntegerBoundedSized) {
       assume_value<ValueIntegerBoundsWithSize>(instruction.value)};
   const auto &integer_bounds{value.first};
   const auto minimum_size{std::get<0>(value.second)};
+  const auto &maximum_size{std::get<1>(value.second)};
   EVALUATE_BEGIN_NON_STRING(LoopItemsIntegerBoundedSized, true);
-  if (!target.is_array() || target.array_size() < minimum_size) {
+  if (!target.is_array() || target.array_size() < minimum_size ||
+      (maximum_size.has_value() &&
+       target.array_size() > maximum_size.value())) {
     EVALUATE_END(LoopItemsIntegerBoundedSized);
   }
 

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -7340,5 +7340,243 @@
         "The object properties not covered by other adjacent object keywords were expected to validate against this subschema"
       ]
     }
+  },
+  {
+    "description": "array_items_bounds_toomany",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ "LogicalWhenType", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenType", "/items", "#/items", "" ],
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 100",
+        "The integer value 3 was expected to be greater than or equal to the integer 0",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The value was expected to be of type array",
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_toofew",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "LogicalWhenType", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenType", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The value was expected to be of type array",
+        "The array value was expected to contain at most 2 items and it contained 0 items",
+        "The array value was expected to contain at least 1 item but it contained 0 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_inrange",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "LogicalWhenType", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenType", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The value was expected to be of type array",
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_elem_out_of_range",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 999 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be less than or equal to the integer 100",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -8071,5 +8071,204 @@
         "The title of the instance was \"x\""
       ]
     }
+  },
+  {
+    "description": "array_items_bounds_toomany",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_toofew",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 0 items",
+        "The array value was expected to contain at least 1 item but it contained 0 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_inrange",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "LoopItemsFrom", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
+        [ "Annotation", "/items", "#/items", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
+        [ true, "Annotation", "/items", "#/items", "", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type number",
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 2 additional items not described by related keywords",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_elem_out_of_range",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 999 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "LoopItemsFrom", "/items", "#/items", "" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+      ],
+      "post": [
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type number",
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be less than or equal to the integer 100",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft4.json
+++ b/test/evaluator/evaluator_draft4.json
@@ -12825,5 +12825,144 @@
         "The value was expected to be an object that defines the property \"a\""
       ]
     }
+  },
+  {
+    "description": "array_items_bounds_sized_toomany",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "scores": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "minItems": 1,
+          "maxItems": 2
+        }
+      }
+    },
+    "instance": { "scores": [ 1, 2, 3 ] },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
+        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
+        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
+        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
+        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
+        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
+        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
+        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/2" ],
+        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/2" ],
+        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/2" ],
+        [ "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
+        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
+        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
+        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
+        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
+        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
+        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/2" ],
+        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/2" ],
+        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/2" ],
+        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
+        [ false, "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
+        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 100",
+        "The integer value 3 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items but it contained 3 items",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_sized_inrange",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "scores": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "minItems": 1,
+          "maxItems": 2
+        }
+      }
+    },
+    "instance": { "scores": [ 1, 2 ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
+        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
+        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
+        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
+        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
+        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
+        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
+        [ "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
+        [ "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
+        [ "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
+        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
+        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
+        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
+        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
+        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
+        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
+        [ true, "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
+        [ true, "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
+        [ true, "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type array",
+        "The object value was expected to validate against the single defined property subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -6922,5 +6922,222 @@
         "The value was expected to be an object that defines the property \"a\""
       ]
     }
+  },
+  {
+    "description": "array_items_bounds_toomany",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 100",
+        "The integer value 3 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_toofew",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items and it contained 0 items",
+        "The array value was expected to contain at least 1 item but it contained 0 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_inrange",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_elem_out_of_range",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 999 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be less than or equal to the integer 100",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -3373,5 +3373,222 @@
         "The object value defined the property \"unevaluatedProperties\""
       ]
     }
+  },
+  {
+    "description": "array_items_bounds_toomany",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 3 was expected to be less than or equal to the integer 100",
+        "The integer value 3 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items but it contained 3 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_toofew",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "post": [
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items and it contained 0 items",
+        "The array value was expected to contain at least 1 item but it contained 0 items"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_inrange",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
+        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range",
+        "The value was expected to consist of an array of 1 to 2 items"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
+        [ true, "LoopItems", "/items", "#/items", "" ],
+        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
+        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 2 was expected to be less than or equal to the integer 100",
+        "The integer value 2 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to contain at most 2 items and it contained 2 items",
+        "The array value was expected to contain at least 1 item and it contained 2 items",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "array_items_bounds_elem_out_of_range",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "instance": [ 1, 999 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "post": [
+        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "Every item in the array was expected to be a number within the given range"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopItems", "/items", "#/items", "" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+      ],
+      "post": [
+        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
+        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
+        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
+        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
+        [ false, "LoopItems", "/items", "#/items", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to be less than or equal to the integer 100",
+        "The integer value 1 was expected to be greater than or equal to the integer 0",
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be less than or equal to the integer 100",
+        "Every item in the array value was expected to validate against the given subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

