### PR TITLE
Confirm key length in perfect-hash simple-properties matching

### DIFF
--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -1042,9 +1042,13 @@ INSTRUCTION_HANDLER(AssertionObjectPropertiesSimple) {
     for (std::size_t schema_index = 0; schema_index < schema_size;
          schema_index++) {
       const auto &schema_hash{std::get<1>(value[schema_index])};
+      // A perfect hash captures the key bytes but not its length, so its size
+      // is confirmed rather than trusting the hash match alone
       if (schema_hash == instance_hash &&
-          (property_hasher.is_perfect(instance_hash) ||
-           instance_entry.first == std::get<0>(value[schema_index]))) {
+          (property_hasher.is_perfect(instance_hash)
+               ? instance_entry.first.size() ==
+                     std::get<0>(value[schema_index]).size()
+               : instance_entry.first == std::get<0>(value[schema_index]))) {
         seen |= (static_cast<std::uint32_t>(1) << schema_index);
         if (schema_index < instruction.children.size()) {
           const auto &child{instruction.children[schema_index]};

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -7578,5 +7578,46 @@
         "Every item in the array value was expected to validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "hash_length_object_properties_simple_false_reject",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "object",
+      "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+    },
+    "instance": { "aa\u0000": 123, "bb": "ok" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "bb" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"bb\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -8270,5 +8270,46 @@
         "Every item in the array value was expected to validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "hash_length_object_properties_simple_false_reject",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+    },
+    "instance": { "aa\u0000": 123, "bb": "ok" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ "Annotation", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "bb" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object property \"bb\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -3590,5 +3590,43 @@
         "Every item in the array value was expected to validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "hash_length_object_properties_simple_false_reject",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+    },
+    "instance": { "aa\u0000": 123, "bb": "ok" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the defined property subschemas"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The value was expected to be of type object"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

