### PR TITLE
Fix fast-mode if/then/else branch boundaries after post-processing inlining

### DIFF
--- a/ports/javascript/index.mjs
+++ b/ports/javascript/index.mjs
@@ -1710,24 +1710,27 @@ function LogicalCondition(instruction, instance, depth, template, evaluator) {
   const children = instruction[6];
   const childrenSize = children ? children.length : 0;
 
-  let conditionEnd = childrenSize;
-  if (thenStart > 0) conditionEnd = thenStart;
-  else if (elseStart > 0) conditionEnd = elseStart;
-
   const target = resolveInstance(instance, instruction[2]);
 
   let conditionResult = true;
-  for (let cursor = 0; cursor < conditionEnd; cursor++) {
+  for (let cursor = 0; cursor < thenStart; cursor++) {
     if (!evaluateInstruction(children[cursor], target, depth + 1, template, evaluator)) {
       conditionResult = false;
       break;
     }
   }
 
-  const consequenceStart = conditionResult ? thenStart : elseStart;
-  const consequenceEnd = (conditionResult && elseStart > 0) ? elseStart : childrenSize;
+  let consequenceStart;
+  let consequenceEnd;
+  if (conditionResult) {
+    consequenceStart = thenStart;
+    consequenceEnd = elseStart > 0 ? elseStart : childrenSize;
+  } else {
+    consequenceStart = elseStart;
+    consequenceEnd = elseStart > 0 ? childrenSize : elseStart;
+  }
 
-  if (consequenceStart > 0) {
+  if (consequenceStart < consequenceEnd) {
     if (evaluator.trackMode || evaluator.callbackMode) {
       evaluator.popPath(instruction[1].length);
     }
@@ -2968,21 +2971,25 @@ function LogicalCondition_fast(instruction, instance, depth, template, evaluator
   const elseStart = value[1];
   const children = instruction[6];
   const childrenSize = children ? children.length : 0;
-  let conditionEnd = childrenSize;
-  if (thenStart > 0) conditionEnd = thenStart;
-  else if (elseStart > 0) conditionEnd = elseStart;
   const relInstance = instruction[2];
   const target = relInstance.length === 0 ? instance : resolveInstance(instance, relInstance);
   let conditionResult = true;
-  for (let cursor = 0; cursor < conditionEnd; cursor++) {
+  for (let cursor = 0; cursor < thenStart; cursor++) {
     if (!evaluateInstruction(children[cursor], target, depth + 1, template, evaluator)) {
       conditionResult = false;
       break;
     }
   }
-  const consequenceStart = conditionResult ? thenStart : elseStart;
-  const consequenceEnd = (conditionResult && elseStart > 0) ? elseStart : childrenSize;
-  if (consequenceStart > 0) {
+  let consequenceStart;
+  let consequenceEnd;
+  if (conditionResult) {
+    consequenceStart = thenStart;
+    consequenceEnd = elseStart > 0 ? elseStart : childrenSize;
+  } else {
+    consequenceStart = elseStart;
+    consequenceEnd = elseStart > 0 ? childrenSize : elseStart;
+  }
+  if (consequenceStart < consequenceEnd) {
     if (evaluator.trackMode) {
       evaluator.popPath(instruction[1].length);
     }

--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -104,32 +104,57 @@ inline auto duplicate_metadata(Instruction &instruction,
   }
 }
 
+// Whether an instruction relays its children without pushing its own schema
+// location onto the evaluation path, leaving them anchored on its own parent
+inline auto is_pass_through_instruction(const InstructionIndex type) noexcept
+    -> bool {
+  switch (type) {
+    case InstructionIndex::ControlGroup:
+    case InstructionIndex::ControlGroupWhenDefines:
+    case InstructionIndex::ControlGroupWhenDefinesDirect:
+    case InstructionIndex::ControlGroupWhenType:
+    case InstructionIndex::ControlEvaluate:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Prefix every instruction that anchors its schema location on the point an
+// inlined target is spliced into. That is the top instruction itself, plus
+// the instructions that evaluation reaches without a location of their own in
+// between: the consequence children of a conditional, which re-anchor on the
+// conditional's parent, and the children of pass-through instructions.
+// Condition children and ordinary nested children stay relative to their
+// parent instruction and must be left alone
+inline auto rebase_anchored(Instruction &instruction,
+                            std::vector<InstructionExtra> &extra,
+                            const sourcemeta::core::Pointer &schema_prefix)
+    -> void {
+  extra[instruction.extra_index].relative_schema_location =
+      schema_prefix.concat(
+          extra[instruction.extra_index].relative_schema_location);
+
+  if (instruction.type == InstructionIndex::LogicalCondition) {
+    const auto &value{std::get<ValueIndexPair>(instruction.value)};
+    for (std::size_t index = value.first; index < instruction.children.size();
+         ++index) {
+      rebase_anchored(instruction.children[index], extra, schema_prefix);
+    }
+  } else if (is_pass_through_instruction(instruction.type)) {
+    for (auto &child : instruction.children) {
+      rebase_anchored(child, extra, schema_prefix);
+    }
+  }
+}
+
 inline auto rebase(Instruction &instruction,
                    std::vector<InstructionExtra> &extra,
                    const sourcemeta::core::Pointer &schema_prefix,
                    const sourcemeta::core::Pointer &instance_prefix) -> void {
-  extra[instruction.extra_index].relative_schema_location =
-      schema_prefix.concat(
-          extra[instruction.extra_index].relative_schema_location);
   instruction.relative_instance_location =
       instance_prefix.concat(instruction.relative_instance_location);
-
-  if (instruction.type == InstructionIndex::LogicalCondition) {
-    const auto &value{std::get<ValueIndexPair>(instruction.value)};
-    const auto then_cursor{value.first};
-    // TODO(C++23): Use std::views::enumerate when available in libc++
-    for (std::size_t index = then_cursor; index < instruction.children.size();
-         ++index) {
-      auto &child{instruction.children[index]};
-      extra[child.extra_index].relative_schema_location = schema_prefix.concat(
-          extra[child.extra_index].relative_schema_location);
-      for (auto &grandchild : child.children) {
-        extra[grandchild.extra_index].relative_schema_location =
-            schema_prefix.concat(
-                extra[grandchild.extra_index].relative_schema_location);
-      }
-    }
-  }
+  rebase_anchored(instruction, extra, schema_prefix);
 }
 
 inline auto collect_statistics(const Instructions &instructions,
@@ -410,6 +435,16 @@ inline auto postprocess(std::vector<Instructions> &targets,
         Instructions result;
         result.reserve(current->size());
 
+        // A conditional stores the indices where its branches begin, so when
+        // this pass drops or expands any child, those indices must be remapped
+        // onto the rewritten list
+        const bool remap{owner != nullptr &&
+                         owner->type == InstructionIndex::LogicalCondition};
+        std::vector<std::size_t> boundaries;
+        if (remap) {
+          boundaries.reserve(current->size() + 1);
+        }
+
         // The children of a conditional span its mutually exclusive
         // condition, consequence, and alternative segments, and the children
         // of a disjunction are alternative branches, so an instruction in one
@@ -475,6 +510,10 @@ inline auto postprocess(std::vector<Instructions> &targets,
         std::size_t child_index{0};
 
         for (auto &instruction : *current) {
+          if (remap) {
+            boundaries.push_back(result.size());
+          }
+
           const auto result_size{result.size()};
           const auto positional_index{child_index};
           child_index += 1;
@@ -554,6 +593,31 @@ inline auto postprocess(std::vector<Instructions> &targets,
           }
 
           entries = std::move(reordered);
+        }
+
+        if (remap) {
+          boundaries.push_back(result.size());
+          auto &cursors{std::get<ValueIndexPair>(owner->value)};
+          const auto then_start{boundaries[cursors.first]};
+          if (then_start == 0) {
+            // The condition dropped to nothing, so it is always true: the then
+            // branch applies unconditionally and the else branch is dead. Keep
+            // only the then instructions and record an empty condition with no
+            // else, which the evaluator runs as the consequence
+            const auto else_start{cursors.second > 0
+                                      ? boundaries[cursors.second]
+                                      : result.size()};
+            result.erase(result.begin() +
+                             static_cast<std::ptrdiff_t>(else_start),
+                         result.end());
+            cursors.first = 0;
+            cursors.second = 0;
+          } else {
+            cursors.first = then_start;
+            if (cursors.second > 0) {
+              cursors.second = boundaries[cursors.second];
+            }
+          }
         }
 
         *current = std::move(result);

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -1335,27 +1335,33 @@ INSTRUCTION_HANDLER(LogicalCondition) {
   assert(children_size >= value.second);
   SOURCEMETA_ASSUME(children_size >= value.second);
 
-  auto condition_end{children_size};
-  if (value.first > 0) {
-    condition_end = value.first;
-  } else if (value.second > 0) {
-    condition_end = value.second;
-  }
-
+  // The condition is the leading segment [0, then start). It may be empty,
+  // for example when a `$ref` condition inlines and its jump is dropped, in
+  // which case it trivially passes and the then branch applies
   const auto &target{
       resolve_instance(instance, instruction.relative_instance_location)};
-  for (std::size_t cursor = 0; cursor < condition_end; cursor++) {
+
+  for (std::size_t cursor = 0; cursor < value.first; cursor++) {
     if (!EVALUATE_RECURSE(instruction.children[cursor], target)) {
       result = false;
       break;
     }
   }
 
-  const auto consequence_start{result ? value.first : value.second};
-  const auto consequence_end{(result && value.second > 0) ? value.second
-                                                          : children_size};
+  // On a passing condition the then branch runs, otherwise the else branch,
+  // which is absent when it starts at zero
+  std::size_t consequence_start;
+  std::size_t consequence_end;
+  if (result) {
+    consequence_start = value.first;
+    consequence_end = value.second > 0 ? value.second : children_size;
+  } else {
+    consequence_start = value.second;
+    consequence_end = value.second > 0 ? children_size : value.second;
+  }
+
   result = true;
-  if (consequence_start > 0) {
+  if (consequence_start < consequence_end) {
     if constexpr (Track || HasCallback) {
       if (track) {
         context.evaluator->evaluate_path.pop_back(

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -8045,5 +8045,555 @@
         "The value was expected to be of type array"
       ]
     }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 999,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 7,
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": "foo",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/else/$ref", "#/else/$ref", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/else/$ref", "#/else/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_4",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "left": { "$ref": "#/$defs/shared" },
+        "right": { "$ref": "#/$defs/shared" }
+      },
+      "$defs": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LoopItems", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItems", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The value was expected to consist of a string of at least 1 character",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LoopItems", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ "LogicalWhenType", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "Annotation", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItems", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left", true ],
+        [ true, "LogicalWhenType", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The string value \"x\" was expected to consist of at least 1 character and it consisted of 1 character",
+        "The value was expected to be of type string",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The value was expected to be of type array",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object property \"left\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_5",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "properties": {
+        "left": { "$ref": "#/$defs/shared" },
+        "right": { "$ref": "#/$defs/shared" }
+      },
+      "$defs": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "if": { "minItems": 1 }, "then": { "maxItems": 3 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ "Annotation", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object property \"left\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_fails",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "$defs": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_passes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "$defs": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_fails",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "$defs": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_passes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "$defs": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_nonstring",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/$defs/always" },
+      "else": { "type": "string" },
+      "$defs": { "always": {} }
+    },
+    "instance": 0,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/$defs/always" },
+      "else": { "type": "string" },
+      "$defs": { "always": {} }
+    },
+    "instance": "hi",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -8786,5 +8786,555 @@
         "The object value was expected to validate against the defined properties subschemas"
       ]
     }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 999,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 7,
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
+        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
+        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "number" },
+      "then": { "$ref": "#/$defs/shared", "const": 7 },
+      "else": { "$ref": "#/$defs/shared" },
+      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": "foo",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/else/$ref", "#/else/$ref", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/else/$ref", "#/else/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_4",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "left": { "$ref": "#/$defs/shared" },
+        "right": { "$ref": "#/$defs/shared" }
+      },
+      "$defs": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The value was expected to consist of a string of at least 1 character",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ "LogicalWhenArraySizeGreater", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ "Annotation", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left", true ],
+        [ true, "LogicalWhenArraySizeGreater", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The string value \"x\" was expected to consist of at least 1 character and it consisted of 1 character",
+        "The value was expected to be of type string",
+        "Every item in the array value was expected to validate against the given subschema",
+        "Every item in the array value was successfully validated",
+        "The array value contains 1 additional item not described by related keywords",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object property \"left\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_5",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "left": { "$ref": "#/$defs/shared" },
+        "right": { "$ref": "#/$defs/shared" }
+      },
+      "$defs": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "if": { "minItems": 1 }, "then": { "maxItems": 3 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ "Annotation", "/properties", "#/properties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object property \"left\" successfully validated against its property subschema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_fails",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "$defs": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_passes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "$defs": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_fails",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "$defs": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_passes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/$defs/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "$defs": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_nonstring",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/$defs/always" },
+      "else": { "type": "string" },
+      "$defs": { "always": {} }
+    },
+    "instance": 0,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/$defs/always" },
+      "else": { "type": "string" },
+      "$defs": { "always": {} }
+    },
+    "instance": "hi",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -5634,3 +5634,93 @@ TEST(type_object_oversized_max_properties_ignored) {
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type object");
 }
+
+TEST(annotation_fast_whitelist_if_then_else_inlined_shared_ref) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "if": { "type": "string" },
+    "then": {
+      "$ref": "#/$defs/shared",
+      "x-test-custom": "Then"
+    },
+    "else": { "$ref": "#/$defs/shared" },
+    "$defs": {
+      "shared": { "minProperties": 0, "minLength": 1 }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("foo")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 4, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalCondition, "/if", "#/if", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/if/type", "#/if/type", "");
+  EVALUATE_TRACE_PRE(2, AssertionStringSizeGreater, "/then/$ref/minLength",
+                     "#/$defs/shared/minLength", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/then/x-test-custom",
+                                "#/then/x-test-custom", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/if/type", "#/if/type",
+                              "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionStringSizeGreater,
+                              "/then/$ref/minLength",
+                              "#/$defs/shared/minLength", "");
+  EVALUATE_TRACE_POST_ANNOTATION(2, "/then/x-test-custom",
+                                 "#/then/x-test-custom", "", "Then");
+  EVALUATE_TRACE_POST_SUCCESS(3, LogicalCondition, "/if", "#/if", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The string value \"foo\" was expected to "
+                               "consist of at least 1 character and it "
+                               "consisted of 3 characters");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The unrecognized keyword \"x-test-custom\" was "
+                               "collected as the annotation \"Then\"");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The string value was expected to validate "
+                               "against the given conditional");
+}
+
+TEST(annotation_fast_whitelist_if_then_else_inlined_shared_ref_else_branch) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "if": { "type": "string" },
+    "then": {
+      "$ref": "#/$defs/shared",
+      "x-test-custom": "Then"
+    },
+    "else": { "$ref": "#/$defs/shared" },
+    "$defs": {
+      "shared": { "minProperties": 0, "minLength": 1 }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("42")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"x-test-custom"};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 2, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, LogicalCondition, "/if", "#/if", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/if/type", "#/if/type", "");
+
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionTypeStrict, "/if/type", "#/if/type",
+                              "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalCondition, "/if", "#/if", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string "
+                               "but it was of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The integer value was expected to validate "
+                               "against the given conditional");
+}

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -4058,5 +4058,549 @@
         "The object value was expected to validate against the defined properties subschemas"
       ]
     }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_1",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": { "type": "number" },
+      "then": { "allOf": [ { "$ref": "#/definitions/shared" } ], "const": 7 },
+      "else": { "$ref": "#/definitions/shared" },
+      "definitions": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 999,
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ true, "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "LogicalAnd", "/then/allOf", "#/then/allOf", "" ],
+        [ "ControlJump", "/then/allOf/0/$ref", "#/then/allOf/0/$ref", "" ],
+        [ "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ true, "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ true, "ControlJump", "/then/allOf/0/$ref", "#/then/allOf/0/$ref", "" ],
+        [ true, "LogicalAnd", "/then/allOf", "#/then/allOf", "" ],
+        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 999 was expected to be greater than or equal to the integer 5",
+        "The integer value 999 was expected to be divisible by the integer 1",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value was expected to validate against the given subschema",
+        "The integer value 999 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_2",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": { "type": "number" },
+      "then": { "allOf": [ { "$ref": "#/definitions/shared" } ], "const": 7 },
+      "else": { "$ref": "#/definitions/shared" },
+      "definitions": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": 7,
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ true, "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "LogicalAnd", "/then/allOf", "#/then/allOf", "" ],
+        [ "ControlJump", "/then/allOf/0/$ref", "#/then/allOf/0/$ref", "" ],
+        [ "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionGreaterEqual", "/then/allOf/0/$ref/minimum", "#/definitions/shared/minimum", "" ],
+        [ true, "AssertionDivisible", "/then/allOf/0/$ref/multipleOf", "#/definitions/shared/multipleOf", "" ],
+        [ true, "ControlJump", "/then/allOf/0/$ref", "#/then/allOf/0/$ref", "" ],
+        [ true, "LogicalAnd", "/then/allOf", "#/then/allOf", "" ],
+        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number",
+        "The integer value 7 was expected to be greater than or equal to the integer 5",
+        "The integer value 7 was expected to be divisible by the integer 1",
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value was expected to validate against the given subschema",
+        "The integer value 7 was expected to equal the integer constant 7",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_3",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "if": { "type": "number" },
+      "then": { "allOf": [ { "$ref": "#/definitions/shared" } ], "const": 7 },
+      "else": { "$ref": "#/definitions/shared" },
+      "definitions": { "shared": { "minimum": 5, "multipleOf": 1 } }
+    },
+    "instance": "foo",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ "ControlJump", "/else/$ref", "#/else/$ref", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/else/$ref", "#/else/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type number but it was of type string",
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_4",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "left": { "$ref": "#/definitions/shared" },
+        "right": { "$ref": "#/definitions/shared" }
+      },
+      "definitions": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ "LoopItems", "/properties/left/$ref/then/items", "#/definitions/shared/then/items", "/left" ],
+        [ "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/definitions/shared/then/items/type", "/left/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ true, "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/definitions/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItems", "/properties/left/$ref/then/items", "#/definitions/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The value was expected to consist of a string of at least 1 character",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ "LoopItems", "/properties/left/$ref/then/items", "#/definitions/shared/then/items", "/left" ],
+        [ "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/definitions/shared/then/items/minLength", "/left/0" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/definitions/shared/then/items/type", "/left/0" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ true, "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/definitions/shared/then/items/minLength", "/left/0" ],
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/definitions/shared/then/items/type", "/left/0" ],
+        [ true, "LoopItems", "/properties/left/$ref/then/items", "#/definitions/shared/then/items", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The string value \"x\" was expected to consist of at least 1 character and it consisted of 1 character",
+        "The value was expected to be of type string",
+        "Every item in the array value was expected to validate against the given subschema",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_then_else_inlined_shared_ref_5",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "left": { "$ref": "#/definitions/shared" },
+        "right": { "$ref": "#/definitions/shared" }
+      },
+      "definitions": {
+        "shared": {
+          "if": { "type": "array" },
+          "then": { "if": { "minItems": 1 }, "then": { "maxItems": 3 } }
+        }
+      }
+    },
+    "instance": { "left": [ "x" ] },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/definitions/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/definitions/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/definitions/shared/then/then/maxItems", "/left" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/definitions/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/definitions/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/definitions/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalWhenType", "/properties", "#/properties", "" ],
+        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/definitions/shared/then/if", "/left" ],
+        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/definitions/shared/then/if/minItems", "/left" ],
+        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/definitions/shared/then/then/maxItems", "/left" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/definitions/shared/if/type", "/left" ],
+        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/definitions/shared/then/if/minItems", "/left" ],
+        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/definitions/shared/then/then/maxItems", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/definitions/shared/then/if", "/left" ],
+        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/definitions/shared/if", "/left" ],
+        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
+        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array value was expected to contain at least 1 item and it contained 1 item",
+        "The array value was expected to contain at most 3 items and it contained 1 item",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the given conditional",
+        "The array value was expected to validate against the referenced schema",
+        "The object value was expected to validate against the defined properties subschemas"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_fails",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/definitions/always" },
+      "then": { "minLength": 3 },
+      "definitions": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_then_passes",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifref",
+      "if": { "$ref": "#/definitions/always" },
+      "then": { "minLength": 3 },
+      "definitions": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_fails",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/definitions/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "definitions": { "always": {} }
+    },
+    "instance": "",
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_else_skipped_passes",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifrefelse",
+      "if": { "$ref": "#/definitions/always" },
+      "then": { "minLength": 3 },
+      "else": { "const": "never" },
+      "definitions": { "always": {} }
+    },
+    "instance": "abcd",
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
+        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_nonstring",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/definitions/always" },
+      "else": { "type": "string" },
+      "definitions": { "always": {} }
+    },
+    "instance": 0,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "if_ref_empty_condition_no_then_else_dead_string",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/ifelse",
+      "if": { "$ref": "#/definitions/always" },
+      "else": { "type": "string" },
+      "definitions": { "always": {} }
+    },
+    "instance": "hi",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
+        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
+        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+      ],
+      "descriptions": [
+        "The string value was expected to validate against the referenced schema",
+        "The string value was expected to validate against the given conditional"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

