### PR TITLE
Fix fast-mode `contains` bounds and type-scoped evaluation markers

### DIFF
--- a/ports/javascript/index.mjs
+++ b/ports/javascript/index.mjs
@@ -2500,11 +2500,10 @@ function LoopContains(instruction, instance, depth, template, evaluator) {
   const minimum = range[0];
   const maximum = range[1];
   const isExhaustive = range[2];
-  if (minimum === 0 && target.length === 0) return true;
   if (evaluator.callbackMode) evaluator.callbackPush(instruction);
 
   const children = instruction[6];
-  let result = false;
+  let result = minimum === 0;
   let matchCount = 0;
   for (let index = 0; index < target.length; index++) {
     if (evaluator.callbackMode) evaluator.pushInstanceToken(index);

--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -144,10 +144,10 @@ auto compiler_2019_09_applicator_contains_with_options(
     }
   }
 
-  if (maximum.has_value() && minimum > maximum.value()) {
-    return {make(sourcemeta::blaze::InstructionIndex::AssertionFail, context,
-                 schema_context, dynamic_context, ValueNone{})};
-  }
+  // An unsatisfiable range is deliberately left for the general check below,
+  // which rejects every array yet leaves non-arrays alone. An unconditional
+  // failure here would instead reject non-arrays too, but `contains` does not
+  // apply to them
 
   if (minimum == 0 && !maximum.has_value() && !track_evaluation) {
     return {};
@@ -175,8 +175,12 @@ auto compiler_2019_09_applicator_contains_with_options(
              schema_context, relative_dynamic_context(), ValuePointer{}));
   }
 
-  if (children.empty()) {
-    // We still need to check the instance is not empty
+  // A trivial subschema matches every element, so the number of matches
+  // equals the array size and the constraint reduces to a size bound. The
+  // plain "at least one match" case has a cheap single-instruction form, but
+  // any higher minimum or any maximum needs the general range check, which
+  // handles an empty subschema correctly on its own
+  if (children.empty() && minimum == 1 && !maximum.has_value()) {
     return {make(sourcemeta::blaze::InstructionIndex::AssertionArraySizeGreater,
                  context, schema_context, dynamic_context,
                  ValueUnsignedInteger{0})};
@@ -293,8 +297,12 @@ auto compiler_2019_09_applicator_unevaluateditems(
       return {};
     }
 
-    return {make(sourcemeta::blaze::InstructionIndex::Evaluate, context,
-                 schema_context, dynamic_context, ValueNone{})};
+    // An unconditional marker would record this instance as evaluated whatever
+    // its type, so against a non-array it would wrongly suppress a sibling
+    // `unevaluatedProperties`. An array-guarded marker only records arrays
+    return {make(sourcemeta::blaze::InstructionIndex::LoopItemsUnevaluated,
+                 context, schema_context, dynamic_context, ValueNone{},
+                 Instructions{})};
   }
 
   // TODO: Attempt to short-circuit evaluation tracking by looking at sibling
@@ -391,8 +399,12 @@ auto compiler_2019_09_applicator_unevaluatedproperties(
   }
 
   if (children.empty()) {
-    return {make(sourcemeta::blaze::InstructionIndex::Evaluate, context,
-                 schema_context, dynamic_context, ValueNone{})};
+    // An unconditional marker would record this instance as evaluated whatever
+    // its type, so against a non-object it would wrongly suppress a sibling
+    // `unevaluatedItems`. An object-guarded marker only records objects
+    return {make(sourcemeta::blaze::InstructionIndex::LoopPropertiesEvaluate,
+                 context, schema_context, dynamic_context, ValueNone{},
+                 Instructions{})};
   } else if (!filter_strings.empty() || !filter_prefixes.empty() ||
              !filter_regexes.empty()) {
     return {make(

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -1323,11 +1323,11 @@ auto compiler_draft3_applicator_additionalproperties_with_options(
                                      std::move(filter_regexes)},
                  std::move(children))};
   } else if (track_evaluation) {
-    if (children.empty()) {
-      return {make(sourcemeta::blaze::InstructionIndex::Evaluate, context,
-                   schema_context, dynamic_context, ValueNone{})};
-    }
-
+    // An unconditional marker records this instance as evaluated whatever its
+    // type, so when this schema is applied to a non-object, such as a
+    // conditional branch evaluated against an array, it would wrongly mark that
+    // array evaluated and suppress a sibling `unevaluatedItems`. An
+    // object-guarded marker only records objects, and needs no children
     return {make(sourcemeta::blaze::InstructionIndex::LoopPropertiesEvaluate,
                  context, schema_context, dynamic_context, ValueNone{},
                  std::move(children))};

--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -33,15 +33,18 @@ inline auto is_noop_without_children(const InstructionIndex type) noexcept
     case InstructionIndex::LogicalWhenArraySizeGreater:
     case InstructionIndex::LoopPropertiesMatch:
     case InstructionIndex::LoopProperties:
-    case InstructionIndex::LoopPropertiesEvaluate:
     case InstructionIndex::LoopPropertiesRegex:
     case InstructionIndex::LoopPropertiesStartsWith:
     case InstructionIndex::LoopPropertiesExcept:
     case InstructionIndex::LoopKeys:
     case InstructionIndex::LoopItems:
     case InstructionIndex::LoopItemsFrom:
-    case InstructionIndex::LoopItemsUnevaluated:
-    case InstructionIndex::LoopContains:
+    // Deliberately absent are the loops that still do something with no
+    // children: the one carrying a match count still asserts that the array
+    // size falls within that range, and the ones that mark their instance
+    // location as evaluated still carry that side effect for a later
+    // `unevaluatedProperties` or `unevaluatedItems` to consult. Dropping any of
+    // them would discard those semantics
     case InstructionIndex::ControlGroupWhenDefines:
     case InstructionIndex::ControlGroupWhenDefinesDirect:
     case InstructionIndex::ControlGroupWhenType:

--- a/src/evaluator/evaluator_describe.cc
+++ b/src/evaluator/evaluator_describe.cc
@@ -898,12 +898,21 @@ auto describe(const bool valid, const Instruction &step,
 
   if (step.type ==
       sourcemeta::blaze::InstructionIndex::LoopPropertiesEvaluate) {
-    assert(keyword == "additionalProperties");
+    assert(keyword == "additionalProperties" ||
+           keyword == "unevaluatedProperties");
     std::ostringstream message;
     if (step.children.size() == 1 &&
         step.children.front().type == InstructionIndex::AssertionFail) {
-      message << "The object value was not expected to define additional "
-                 "properties";
+      if (keyword == "unevaluatedProperties") {
+        message << "The object value was not expected to define unevaluated "
+                   "properties";
+      } else {
+        message << "The object value was not expected to define additional "
+                   "properties";
+      }
+    } else if (keyword == "unevaluatedProperties") {
+      message << "The object properties not covered by other object "
+                 "keywords were expected to validate against this subschema";
     } else {
       message << "The object properties not covered by other adjacent object "
                  "keywords were expected to validate against this subschema";

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -1766,7 +1766,8 @@ INSTRUCTION_HANDLER(LoopProperties) {
 
 INSTRUCTION_HANDLER(LoopPropertiesEvaluate) {
   EVALUATE_BEGIN_NON_STRING(LoopPropertiesEvaluate, target.is_object());
-  assert(!instruction.children.empty());
+  // The subschema may compile to no children, in which case every property
+  // trivially matches and only the evaluation marking below takes effect
   result = true;
   for (const auto &entry : target.as_object()) {
     if constexpr (HasCallback) {
@@ -2305,7 +2306,8 @@ INSTRUCTION_HANDLER(LoopItemsFrom) {
 
 INSTRUCTION_HANDLER(LoopItemsUnevaluated) {
   EVALUATE_BEGIN_NON_STRING(LoopItemsUnevaluated, target.is_array());
-  assert(!instruction.children.empty());
+  // The subschema may compile to no children, in which case every item
+  // trivially matches and only the evaluation marking below takes effect
   result = true;
 
   if (!context.evaluator->is_evaluated(&target)) {
@@ -2669,11 +2671,13 @@ INSTRUCTION_HANDLER(LoopItemsIntegerBoundedSized) {
 
 INSTRUCTION_HANDLER(LoopContains) {
   EVALUATE_BEGIN_NON_STRING(LoopContains, target.is_array());
-  assert(!instruction.children.empty());
+  // The subschema may compile to no children, in which case every array
+  // element trivially matches and the range check alone decides the result
   const auto &value{assume_value<ValueRange>(instruction.value)};
   const auto &[minimum, maximum, is_exhaustive] = value;
-  assert(!maximum.has_value() || maximum.value() >= minimum);
-  result = minimum == 0 && target.empty();
+  // Note that the range may be unsatisfiable, as `minContains` and
+  // `maxContains` are free to invert it, in which case no array matches
+  result = minimum == 0;
   auto match_count{
       std::numeric_limits<std::remove_cvref_t<decltype(minimum)>>::min()};
 

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -1158,24 +1158,51 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/contains", "#/contains", "" ]
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
       ],
       "post": [
-        [ false, "AssertionFail", "/contains", "#/contains", "" ]
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
-        "The constraints declared for this keyword were not satisfiable"
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionFail", "/contains", "#/contains", "" ]
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
       ],
       "post": [
-        [ false, "AssertionFail", "/contains", "#/contains", "" ]
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
       ],
       "descriptions": [
-        "The constraints declared for this keyword were not satisfiable"
+        "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
       ]
     }
   },
@@ -8593,6 +8620,790 @@
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
         "The string value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1, 2, 3, 4 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 3 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 3 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "evaluate_marking_additionalproperties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": { "additionalProperties": { "$ref": "#/$defs/e" } },
+      "unevaluatedProperties": false,
+      "$defs": { "e": {} }
+    },
+    "instance": { "foo": 1, "bar": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
+        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
+        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
+        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "foo" ],
+        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
+        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "bar" ],
+        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The integer value was expected to validate against the referenced schema",
+        "The object property \"foo\" successfully validated against the additional properties subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The object property \"bar\" successfully validated against the additional properties subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "evaluate_marking_unevaluateditems",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "array" },
+      "then": { "unevaluatedItems": { "$ref": "#/$defs/e" } },
+      "unevaluatedItems": false,
+      "$defs": { "e": {} }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the given conditional",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the given conditional",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_mincontains_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 2
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain at least 2 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_mincontains_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 2
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items that validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain at least 2 items that validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_maxcontains_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_maxcontains_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "conditional_additional_array_unevaluated_invalid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "additionalProperties": true },
+      "unevaluatedProperties": false,
+      "unevaluatedItems": { "type": "integer" }
+    },
+    "instance": [ { "a": 1 } ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer but it was of type object",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer but it was of type object",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_min_zero_max_zero_matches_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": 1 },
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to equal the integer constant 1",
+        "The integer value 3 was expected to equal the integer constant 1",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to equal the integer constant 1",
+        "The integer value 3 was expected to equal the integer constant 1",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": { "role": "user" },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": "hello",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": null,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_matching_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [ "admin" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"admin\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"admin\" was expected to equal the string constant \"admin\"",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_other_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [ "user" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"user\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"user\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_empty_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_inverted_range_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "minContains": 3,
+      "maxContains": 2,
+      "contains": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_inverted_range_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "minContains": 3,
+      "maxContains": 2,
+      "contains": { "type": "string" }
+    },
+    "instance": [ "foo", "bar", "baz" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
       ]
     }
   }

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -9336,5 +9336,1077 @@
         "The string value was expected to validate against the given conditional"
       ]
     }
+  },
+  {
+    "description": "contains_empty_target_dropped_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_3",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "$ref": "#/$defs/maybe" },
+      "minContains": 2,
+      "maxContains": 3,
+      "properties": { "x": { "$ref": "#/$defs/maybe" } },
+      "$defs": { "maybe": {} }
+    },
+    "instance": [ 1, 2, 3, 4 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 3 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The item at index 3 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 2 to 3 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "evaluate_marking_additionalproperties",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": { "additionalProperties": { "$ref": "#/$defs/e" } },
+      "unevaluatedProperties": false,
+      "$defs": { "e": {} }
+    },
+    "instance": { "foo": 1, "bar": 2 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
+        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
+        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
+        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "foo" ],
+        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
+        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "bar" ],
+        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The integer value was expected to validate against the referenced schema",
+        "The object property \"foo\" successfully validated against the additional properties subschema",
+        "The integer value was expected to validate against the referenced schema",
+        "The object property \"bar\" successfully validated against the additional properties subschema",
+        "The object properties not covered by other adjacent object keywords were expected to validate against this subschema",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "evaluate_marking_unevaluateditems",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "array" },
+      "then": { "unevaluatedItems": { "$ref": "#/$defs/e" } },
+      "unevaluatedItems": false,
+      "$defs": { "e": {} }
+    },
+    "instance": [ 1, 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the given conditional",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
+        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
+        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
+        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The integer value was expected to validate against the referenced schema",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the given conditional",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_mincontains_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 2
+    },
+    "instance": [ 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain at least 2 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_mincontains_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 2
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 2 items that validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain at least 2 items that validate against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_maxcontains_1",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ],
+        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema",
+        "The value was expected to be of type array"
+      ]
+    }
+  },
+  {
+    "description": "contains_trivial_maxcontains_2",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "contains": {},
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [ 1, 2 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "conditional_additional_array_unevaluated_invalid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "additionalProperties": true },
+      "unevaluatedProperties": false,
+      "unevaluatedItems": { "type": "integer" }
+    },
+    "instance": [ { "a": 1 } ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer but it was of type object",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer but it was of type object",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "conditional_additional_array_unevaluated_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "additionalProperties": true },
+      "unevaluatedProperties": false,
+      "unevaluatedItems": { "type": "integer" }
+    },
+    "instance": [ 1, 2 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer",
+        "The value was expected to be of type integer",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "" ],
+        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
+        [ "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
+        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
+        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
+        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the given conditional",
+        "The value was expected to be of type integer",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The value was expected to be of type integer",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_min_zero_max_zero_matches_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": 1 },
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [ 2, 3 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to equal the integer constant 1",
+        "The integer value 3 was expected to equal the integer constant 1",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 2 was expected to equal the integer constant 1",
+        "The integer value 3 was expected to equal the integer constant 1",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_min_zero_max_too_many_invalid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": 1 },
+      "minContains": 0,
+      "maxContains": 1
+    },
+    "instance": [ 1, 1 ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to equal the integer constant 1",
+        "The integer value 1 was expected to equal the integer constant 1",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value 1 was expected to equal the integer constant 1",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The integer value 1 was expected to equal the integer constant 1",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain up to 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "dynamic_unevaluated_items_marks_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/root",
+      "$ref": "https://example.com/inner",
+      "$defs": {
+        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
+        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "inner": {
+          "$id": "https://example.com/inner",
+          "$dynamicRef": "https://example.com/a#T",
+          "unevaluatedItems": true,
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "instance": { "a": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ false, "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ false, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties",
+        "The object value was expected to validate against the referenced schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
+        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ false, "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ false, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The title of the instance was \"x\"",
+        "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties",
+        "The object value was expected to validate against the referenced schema"
+      ]
+    }
+  },
+  {
+    "description": "dynamic_unevaluated_items_marks_object_empty",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/root",
+      "$ref": "https://example.com/inner",
+      "$defs": {
+        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
+        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "inner": {
+          "$id": "https://example.com/inner",
+          "$dynamicRef": "https://example.com/a#T",
+          "unevaluatedItems": true,
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "The object value was not expected to define unevaluated properties",
+        "The object value was expected to validate against the referenced schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
+        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
+        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The title of the instance was \"x\"",
+        "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "The object value was not expected to define unevaluated properties",
+        "The object value was expected to validate against the referenced schema"
+      ]
+    }
+  },
+  {
+    "description": "dynamic_unevaluated_items_marks_object_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/root",
+      "$ref": "https://example.com/inner",
+      "$defs": {
+        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
+        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "inner": {
+          "$id": "https://example.com/inner",
+          "$dynamicRef": "https://example.com/a#T",
+          "unevaluatedItems": true,
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "instance": [ 1 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ true, "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
+        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the referenced schema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
+        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
+        [ "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
+        [ "Annotation", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
+        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
+        [ true, "Annotation", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "", true ],
+        [ true, "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
+        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+      ],
+      "descriptions": [
+        "The title of the instance was \"x\"",
+        "The array value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
+        "At least one item of the array value successfully validated against the subschema for unevaluated items",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema",
+        "The array value was expected to validate against the referenced schema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": { "role": "user" },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_string",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": "hello",
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_null",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": null,
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_matching_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [ "admin" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"admin\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"admin\" was expected to equal the string constant \"admin\"",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_other_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [ "user" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"user\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+      ],
+      "post": [
+        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The string value \"user\" was expected to equal the string constant \"admin\"",
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_unsatisfiable_empty_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "contains": { "const": "admin" },
+      "maxContains": 0
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain 1 to 0 items that validate against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_inverted_range_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minContains": 3,
+      "maxContains": 2,
+      "contains": { "type": "string" }
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    },
+    "exhaustive": {
+      "pre": [],
+      "post": [],
+      "descriptions": []
+    }
+  },
+  {
+    "description": "contains_inverted_range_array",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minContains": 3,
+      "maxContains": 2,
+      "contains": { "type": "string" }
+    },
+    "instance": [ "foo", "bar", "baz" ],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ "Annotation", "/contains", "#/contains", "" ],
+        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ "Annotation", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
+        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
+        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type string",
+        "The item at index 0 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 1 of the array value successfully validated against the containment check subschema",
+        "The value was expected to be of type string",
+        "The item at index 2 of the array value successfully validated against the containment check subschema",
+        "The array value was expected to contain 3 to 2 items that validate against the given subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -5724,3 +5724,49 @@ TEST(annotation_fast_whitelist_if_then_else_inlined_shared_ref_else_branch) {
                                "The integer value was expected to validate "
                                "against the given conditional");
 }
+
+TEST(dynamic_unevaluated_properties_does_not_mark_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/root",
+    "allOf": [ { "$ref": "https://example.com/inner" } ],
+    "unevaluatedItems": false,
+    "$defs": {
+      "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
+      "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+      "inner": {
+        "$id": "https://example.com/inner",
+        "$dynamicRef": "https://example.com/a#T",
+        "unevaluatedProperties": true
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1 ])JSON")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 5, "");
+
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "https://example.com/root#/allOf",
+                     "");
+  EVALUATE_TRACE_PRE(1, ControlJump, "/allOf/0/$ref",
+                     "https://example.com/root#/allOf/0/$ref", "");
+  EVALUATE_TRACE_PRE(2, ControlDynamicAnchorJump, "/allOf/0/$ref/$dynamicRef",
+                     "https://example.com/inner#/$dynamicRef", "");
+  EVALUATE_TRACE_PRE(3, LoopItemsUnevaluated, "/unevaluatedItems",
+                     "https://example.com/root#/unevaluatedItems", "");
+  EVALUATE_TRACE_PRE(4, AssertionFail, "/unevaluatedItems",
+                     "https://example.com/root#/unevaluatedItems", "/0");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, ControlDynamicAnchorJump,
+                              "/allOf/0/$ref/$dynamicRef",
+                              "https://example.com/inner#/$dynamicRef", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, ControlJump, "/allOf/0/$ref",
+                              "https://example.com/root#/allOf/0/$ref", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf",
+                              "https://example.com/root#/allOf", "");
+  EVALUATE_TRACE_POST_FAILURE(3, AssertionFail, "/unevaluatedItems",
+                              "https://example.com/root#/unevaluatedItems",
+                              "/0");
+  EVALUATE_TRACE_POST_FAILURE(4, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "https://example.com/root#/unevaluatedItems", "");
+}

--- a/test/evaluator/evaluator_draft7.json
+++ b/test/evaluator/evaluator_draft7.json
@@ -4602,5 +4602,74 @@
         "The string value was expected to validate against the given conditional"
       ]
     }
+  },
+  {
+    "description": "contains_empty_target_dropped_1",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "contains": { "$ref": "#/definitions/maybe" },
+      "properties": { "x": { "$ref": "#/definitions/maybe" } },
+      "definitions": { "maybe": {} }
+    },
+    "instance": [],
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ false, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 1 item that validates against the given subschema"
+      ]
+    }
+  },
+  {
+    "description": "contains_empty_target_dropped_2",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "contains": { "$ref": "#/definitions/maybe" },
+      "properties": { "x": { "$ref": "#/definitions/maybe" } },
+      "definitions": { "maybe": {} }
+    },
+    "instance": [ 1 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "post": [
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The array value was expected to contain at least 1 item that validates against the given subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LoopContains", "/contains", "#/contains", "" ],
+        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ]
+      ],
+      "post": [
+        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
+        [ true, "LoopContains", "/contains", "#/contains", "" ]
+      ],
+      "descriptions": [
+        "The integer value was expected to validate against the referenced schema",
+        "The array value was expected to contain at least 1 item that validates against the given subschema"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

