### PR TITLE
Fix fast-mode evaluation-mark elision on `anyOf` `$ref` dependencies

### DIFF
--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -232,7 +232,15 @@ auto compile_required_assertions(const Context &context,
             types.insert(std::get<ValueType>(property.second.front().value));
           }
 
-          if (types.size() == 1) {
+          // `properties` only collapses into the fused form that also
+          // enforces these requirements when it is neither emitting
+          // annotations nor tracking evaluation, so this must mirror both of
+          // its gates. Note that we must ask that of `properties` rather than
+          // of this keyword, as evaluation tracking follows the keywords an
+          // `unevaluatedProperties` depends on, which `required` is not one of
+          if (types.size() == 1 &&
+              !annotations_enabled(context, KEYWORD_PROPERTIES) &&
+              !requires_evaluation(context, new_schema_context)) {
             // Handled in `properties`
             return {};
           }
@@ -614,8 +622,11 @@ auto compiler_draft3_applicator_properties_with_options(
   auto properties{compile_properties(context, schema_context,
                                      effective_dynamic_context, current)};
 
+  // These fused forms collapse every property into a single instruction that
+  // does not mark the properties it matches as evaluated, so under evaluation
+  // tracking we must fall through to the form that emits the markers
   if (!emit_annotation && context.mode == Mode::FastValidation &&
-      !required.empty() &&
+      !track_evaluation && !required.empty() &&
       schema_context.schema.defines("additionalProperties") &&
       schema_context.schema.at("additionalProperties").is_boolean() &&
       !schema_context.schema.at("additionalProperties").to_boolean() &&

--- a/src/compiler/include/sourcemeta/blaze/compiler_unevaluated.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_unevaluated.h
@@ -22,7 +22,8 @@ namespace sourcemeta::blaze {
 struct SchemaUnevaluatedEntry {
   /// The absolute pointers of the static keyword dependencies
   std::set<sourcemeta::core::WeakPointer> static_dependencies;
-  /// The absolute pointers of the static keyword dependencies
+  /// The absolute pointers of the dynamic keyword dependencies, along with the
+  /// references that lead to them
   std::set<sourcemeta::core::WeakPointer> dynamic_dependencies;
   /// Whether the entry cannot be fully resolved, which means
   /// there might be unknown dynamic dependencies

--- a/src/compiler/unevaluated.cc
+++ b/src/compiler/unevaluated.cc
@@ -54,9 +54,24 @@ auto find_adjacent_dependencies(
             frame.dereference(entry, make_weak_pointer(property.first))};
         if (reference.first == SchemaReferenceType::Static &&
             reference.second.has_value()) {
+          const auto dynamic_size{result.dynamic_dependencies.size()};
           find_adjacent_dependencies(
               current, schema, frame, walker, resolver, keywords, root,
               reference.second.value().get(), is_static, result);
+
+          // Whatever the target contributes gets recorded at the location of
+          // the target itself, which tells the applicators this reference sits
+          // under nothing about it. Record the reference as a dependency of
+          // its own too, so that they can still tell that reaching through it
+          // leads to one, and therefore that they cannot short-circuit. Only
+          // the dynamic dependencies are consulted that way, whereas the
+          // static ones name the keyword locations that evaluate, which a
+          // reference is not one of
+          if (!is_static &&
+              result.dynamic_dependencies.size() != dynamic_size) {
+            result.dynamic_dependencies.emplace(
+                entry.pointer.concat(make_weak_pointer(property.first)));
+          }
         } else if (reference.first == SchemaReferenceType::Dynamic) {
           result.unresolved = true;
         }

--- a/src/compiler/unevaluated.cc
+++ b/src/compiler/unevaluated.cc
@@ -54,10 +54,15 @@ auto find_adjacent_dependencies(
             frame.dereference(entry, make_weak_pointer(property.first))};
         if (reference.first == SchemaReferenceType::Static &&
             reference.second.has_value()) {
-          const auto dynamic_size{result.dynamic_dependencies.size()};
+          // Recurse into a dedicated entry so that whether this reference's
+          // target contributes any dynamic dependency can be read directly,
+          // rather than inferred from whether it grew the shared deduplicated
+          // set, which misses every reference after the first to a common
+          // target
+          SchemaUnevaluatedEntry nested;
           find_adjacent_dependencies(
               current, schema, frame, walker, resolver, keywords, root,
-              reference.second.value().get(), is_static, result);
+              reference.second.value().get(), is_static, nested);
 
           // Whatever the target contributes gets recorded at the location of
           // the target itself, which tells the applicators this reference sits
@@ -67,11 +72,14 @@ auto find_adjacent_dependencies(
           // the dynamic dependencies are consulted that way, whereas the
           // static ones name the keyword locations that evaluate, which a
           // reference is not one of
-          if (!is_static &&
-              result.dynamic_dependencies.size() != dynamic_size) {
+          if (!is_static && !nested.dynamic_dependencies.empty()) {
             result.dynamic_dependencies.emplace(
                 entry.pointer.concat(make_weak_pointer(property.first)));
           }
+
+          result.unresolved = result.unresolved || nested.unresolved;
+          result.static_dependencies.merge(nested.static_dependencies);
+          result.dynamic_dependencies.merge(nested.dynamic_dependencies);
         } else if (reference.first == SchemaReferenceType::Dynamic) {
           result.unresolved = true;
         }

--- a/test/compiler/compiler_unevaluated_2020_12_test.cc
+++ b/test/compiler/compiler_unevaluated_2020_12_test.cc
@@ -251,6 +251,49 @@ TEST(unevaluatedProperties_7) {
   EXPECT_UNEVALUATED_RESOLVED(result, "#/unevaluatedProperties");
 }
 
+TEST(unevaluatedProperties_7_repeated_reference) {
+  const auto schema = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/foo",
+    "unevaluatedProperties": false,
+    "anyOf": [ { "$ref": "#/$defs/bar" }, { "$ref": "#/$defs/bar" } ],
+    "$defs": {
+      "foo": {
+        "properties": {
+          "foo": true
+        }
+      },
+      "bar": {
+        "additionalProperties": false
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+  const auto result{sourcemeta::blaze::unevaluated(
+      schema, frame, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver)};
+
+  EXPECT_EQ(result.size(), 1);
+
+  EXPECT_UNEVALUATED_STATIC(result, "#/unevaluatedProperties", 1);
+  EXPECT_UNEVALUATED_STATIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                       "/$defs/foo/properties");
+
+  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedProperties", 3);
+  EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                        "/$defs/bar/additionalProperties");
+  EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                        "/anyOf/0/$ref");
+  EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                        "/anyOf/1/$ref");
+
+  EXPECT_UNEVALUATED_RESOLVED(result, "#/unevaluatedProperties");
+}
+
 TEST(unevaluatedProperties_8) {
   const auto schema = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com",

--- a/test/compiler/compiler_unevaluated_2020_12_test.cc
+++ b/test/compiler/compiler_unevaluated_2020_12_test.cc
@@ -242,9 +242,11 @@ TEST(unevaluatedProperties_7) {
   EXPECT_UNEVALUATED_STATIC_DEPENDENCY(result, "#/unevaluatedProperties",
                                        "/$defs/foo/properties");
 
-  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedProperties", 1);
+  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedProperties", 2);
   EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
                                         "/$defs/bar/additionalProperties");
+  EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                        "/anyOf/0/$ref");
 
   EXPECT_UNEVALUATED_RESOLVED(result, "#/unevaluatedProperties");
 }

--- a/test/evaluator/evaluator_2019_09.json
+++ b/test/evaluator/evaluator_2019_09.json
@@ -9406,5 +9406,555 @@
         "The array value was expected to contain 3 to 2 items that validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": "y" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/b" ],
+        [ "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ true, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "b" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/b" ],
+        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The value was expected to be of type string",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_bad_type",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ false, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ false, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ false, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_missing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": "y", "c": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\", but it also defines the property \"c\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\", but it also defines the property \"c\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_non_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type integer",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type integer",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_evaluates",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
+        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_unrelated_property",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": 1, "zzz": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
+        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_failing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ false, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer but it was of type string",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ false, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ false, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer but it was of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_empty",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -10408,5 +10408,621 @@
         "The array value was expected to contain 3 to 2 items that validate against the given subschema"
       ]
     }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": "y" },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/b" ],
+        [ "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ true, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "b" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/b" ],
+        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ true, "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
+        [ true, "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The value was expected to be of type string",
+        "The object property \"b\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was not expected to define additional properties",
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the given conditional",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_bad_type",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ false, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ "Annotation", "/then/properties", "#/then/properties", "" ],
+        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
+        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
+        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
+        [ false, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
+        [ false, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The value was expected to be of type string",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The value was expected to be of type string but it was of type integer",
+        "The object value was expected to validate against the defined properties subschemas",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_missing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_additional",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x", "b": "y", "c": 1 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be an object that only defines properties \"a\", and \"b\", but it also defines the property \"c\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
+        [ false, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to only define properties \"a\", and \"b\", but it also defines the property \"c\"",
+        "The object value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "conditional_properties_fusion_tracked_non_object",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "if": { "type": "object" },
+      "then": {
+        "type": "object",
+        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+        "required": [ "a", "b" ],
+        "additionalProperties": false
+      },
+      "unevaluatedProperties": false
+    },
+    "instance": 5,
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type integer",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalCondition", "/if", "#/if", "" ],
+        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+      ],
+      "post": [
+        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
+        [ true, "LogicalCondition", "/if", "#/if", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object but it was of type integer",
+        "The integer value was expected to validate against the given conditional"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_evaluates",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": 1 },
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
+        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_unrelated_property",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": 1, "zzz": 2 },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
+        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer",
+        "The object property \"a\" successfully validated against its property subschema",
+        "The instance location was marked as evaluated",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"zzz\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_failing",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": { "a": "x" },
+    "valid": false,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ false, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer but it was of type string",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
+        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ false, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
+        [ false, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ false, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
+        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The value was expected to be of type integer but it was of type string",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define the property \"a\"",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_empty",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
+      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedProperties": false
+    },
+    "instance": {},
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type object",
+        "The object value was expected to validate against the single defined property subschema",
+        "The object value was expected to validate against the referenced schema",
+        "The object value was expected to validate against at least one of the 2 given subschemas",
+        "The object value was not expected to define unevaluated properties"
+      ]
+    }
+  },
+  {
+    "description": "any_of_reference_branch_items",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": { "D": { "prefixItems": [ { "type": "integer" } ] } },
+      "anyOf": [ { "type": "array" }, { "$ref": "#/$defs/D" } ],
+      "unevaluatedItems": false
+    },
+    "instance": [ 1 ],
+    "valid": true,
+    "fast": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
+        [ true, "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The value was expected to be of type integer",
+        "The first item of the array value was expected to validate against the corresponding subschemas",
+        "The array value was expected to validate against at least one of the 2 given subschemas",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    },
+    "exhaustive": {
+      "pre": [
+        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
+        [ "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "post": [
+        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
+        [ true, "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
+        [ true, "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "", 0 ],
+        [ true, "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "", true ],
+        [ true, "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
+        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
+        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
+        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+      ],
+      "descriptions": [
+        "The value was expected to be of type array",
+        "The value was expected to be of type integer",
+        "The first item of the array value successfully validated against the first positional subschema",
+        "Every item of the array value validated against the given positional subschemas",
+        "The first item of the array value was expected to validate against the corresponding subschemas",
+        "The array value was expected to validate against the referenced schema",
+        "The array value was expected to validate against at least one of the 2 given subschemas",
+        "The array items not covered by other array keywords, if any, were expected to validate against this subschema"
+      ]
+    }
   }
 ]

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -5770,3 +5770,90 @@ TEST(dynamic_unevaluated_properties_does_not_mark_array) {
   EVALUATE_TRACE_POST_FAILURE(4, LoopItemsUnevaluated, "/unevaluatedItems",
                               "https://example.com/root#/unevaluatedItems", "");
 }
+
+TEST(properties_closed_required_annotation_whitelist_fast) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [ "a", "b" ],
+    "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+    "additionalProperties": false
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json(
+      R"JSON({ "a": "x", "b": "y", "zzz": 1 })JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.annotations =
+      std::unordered_set<sourcemeta::core::JSON::StringView>{"properties"};
+
+  EVALUATE_WITH_TRACE_FAST_FAILURE_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionDefinesExactlyStrict, "/required",
+                     "#/required", "");
+  EVALUATE_TRACE_POST_FAILURE(0, AssertionDefinesExactlyStrict, "/required",
+                              "#/required", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an object that only defines properties "
+      "\"a\", and \"b\", but it also defines the property \"zzz\"");
+}
+
+TEST(any_of_reference_branch_items_extra) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": { "D": { "prefixItems": [ { "type": "integer" } ] } },
+    "anyOf": [ { "type": "array" }, { "$ref": "#/$defs/D" } ],
+    "unevaluatedItems": false
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
+  EVALUATE_WITH_TRACE_FAST_FAILURE(schema, instance, 6, "");
+
+  EVALUATE_TRACE_PRE(0, LogicalOr, "/anyOf", "#/anyOf", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/anyOf/0/type", "#/anyOf/0/type",
+                     "");
+  EVALUATE_TRACE_PRE(2, AssertionArrayPrefixEvaluate,
+                     "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "");
+  EVALUATE_TRACE_PRE(3, AssertionType, "/anyOf/1/$ref/prefixItems/0/type",
+                     "#/$defs/D/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_PRE(4, LoopItemsUnevaluated, "/unevaluatedItems",
+                     "#/unevaluatedItems", "");
+  EVALUATE_TRACE_PRE(5, AssertionFail, "/unevaluatedItems",
+                     "#/unevaluatedItems", "/1");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/anyOf/0/type",
+                              "#/anyOf/0/type", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType,
+                              "/anyOf/1/$ref/prefixItems/0/type",
+                              "#/$defs/D/prefixItems/0/type", "/0");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionArrayPrefixEvaluate,
+                              "/anyOf/1/$ref/prefixItems",
+                              "#/$defs/D/prefixItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(3, LogicalOr, "/anyOf", "#/anyOf", "");
+  EVALUATE_TRACE_POST_FAILURE(4, AssertionFail, "/unevaluatedItems",
+                              "#/unevaluatedItems", "/1");
+  EVALUATE_TRACE_POST_FAILURE(5, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type array");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The first item of the array value was expected "
+                               "to validate against the corresponding "
+                               "subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The array value was expected to validate "
+                               "against at least one of the 2 given "
+                               "subschemas");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
+                               "The array value was not expected to define the "
+                               "item at index 1");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 5,
+                               "The array items not covered by other array "
+                               "keywords, if any, were expected to validate "
+                               "against this subschema");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

