### PR TITLE
Canonicalize away unknown `type` values

### DIFF
--- a/src/canonicalizer/canonicalize.cc
+++ b/src/canonicalizer/canonicalize.cc
@@ -366,6 +366,7 @@ auto apply(const std::vector<Rule> &rules, sourcemeta::core::JSON &schema,
 #include "rules/unevaluated_properties_to_additional_properties.h"
 #include "rules/unknown_keywords_prefix.h"
 #include "rules/unknown_local_ref.h"
+#include "rules/unknown_type_names.h"
 #include "rules/unnecessary_allof_ref_wrapper_draft.h"
 #include "rules/unnecessary_extends_ref_wrapper.h"
 #include "rules/unsatisfiable_drop_validation.h"
@@ -405,6 +406,7 @@ auto canonicalize(sourcemeta::core::JSON &schema,
   rules.push_back(make_rule<AllOfMergeCompatibleBranches>());
   rules.push_back(make_rule<TypeInheritInPlace>());
   rules.push_back(make_rule<TypeUnionImplicit>());
+  rules.push_back(make_rule<UnknownTypeNames>());
   rules.push_back(make_rule<TypeArrayToAnyOf>());
   rules.push_back(make_rule<DefinitionsToDefs>());
   rules.push_back(make_rule<ContentMediaTypeWithoutEncoding>());

--- a/src/canonicalizer/rules/unknown_type_names.h
+++ b/src/canonicalizer/rules/unknown_type_names.h
@@ -1,0 +1,66 @@
+class UnknownTypeNames final : public SchemaTransformRule {
+public:
+  using reframe_after_transform = std::false_type;
+  UnknownTypeNames() : SchemaTransformRule{"unknown_type_names"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::Vocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &) const -> bool override {
+    ONLY_CONTINUE_IF(vocabularies.contains_any(
+                         {Vocabularies::Known::JSON_Schema_2020_12_Validation,
+                          Vocabularies::Known::JSON_Schema_2019_09_Validation,
+                          Vocabularies::Known::JSON_Schema_Draft_7,
+                          Vocabularies::Known::JSON_Schema_Draft_6,
+                          Vocabularies::Known::JSON_Schema_Draft_4}) &&
+                     schema.is_object());
+
+    const auto *type{schema.try_at("type")};
+    ONLY_CONTINUE_IF(type);
+
+    // An unrecognised type name constrains nothing, so it is safe (and more
+    // canonical) to drop it: a scalar unknown name leaves no constraint at all,
+    // and an unknown name inside a union just does not contribute an
+    // alternative. `parse_schema_type` yields an empty set for a name it does
+    // not recognise
+    if (type->is_string()) {
+      return !parse_schema_type(*type).any();
+    }
+
+    if (type->is_array()) {
+      for (const auto &entry : type->as_array()) {
+        if (entry.is_string() && !parse_schema_type(entry).any()) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+    if (schema.at("type").is_string()) {
+      schema.erase("type");
+      return;
+    }
+
+    auto recognised{sourcemeta::core::JSON::make_array()};
+    for (const auto &entry : schema.at("type").as_array()) {
+      if (entry.is_string() && !parse_schema_type(entry).any()) {
+        continue;
+      }
+
+      recognised.push_back(entry);
+    }
+
+    if (recognised.empty()) {
+      schema.erase("type");
+    } else {
+      schema.at("type").into(std::move(recognised));
+    }
+  }
+};

--- a/test/canonicalizer/canonicalizer_2019_09_test.cc
+++ b/test/canonicalizer/canonicalizer_2019_09_test.cc
@@ -1843,3 +1843,18 @@ TEST(enum_split_anchor_referenced_twice_2019) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_array_drops_unknown_name) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": [ "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "string",
+    "minLength": 0
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_2020_12_test.cc
+++ b/test/canonicalizer/canonicalizer_2020_12_test.cc
@@ -1016,6 +1016,38 @@ TEST(type_array_to_any_of_5) {
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
 
+TEST(type_array_drops_unknown_name) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": [ "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "minLength": 0
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
+TEST(type_array_drops_unknown_name_before_split) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": [ "integer", "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "anyOf": [
+      { "type": "integer", "multipleOf": 1 },
+      { "type": "string", "minLength": 0 }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
 TEST(max_contains_covered_by_max_items_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/canonicalizer/canonicalizer_draft4_test.cc
+++ b/test/canonicalizer/canonicalizer_draft4_test.cc
@@ -5121,3 +5121,18 @@ TEST(enum_split_in_not) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_array_drops_unknown_name) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": [ "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "string",
+    "minLength": 0
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft6_test.cc
+++ b/test/canonicalizer/canonicalizer_draft6_test.cc
@@ -4466,3 +4466,18 @@ TEST(draft4_id_becomes_unknown_keyword) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_array_drops_unknown_name) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": [ "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "string",
+    "minLength": 0
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft7_test.cc
+++ b/test/canonicalizer/canonicalizer_draft7_test.cc
@@ -6233,3 +6233,18 @@ TEST(if_then_else_closed_object) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_array_drops_unknown_name) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": [ "string", "foo" ]
+  })JSON");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "string",
+    "minLength": 0
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/codegen/codegen_test.cc
+++ b/test/codegen/codegen_test.cc
@@ -3,6 +3,8 @@
 #include <sourcemeta/blaze/codegen.h>
 #include <sourcemeta/blaze/foundation.h>
 
+#include <sstream> // std::ostringstream
+
 TEST(unsupported_dialect_draft3) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
@@ -52,19 +54,38 @@ TEST(unsupported_keyword_value_error_type_not_string) {
   }
 }
 
-TEST(unsupported_keyword_value_error_unknown_type) {
+TEST(unknown_type_value_ignored) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "foo"
   })JSON")};
 
-  try {
-    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
-                               sourcemeta::blaze::schema_resolver,
-                               sourcemeta::blaze::default_compiler);
-    FAIL();
-  } catch (
-      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
-    EXPECT_STREQ(error.what(), "Unsupported type value");
-  }
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  std::ostringstream output;
+  sourcemeta::blaze::generate<sourcemeta::blaze::TypeScript>(output, result);
+
+  EXPECT_EQ(output.str(), "export type Schema_5 = number;\n"
+                          "\n"
+                          "export type Schema_4 = string;\n"
+                          "\n"
+                          "export type Schema_3Items = unknown;\n"
+                          "\n"
+                          "export type Schema_3 = Schema_3Items[];\n"
+                          "\n"
+                          "export type Schema_2 = Record<string, unknown>;\n"
+                          "\n"
+                          "export type Schema_1 = boolean;\n"
+                          "\n"
+                          "export type Schema_0 = null;\n"
+                          "\n"
+                          "export type Schema =\n"
+                          "  Schema_0 |\n"
+                          "  Schema_1 |\n"
+                          "  Schema_2 |\n"
+                          "  Schema_3 |\n"
+                          "  Schema_4 |\n"
+                          "  Schema_5;\n");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

