### PR TITLE
Forbid `rdf:langString` as an `x-jsonld-datatype` value

### DIFF
--- a/schemas/sourcemeta-extension/v1/2019-09/vocabulary.json
+++ b/schemas/sourcemeta-extension/v1/2019-09/vocabulary.json
@@ -38,8 +38,12 @@
           "type": "null"
         },
         {
+          "$comment": "A literal has the langString datatype exactly when it carries a language tag, which only x-jsonld-language declares",
           "x-format-assertion": true,
           "type": "string",
+          "not": {
+            "const": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+          },
           "format": "iri"
         }
       ]

--- a/schemas/sourcemeta-extension/v1/2020-12/vocabulary.json
+++ b/schemas/sourcemeta-extension/v1/2020-12/vocabulary.json
@@ -38,8 +38,12 @@
           "type": "null"
         },
         {
+          "$comment": "A literal has the langString datatype exactly when it carries a language tag, which only x-jsonld-language declares",
           "x-format-assertion": true,
           "type": "string",
+          "not": {
+            "const": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+          },
           "format": "iri"
         }
       ]

--- a/schemas/sourcemeta-extension/v1/README.markdown
+++ b/schemas/sourcemeta-extension/v1/README.markdown
@@ -99,7 +99,10 @@ apply to this keyword.
 #### 3.2.4. `x-jsonld-datatype`
 
 The value of this keyword MUST be a string representing an absolute IRI
-[RFC3987].
+[RFC3987], and MUST NOT be the IRI
+`http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`, as a literal has
+that datatype exactly when it carries a language tag, which only
+`x-jsonld-language` declares.
 
 This keyword declares the datatype IRI of the typed literal that the annotated
 instance location materializes as, such as

--- a/schemas/sourcemeta-extension/v1/vocabulary.test.json
+++ b/schemas/sourcemeta-extension/v1/vocabulary.test.json
@@ -260,6 +260,27 @@
       }
     },
     {
+      "description": "x-jsonld-datatype with the langString IRI is rejected",
+      "valid": false,
+      "data": {
+        "x-jsonld-datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+      }
+    },
+    {
+      "description": "x-jsonld-datatype with a case variant of the langString IRI is a different IRI and accepted",
+      "valid": true,
+      "data": {
+        "x-jsonld-datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#LangString"
+      }
+    },
+    {
+      "description": "x-jsonld-datatype with another IRI in the rdf-syntax-ns namespace is accepted",
+      "valid": true,
+      "data": {
+        "x-jsonld-datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON"
+      }
+    },
+    {
       "description": "x-jsonld-language with primary subtag is valid",
       "valid": true,
       "data": {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

