### PR TITLE
Don't misparse Draft 0-3 `type` unions that contain schemas or `any`

### DIFF
--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -52,6 +52,35 @@ inline auto IS_IN_PLACE_APPLICATOR(const SchemaKeywordType type) -> bool {
          type == SchemaKeywordType::ApplicatorValueInPlaceNegate;
 }
 
+// Whether a `type` value only consists of simple type names that can be
+// parsed into a complete set of instance types. Draft 0 to Draft 3 unions
+// may contain subschemas or `any`, in which case the parsed set is an
+// under-approximation that cannot be trusted. Later dialects do not give
+// such forms any meaning, so the parsed set stands
+inline auto IS_KNOWN_TYPE_FORM(const JSON &type,
+                               const Vocabularies &vocabularies) -> bool {
+  if (!vocabularies.contains_any(
+          {Vocabularies::Known::JSON_Schema_Draft_0,
+           Vocabularies::Known::JSON_Schema_Draft_0_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_1,
+           Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_2,
+           Vocabularies::Known::JSON_Schema_Draft_2_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_3,
+           Vocabularies::Known::JSON_Schema_Draft_3_Hyper})) {
+    return true;
+  }
+  if (type.is_string()) {
+    return type.to_string() != "any";
+  }
+  if (!type.is_array()) {
+    return false;
+  }
+  return std::ranges::all_of(type.as_array(), [](const auto &entry) -> auto {
+    return entry.is_string() && entry.to_string() != "any";
+  });
+}
+
 // Walk up from a schema location, continuing as long as the traversal
 // predicate returns true for each keyword type encountered. Returns a
 // reference to the pointer of the ancestor where the match callback returned

--- a/src/alterschema/common/non_applicable_disallow_types.h
+++ b/src/alterschema/common/non_applicable_disallow_types.h
@@ -28,7 +28,7 @@ public:
 
     const auto *parent_type_value{schema.try_at("type")};
     ONLY_CONTINUE_IF(parent_type_value &&
-                     is_known_type_form(*parent_type_value));
+                     IS_KNOWN_TYPE_FORM(*parent_type_value, vocabularies));
 
     const auto parent_types{parse_schema_type(*parent_type_value)};
     ONLY_CONTINUE_IF(parent_types.any());
@@ -41,7 +41,7 @@ public:
         entry_types = parse_schema_type(entry);
       } else if (entry.is_object()) {
         const auto *entry_type{entry.try_at("type")};
-        if (entry_type && is_known_type_form(*entry_type)) {
+        if (entry_type && IS_KNOWN_TYPE_FORM(*entry_type, vocabularies)) {
           entry_types = parse_schema_type(*entry_type);
         }
       }
@@ -81,18 +81,5 @@ public:
     } else {
       schema.assign("disallow", std::move(new_disallow));
     }
-  }
-
-private:
-  static auto is_known_type_form(const sourcemeta::core::JSON &type) -> bool {
-    if (type.is_string()) {
-      return type.to_string() != "any";
-    }
-    if (!type.is_array()) {
-      return false;
-    }
-    return std::ranges::all_of(type.as_array(), [](const auto &entry) -> auto {
-      return entry.is_string() && entry.to_string() != "any";
-    });
   }
 };

--- a/src/alterschema/common/non_applicable_type_specific_keywords.h
+++ b/src/alterschema/common/non_applicable_type_specific_keywords.h
@@ -32,7 +32,8 @@ public:
                             Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
                             Vocabularies::Known::JSON_Schema_Draft_0,
                             Vocabularies::Known::JSON_Schema_Draft_0_Hyper}) &&
-                               type_value
+                               type_value &&
+                               IS_KNOWN_TYPE_FORM(*type_value, vocabularies)
                            ? parse_schema_type(*type_value)
                            : sourcemeta::core::JSON::TypeSet{}};
 

--- a/src/alterschema/common/unsatisfiable_in_place_applicator_type.h
+++ b/src/alterschema/common/unsatisfiable_in_place_applicator_type.h
@@ -29,6 +29,7 @@ public:
          Vocabularies::Known::JSON_Schema_Draft_2,
          Vocabularies::Known::JSON_Schema_Draft_1,
          Vocabularies::Known::JSON_Schema_Draft_0}));
+    ONLY_CONTINUE_IF(IS_KNOWN_TYPE_FORM(schema.at("type"), vocabularies));
     const auto parent_types{parse_schema_type(schema.at("type"))};
     ONLY_CONTINUE_IF(parent_types.any());
 
@@ -51,7 +52,7 @@ public:
             continue;
           }
           const auto *branch_type{branch.try_at("type")};
-          if (!branch_type) {
+          if (!branch_type || !IS_KNOWN_TYPE_FORM(*branch_type, vocabularies)) {
             continue;
           }
 
@@ -68,7 +69,7 @@ public:
           continue;
         }
         const auto *branch_type{entry.second.try_at("type")};
-        if (!branch_type) {
+        if (!branch_type || !IS_KNOWN_TYPE_FORM(*branch_type, vocabularies)) {
           continue;
         }
 

--- a/src/alterschema/linter/unnecessary_extends_wrapper.h
+++ b/src/alterschema/linter/unnecessary_extends_wrapper.h
@@ -35,7 +35,8 @@ public:
 
     const auto *parent_type_value{schema.try_at("type")};
     const JSON::TypeSet parent_types{
-        parent_type_value && is_known_type_form(*parent_type_value)
+        parent_type_value &&
+                IS_KNOWN_TYPE_FORM(*parent_type_value, vocabularies)
             ? parse_schema_type(*parent_type_value)
             : JSON::TypeSet{}};
 
@@ -131,18 +132,5 @@ public:
         extends_prefix.concat(Pointer{relative.at(0), keyword})};
     const Pointer new_prefix{current.concat(keyword)};
     return target.rebase(old_prefix, new_prefix);
-  }
-
-private:
-  static auto is_known_type_form(const sourcemeta::core::JSON &type) -> bool {
-    if (type.is_string()) {
-      return type.to_string() != "any";
-    }
-    if (!type.is_array()) {
-      return false;
-    }
-    return std::ranges::all_of(type.as_array(), [](const auto &entry) -> auto {
-      return entry.is_string() && entry.to_string() != "any";
-    });
   }
 };

--- a/src/canonicalizer/helpers.h
+++ b/src/canonicalizer/helpers.h
@@ -18,6 +18,35 @@ inline auto IS_IN_PLACE_APPLICATOR(const SchemaKeywordType type) -> bool {
 // reference to the pointer of the ancestor where the match callback returned
 // true, or nullopt if no match was found or the traversal predicate stopped
 // the walk.
+// Whether a `type` value only consists of simple type names that can be
+// parsed into a complete set of instance types. Draft 0 to Draft 3 unions
+// may contain subschemas or `any`, in which case the parsed set is an
+// under-approximation that cannot be trusted. Later dialects do not give
+// such forms any meaning, so the parsed set stands
+inline auto IS_KNOWN_TYPE_FORM(const sourcemeta::core::JSON &type,
+                               const Vocabularies &vocabularies) -> bool {
+  if (!vocabularies.contains_any(
+          {Vocabularies::Known::JSON_Schema_Draft_0,
+           Vocabularies::Known::JSON_Schema_Draft_0_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_1,
+           Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_2,
+           Vocabularies::Known::JSON_Schema_Draft_2_Hyper,
+           Vocabularies::Known::JSON_Schema_Draft_3,
+           Vocabularies::Known::JSON_Schema_Draft_3_Hyper})) {
+    return true;
+  }
+  if (type.is_string()) {
+    return type.to_string() != "any";
+  }
+  if (!type.is_array()) {
+    return false;
+  }
+  return std::ranges::all_of(type.as_array(), [](const auto &entry) -> auto {
+    return entry.is_string() && entry.to_string() != "any";
+  });
+}
+
 template <typename TraversePredicate, typename MatchCallback>
 auto WALK_UP(const sourcemeta::core::JSON &root, const SchemaFrame &frame,
              const SchemaFrame::Location &location, const SchemaWalker &walker,

--- a/src/canonicalizer/rules/non_applicable_disallow_types.h
+++ b/src/canonicalizer/rules/non_applicable_disallow_types.h
@@ -23,7 +23,7 @@ public:
 
     const auto *parent_type_value{schema.try_at("type")};
     ONLY_CONTINUE_IF(parent_type_value &&
-                     is_known_type_form(*parent_type_value));
+                     IS_KNOWN_TYPE_FORM(*parent_type_value, vocabularies));
 
     const auto parent_types{parse_schema_type(*parent_type_value)};
     ONLY_CONTINUE_IF(parent_types.any());
@@ -36,7 +36,7 @@ public:
         entry_types = parse_schema_type(entry);
       } else if (entry.is_object()) {
         const auto *entry_type{entry.try_at("type")};
-        if (entry_type && is_known_type_form(*entry_type)) {
+        if (entry_type && IS_KNOWN_TYPE_FORM(*entry_type, vocabularies)) {
           entry_types = parse_schema_type(*entry_type);
         }
       }
@@ -77,19 +77,6 @@ public:
     } else {
       schema.assign("disallow", std::move(new_disallow));
     }
-  }
-
-private:
-  static auto is_known_type_form(const sourcemeta::core::JSON &type) -> bool {
-    if (type.is_string()) {
-      return type.to_string() != "any";
-    }
-    if (!type.is_array()) {
-      return false;
-    }
-    return std::ranges::all_of(type.as_array(), [](const auto &entry) -> auto {
-      return entry.is_string() && entry.to_string() != "any";
-    });
   }
 
 private:

--- a/src/canonicalizer/rules/non_applicable_type_specific_keywords.h
+++ b/src/canonicalizer/rules/non_applicable_type_specific_keywords.h
@@ -28,7 +28,8 @@ public:
                             Vocabularies::Known::JSON_Schema_Draft_1_Hyper,
                             Vocabularies::Known::JSON_Schema_Draft_0,
                             Vocabularies::Known::JSON_Schema_Draft_0_Hyper}) &&
-                               type_value
+                               type_value &&
+                               IS_KNOWN_TYPE_FORM(*type_value, vocabularies)
                            ? parse_schema_type(*type_value)
                            : sourcemeta::core::JSON::TypeSet{}};
 

--- a/src/canonicalizer/rules/unsatisfiable_in_place_applicator_type.h
+++ b/src/canonicalizer/rules/unsatisfiable_in_place_applicator_type.h
@@ -24,6 +24,7 @@ public:
          Vocabularies::Known::JSON_Schema_Draft_2,
          Vocabularies::Known::JSON_Schema_Draft_1,
          Vocabularies::Known::JSON_Schema_Draft_0}));
+    ONLY_CONTINUE_IF(IS_KNOWN_TYPE_FORM(schema.at("type"), vocabularies));
     const auto parent_types{parse_schema_type(schema.at("type"))};
     ONLY_CONTINUE_IF(parent_types.any());
 
@@ -46,7 +47,7 @@ public:
             continue;
           }
           const auto *branch_type{branch.try_at("type")};
-          if (!branch_type) {
+          if (!branch_type || !IS_KNOWN_TYPE_FORM(*branch_type, vocabularies)) {
             continue;
           }
 
@@ -63,7 +64,7 @@ public:
           continue;
         }
         const auto *branch_type{entry.second.try_at("type")};
-        if (!branch_type) {
+        if (!branch_type || !IS_KNOWN_TYPE_FORM(*branch_type, vocabularies)) {
           continue;
         }
 

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1341,6 +1341,31 @@ TEST(unsatisfiable_logic_branch_type_anyof_1) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(unsatisfiable_logic_branch_type_anyof_invalid_draft3_type_union) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": [ "string", { "type": "object" } ],
+    "anyOf": [
+      { "type": "number" },
+      { "minLength": 1 }
+    ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": [ "string", { "type": "object" } ],
+    "anyOf": [
+      { "minLength": 1 }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(unsatisfiable_logic_branch_type_anyof_2) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/alterschema/alterschema_lint_draft0_test.cc
+++ b/test/alterschema/alterschema_lint_draft0_test.cc
@@ -573,3 +573,21 @@ TEST(pattern_non_ecma_regex_valid_simple) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(traces.size(), 0);
 }
+
+TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft0_test.cc
+++ b/test/alterschema/alterschema_lint_draft0_test.cc
@@ -591,3 +591,27 @@ TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(non_applicable_type_specific_keywords_type_union_any) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_TRUE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -1167,3 +1167,27 @@ TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(non_applicable_type_specific_keywords_type_union_any) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -1149,3 +1149,21 @@ TEST(pattern_non_ecma_regex_valid_simple) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(traces.size(), 0);
 }
+
+TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -1149,3 +1149,21 @@ TEST(pattern_non_ecma_regex_valid_simple) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(traces.size(), 0);
 }
+
+TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -1167,3 +1167,27 @@ TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(non_applicable_type_specific_keywords_type_union_any) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -1288,6 +1288,90 @@ TEST(non_applicable_type_specific_keywords_1) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(non_applicable_type_specific_keywords_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(non_applicable_type_specific_keywords_type_union_any) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(unsatisfiable_in_place_applicator_type_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(unsatisfiable_in_place_applicator_type_nested_type_union_schema_variant) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": [ "string", { "maxItems": 2 } ] } ]
+  })JSON");
+
+  LINT_AND_FIX(document, result, traces);
+
+  EXPECT_FALSE(result.first);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": [ "string", { "maxItems": 2 } ] } ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(unknown_keywords_prefix_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",

--- a/test/canonicalizer/canonicalizer_draft0_test.cc
+++ b/test/canonicalizer/canonicalizer_draft0_test.cc
@@ -88,3 +88,20 @@ TEST(object_with_property_optional_implicit) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_union_schema_variant) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "items": {} },
+      { "type": "object", "properties": {}, "additionalProperties": {} }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft1_test.cc
+++ b/test/canonicalizer/canonicalizer_draft1_test.cc
@@ -396,3 +396,20 @@ TEST(additionalProperties_false) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_union_schema_variant) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "items": {} },
+      { "type": "object", "properties": {}, "additionalProperties": {} }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft2_test.cc
+++ b/test/canonicalizer/canonicalizer_draft2_test.cc
@@ -357,3 +357,20 @@ TEST(additionalProperties_false) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(type_union_schema_variant) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+      { "type": "object", "properties": {}, "additionalProperties": {} }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft3_test.cc
+++ b/test/canonicalizer/canonicalizer_draft3_test.cc
@@ -484,6 +484,156 @@ TEST(draft3_type_any_in_array_empty_object_collapses) {
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
 
+TEST(draft3_type_union_string_and_object_schema_variant) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+      { "type": "object", "properties": {}, "patternProperties": {}, "additionalProperties": {} }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
+TEST(draft3_type_union_schema_variant_distributes_properties) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+      {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "extends": [ { "type": "string", "minLength": 0 } ],
+            "required": false
+          }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
+TEST(draft3_type_union_with_any_keeps_properties) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "string", "any" ],
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [
+      { "enum": [ null ] },
+      { "enum": [ false, true ] },
+      {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "extends": [ { "type": "string", "minLength": 0 } ],
+            "required": false
+          }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      },
+      { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+      { "type": "string", "minLength": 0 },
+      { "type": "number" }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
+TEST(draft3_type_union_nested_schema_union_variant) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": [ "string", { "maxItems": 2 } ] } ]
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [
+      { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+      {
+        "type": [
+          { "type": "string", "minLength": 0 },
+          {
+            "type": [
+              { "enum": [ null ] },
+              { "enum": [ false, true ] },
+              { "type": "object", "properties": {}, "patternProperties": {}, "additionalProperties": {} },
+              { "type": "array", "maxItems": 2, "minItems": 0, "uniqueItems": false, "items": {} },
+              { "type": "string", "minLength": 0 },
+              { "type": "number" }
+            ]
+          }
+        ]
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
+TEST(draft3_type_union_schema_variant_with_extends) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "type": [ "array", { "type": "object" } ],
+    "extends": {
+      "type": "object",
+      "properties": {
+        "foo": { "type": "string" }
+      }
+    }
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "extends": [
+      {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "extends": [ { "type": "string", "minLength": 0 } ],
+            "required": false
+          }
+        },
+        "patternProperties": {},
+        "additionalProperties": {}
+      },
+      {
+        "type": [
+          { "type": "array", "minItems": 0, "uniqueItems": false, "items": {} },
+          { "type": "object", "properties": {}, "patternProperties": {}, "additionalProperties": {} }
+        ]
+      }
+    ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}
+
 TEST(draft3_type_any_as_string_collapses) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/blaze/issues/958
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

