### PR TITLE
Support a format registry in `x-jsonld-self`

### DIFF
--- a/schemas/sourcemeta-extension/v1/README.markdown
+++ b/schemas/sourcemeta-extension/v1/README.markdown
@@ -35,7 +35,7 @@ new vocabulary published under a new major version with a new URI.
 | [`x-jsonld-json`](#327-x-jsonld-json) | A boolean | Any subschema |
 | [`x-jsonld-graph`](#328-x-jsonld-graph) | A boolean | Object subschemas |
 | [`x-jsonld-container`](#329-x-jsonld-container) | `@list`, `@set`, `@language`, or `@index` | Array or object property subschemas |
-| [`x-jsonld-self`](#3210-x-jsonld-self) | A URI Template | Scalar or object subschemas |
+| [`x-jsonld-self`](#3210-x-jsonld-self) | A URI Template or scheme identity name | Scalar or object subschemas |
 | [`x-jsonld-override`](#3211-x-jsonld-override) | A boolean | Any subschema |
 | [`x-jsonld-value`](#3212-x-jsonld-value) | An absolute IRI | Scalar subschemas |
 | [`x-jsonld-constants`](#3213-x-jsonld-constants) | An expanded-form fragment | Object or promoted scalar subschemas |
@@ -171,7 +171,7 @@ vocabulary other than `x-jsonld-id` at the same location, and the members of a
 #### 3.2.10. `x-jsonld-self`
 
 The value of this keyword MUST be a string representing a URI Template
-[RFC6570].
+[RFC6570] or one of the scheme identity names defined in this section.
 
 This keyword mints the identifier of the node that the annotated instance
 location materializes as, giving an object its `@id` or promoting a scalar to
@@ -189,6 +189,31 @@ character, as [RFC6570] prescribes. The location value
 MUST NOT be an array, and the keyword MUST NOT be combined with
 `x-jsonld-datatype`, `x-jsonld-language`, or `x-jsonld-direction` at the same
 location.
+
+A scheme identity name mints the canonical IRI that identifies the location
+value itself in the named scheme, where the vocabulary owns the whole recipe,
+both the transformation of the raw value and the single blessed IRI spelling,
+so an identifier minted from instance data compares equal, as RDF requires,
+to the same identity spelled anywhere else. The location value MUST be a
+string within the source grammar of the named scheme. The defined names are:
+
+- `mailto`: the location value MUST be a `Mailbox` [RFC5321], and the minted
+  identity is its `mailto` IRI [RFC6068]. The characters that [RFC6068]
+  reserves are percent encoded and the domain name is lowercased, while the
+  local part and any address literal keep their spelling, as only the domain
+  is case-insensitive.
+- `acct`: the location value MUST be a `user@host` account [RFC7565] whose
+  user part, which may itself contain `@`, is limited to the printable ASCII
+  repertoire of the PRECIS IdentifierClass, and the minted identity is its
+  `acct` IRI [RFC7565]. The characters outside the user part production are
+  percent encoded and the host is lowercased, while the user part keeps its
+  case.
+
+A scheme identity name contains no colon and no expression, so read as a URI
+Template it could never have expanded to an absolute IRI. The names are
+therefore carved out of the guaranteed error space of the template form, and
+no template that mints an identifier changes meaning. A value that is not a
+defined name keeps its URI Template treatment.
 
 #### 3.2.11. `x-jsonld-override`
 
@@ -286,12 +311,18 @@ named `@graph`, constant properties land on the inner subject.
 - [RFC3987] Duerst, M. and M. Suignard, ["Internationalized Resource
   Identifiers (IRIs)"](https://www.rfc-editor.org/info/rfc3987), RFC 3987,
   January 2005
+- [RFC5321] Klensin, J., ["Simple Mail Transfer
+  Protocol"](https://www.rfc-editor.org/info/rfc5321), RFC 5321, October 2008
 - [RFC5646] Phillips, A. and M. Davis, ["Tags for Identifying
   Languages"](https://www.rfc-editor.org/info/rfc5646), BCP 47, RFC 5646,
   September 2009
+- [RFC6068] Duerst, M., Masinter, L., and J. Zawinski, ["The 'mailto' URI
+  Scheme"](https://www.rfc-editor.org/info/rfc6068), RFC 6068, October 2010
 - [RFC6570] Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., and D.
   Orchard, ["URI Template"](https://www.rfc-editor.org/info/rfc6570), RFC
   6570, March 2012
+- [RFC7565] Saint-Andre, P., ["The 'acct' URI
+  Scheme"](https://www.rfc-editor.org/info/rfc7565), RFC 7565, May 2016
 - [JSONLD11] Sporny, M., Longley, D., Kellogg, G., Lanthaler, M., Champin,
   P., and N. Lindström, ["JSON-LD 1.1"](https://www.w3.org/TR/json-ld11/),
   W3C Recommendation, July 2020

--- a/schemas/sourcemeta-extension/v1/README.markdown
+++ b/schemas/sourcemeta-extension/v1/README.markdown
@@ -205,9 +205,9 @@ string within the source grammar of the named scheme. The defined names are:
 - `acct`: the location value MUST be a `user@host` account [RFC7565] whose
   user part, which may itself contain `@`, is limited to the printable ASCII
   repertoire of the PRECIS IdentifierClass, and the minted identity is its
-  `acct` IRI [RFC7565]. The characters outside the user part production are
-  percent encoded and the host is lowercased, while the user part keeps its
-  case.
+  `acct` IRI [RFC7565]. The characters in the user part that [RFC7565] does
+  not let pass through are percent encoded and the host is lowercased, while
+  the user part keeps its case.
 
 A scheme identity name contains no colon and no expression, so read as a URI
 Template it could never have expanded to an absolute IRI. The names are

--- a/schemas/sourcemeta-extension/v1/dialect.test.json
+++ b/schemas/sourcemeta-extension/v1/dialect.test.json
@@ -253,6 +253,32 @@
       }
     },
     {
+      "description": "x-jsonld-self nested in properties with the mailto scheme identity name is valid",
+      "valid": true,
+      "data": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "x-jsonld-self": "mailto"
+          }
+        }
+      }
+    },
+    {
+      "description": "x-jsonld-self nested in properties with the acct scheme identity name is valid",
+      "valid": true,
+      "data": {
+        "type": "object",
+        "properties": {
+          "account": {
+            "type": "string",
+            "x-jsonld-self": "acct"
+          }
+        }
+      }
+    },
+    {
       "description": "x-jsonld-graph deeply nested through properties and items is valid",
       "valid": true,
       "data": {

--- a/schemas/sourcemeta-extension/v1/vocabulary.test.json
+++ b/schemas/sourcemeta-extension/v1/vocabulary.test.json
@@ -813,6 +813,20 @@
       }
     },
     {
+      "description": "x-jsonld-self with the mailto scheme identity name is valid",
+      "valid": true,
+      "data": {
+        "x-jsonld-self": "mailto"
+      }
+    },
+    {
+      "description": "x-jsonld-self with the acct scheme identity name is valid",
+      "valid": true,
+      "data": {
+        "x-jsonld-self": "acct"
+      }
+    },
+    {
       "description": "x-jsonld-self with unclosed expression is rejected",
       "valid": false,
       "data": {

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -16,6 +16,8 @@ target_link_libraries(sourcemeta_blaze_output PUBLIC
 target_link_libraries(sourcemeta_blaze_output PUBLIC
   sourcemeta::core::jsonpointer)
 target_link_libraries(sourcemeta_blaze_output PRIVATE
+  sourcemeta::core::email)
+target_link_libraries(sourcemeta_blaze_output PRIVATE
   sourcemeta::core::jsonld)
 target_link_libraries(sourcemeta_blaze_output PRIVATE
   sourcemeta::core::langtag)

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -452,26 +452,6 @@ auto literal_error(const sourcemeta::core::WeakPointer &pointer,
   return std::nullopt;
 }
 
-// The scheme identity registry of x-jsonld-self. A registered name mints the
-// canonical IRI of the annotated string value in the named scheme through the
-// transformation that owns it, and any other value keeps its URI Template
-// treatment, which a bare name always fails, as it cannot expand to an
-// absolute IRI
-using SchemeIdentityFunction =
-    std::optional<std::string> (*)(const std::string_view);
-auto scheme_identity_function(const sourcemeta::core::JSON::String &pattern)
-    -> SchemeIdentityFunction {
-  if (pattern == "mailto") {
-    return sourcemeta::core::mailto_iri;
-  }
-
-  if (pattern == "acct") {
-    return sourcemeta::core::acct_iri;
-  }
-
-  return nullptr;
-}
-
 // Expand an x-jsonld-self URI Template into a concrete identifier. An object
 // binds each variable to the member of that name, and a scalar binds the
 // reserved variable this to its own value. Only a non-empty string can bind,
@@ -488,8 +468,7 @@ auto expand_self(const sourcemeta::core::WeakPointer &pointer,
                  const sourcemeta::core::JSON &value, const std::string &origin)
     -> std::variant<sourcemeta::core::JSON::String,
                     sourcemeta::blaze::JSONLDResolutionError> {
-  const auto scheme_function{scheme_identity_function(pattern)};
-  if (scheme_function != nullptr) {
+  if (pattern == "mailto" || pattern == "acct") {
     if (!value.is_string()) {
       return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Self,
                          "A JSON-LD self identity scheme can only be assigned "
@@ -497,7 +476,9 @@ auto expand_self(const sourcemeta::core::WeakPointer &pointer,
                          origin);
     }
 
-    auto identity{scheme_function(value.to_string())};
+    auto identity{pattern == "mailto"
+                      ? sourcemeta::core::mailto_iri(value.to_string())
+                      : sourcemeta::core::acct_iri(value.to_string())};
     if (!identity.has_value()) {
       return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Self,
                          "A JSON-LD self identity value is outside the domain "

--- a/src/output/output_jsonld.cc
+++ b/src/output/output_jsonld.cc
@@ -1,5 +1,6 @@
 #include <sourcemeta/blaze/output_jsonld.h>
 
+#include <sourcemeta/core/email.h>
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/langtag.h>
@@ -451,6 +452,26 @@ auto literal_error(const sourcemeta::core::WeakPointer &pointer,
   return std::nullopt;
 }
 
+// The scheme identity registry of x-jsonld-self. A registered name mints the
+// canonical IRI of the annotated string value in the named scheme through the
+// transformation that owns it, and any other value keeps its URI Template
+// treatment, which a bare name always fails, as it cannot expand to an
+// absolute IRI
+using SchemeIdentityFunction =
+    std::optional<std::string> (*)(const std::string_view);
+auto scheme_identity_function(const sourcemeta::core::JSON::String &pattern)
+    -> SchemeIdentityFunction {
+  if (pattern == "mailto") {
+    return sourcemeta::core::mailto_iri;
+  }
+
+  if (pattern == "acct") {
+    return sourcemeta::core::acct_iri;
+  }
+
+  return nullptr;
+}
+
 // Expand an x-jsonld-self URI Template into a concrete identifier. An object
 // binds each variable to the member of that name, and a scalar binds the
 // reserved variable this to its own value. Only a non-empty string can bind,
@@ -458,12 +479,35 @@ auto literal_error(const sourcemeta::core::WeakPointer &pointer,
 // is a fail-loud resolution error. Expansion runs in IRI mode so that
 // internationalized characters flowing through a template mint the same raw
 // term that constant identities emit, as RDF compares IRIs by simple string
-// comparison (RDF 1.1 Concepts Section 3.2)
+// comparison (RDF 1.1 Concepts Section 3.2). A scheme identity name bypasses
+// expansion entirely, minting the canonical IRI of the string value in the
+// named scheme, where an input outside the scheme's source grammar is a
+// fail-loud resolution error
 auto expand_self(const sourcemeta::core::WeakPointer &pointer,
                  const sourcemeta::core::JSON::String &pattern,
                  const sourcemeta::core::JSON &value, const std::string &origin)
     -> std::variant<sourcemeta::core::JSON::String,
                     sourcemeta::blaze::JSONLDResolutionError> {
+  const auto scheme_function{scheme_identity_function(pattern)};
+  if (scheme_function != nullptr) {
+    if (!value.is_string()) {
+      return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Self,
+                         "A JSON-LD self identity scheme can only be assigned "
+                         "to a string value",
+                         origin);
+    }
+
+    auto identity{scheme_function(value.to_string())};
+    if (!identity.has_value()) {
+      return facet_error(pointer, sourcemeta::blaze::JSONLDFacet::Self,
+                         "A JSON-LD self identity value is outside the domain "
+                         "of its scheme",
+                         origin);
+    }
+
+    return sourcemeta::core::JSON::String{std::move(identity.value())};
+  }
+
   std::optional<sourcemeta::blaze::JSONLDResolutionError> failure;
   const sourcemeta::core::URITemplate uri_template{pattern};
   auto expanded{uri_template.expand(

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -8117,6 +8117,779 @@ TEST(JSONLD_self_edge_on_root_is_a_resolution_error) {
       "#/x-jsonld-id");
 }
 
+TEST(JSONLD_self_mailto_scalar_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_scalar_reference_with_type) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-type": "https://schema.org/ContactPoint",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        {
+          "@id": "mailto:user@example.com",
+          "@type": [ "https://schema.org/ContactPoint" ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_encodes_reserved_characters) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "gorby%kremvax@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:gorby%25kremvax@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_encodes_fragment_delimiter) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "a#b@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:a%23b@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_lowercases_domain) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "User@EXAMPLE.COM" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:User@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_quoted_local_part) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "\"a b\"@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:%22a%20b%22@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_address_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@[192.168.1.1]" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user@%5B192.168.1.1%5D" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_root_scalar_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "x-jsonld-type": "https://schema.org/ContactPoint",
+    "x-jsonld-self": "mailto"
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON("user@example.com")JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@id": "mailto:user@example.com",
+      "@type": [ "https://schema.org/ContactPoint" ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_reverse_edge_to_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-reverse": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "@reverse": {
+        "https://schema.org/email": [
+          { "@id": "mailto:user@example.com" }
+        ]
+      }
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_fuses_with_value_predicate) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto",
+        "x-jsonld-value": "https://example.com/carries"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        {
+          "@id": "mailto:user@example.com",
+          "https://example.com/carries": [ { "@value": "user@example.com" } ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_with_constants) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto",
+        "x-jsonld-constants": {
+          "https://example.com/status": "verified"
+        }
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        {
+          "@id": "mailto:user@example.com",
+          "https://example.com/status": [ { "@value": "verified" } ]
+        }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_idempotent_via_allof) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "allOf": [
+          { "x-jsonld-self": "mailto" },
+          { "x-jsonld-self": "mailto" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_on_null_is_dropped) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "email": null })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_invalid_address_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "email": "plain" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_empty_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "email": "" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_internationalized_address_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "usér@example.com" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_non_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "email": 42 })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity scheme can only be assigned to a string value",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_on_object_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "object",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": { "address": "user@example.com" } })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity scheme can only be assigned to a string value",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_conflict_with_template_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "allOf": [
+          { "x-jsonld-self": "mailto" },
+          { "x-jsonld-self": "https://example.com/{this}" }
+        ]
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR_WITH_CONFLICT(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity cannot be assigned more than one value",
+      "#/properties/email/allOf/0/x-jsonld-self",
+      "#/properties/email/allOf/1/x-jsonld-self");
+}
+
+TEST(JSONLD_self_acct_scalar_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "alice@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/identifier": [
+        { "@id": "acct:alice@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_acct_encodes_at_sign_in_user_part) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "juliet@capulet.example@shoppingsite.example" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/identifier": [
+        { "@id": "acct:juliet%40capulet.example@shoppingsite.example" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_acct_lowercases_host) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "Alice@Example.COM" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/identifier": [
+        { "@id": "acct:Alice@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_acct_missing_host_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "account": "alice" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/account/x-jsonld-self");
+}
+
+TEST(JSONLD_self_acct_invalid_host_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "alice@-example-" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/account/x-jsonld-self");
+}
+
+TEST(JSONLD_self_acct_internationalized_user_part_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "alíce@example.com" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/account/x-jsonld-self");
+}
+
+TEST(JSONLD_self_acct_non_string_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "account": true })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity scheme can only be assigned to a string value",
+      "#/properties/account/x-jsonld-self");
+}
+
+TEST(JSONLD_self_unknown_scheme_name_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "document": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "doi"
+      }
+    }
+  })JSON")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "document": "10.1000/182" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/document", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity must expand to an absolute IRI",
+      "#/properties/document/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_prefixed_template_keeps_template_treatment) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto:{this}"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user%40example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_override_specializes_referenced_template) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto",
+        "x-jsonld-override": true,
+        "$ref": "#/$defs/library"
+      }
+    },
+    "$defs": {
+      "library": {
+        "type": "string",
+        "x-jsonld-self": "https://example.com/theirs/{this}"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user@example.com" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
+TEST(JSONLD_self_mailto_override_tombstone_restores_plain_literal) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": null,
+        "x-jsonld-override": true,
+        "$ref": "#/$defs/library"
+      }
+    },
+    "$defs": {
+      "library": {
+        "type": "string",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@example.com" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    { "https://schema.org/email": [ { "@value": "user@example.com" } ] }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
 TEST(JSONLD_override_specializes_referenced_datatype) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/output/output_jsonld_test.cc
+++ b/test/output/output_jsonld_test.cc
@@ -8256,6 +8256,33 @@ TEST(JSONLD_self_mailto_lowercases_domain) {
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
+TEST(JSONLD_self_mailto_punycode_domain_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@xn--bcher-kva.example" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/email": [
+        { "@id": "mailto:user@xn--bcher-kva.example" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
 TEST(JSONLD_self_mailto_quoted_local_part) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -8540,6 +8567,50 @@ TEST(JSONLD_self_mailto_internationalized_address_is_a_resolution_error) {
       "#/properties/email/x-jsonld-self");
 }
 
+TEST(JSONLD_self_mailto_internationalized_domain_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "user@bücher.example" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/email/x-jsonld-self");
+}
+
+TEST(JSONLD_self_mailto_fully_internationalized_address_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/email",
+        "x-jsonld-self": "mailto"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "email": "실례@실례.테스트" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/email", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/email/x-jsonld-self");
+}
+
 TEST(JSONLD_self_mailto_non_string_is_a_resolution_error) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -8663,6 +8734,33 @@ TEST(JSONLD_self_acct_encodes_at_sign_in_user_part) {
   EXPECT_JSON_LD_VALUE(schema, instance, expected);
 }
 
+TEST(JSONLD_self_acct_punycode_host_reference) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "alice@xn--bcher-kva.example" })JSON")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON([
+    {
+      "https://schema.org/identifier": [
+        { "@id": "acct:alice@xn--bcher-kva.example" }
+      ]
+    }
+  ])JSON")};
+
+  EXPECT_JSON_LD_VALUE(schema, instance, expected);
+}
+
 TEST(JSONLD_self_acct_lowercases_host) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -8749,6 +8847,28 @@ TEST(JSONLD_self_acct_internationalized_user_part_is_a_resolution_error) {
 
   const auto instance{sourcemeta::core::parse_json(
       R"JSON({ "account": "alíce@example.com" })JSON")};
+
+  EXPECT_JSON_LD_RESOLUTION_ERROR(
+      schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,
+      "A JSON-LD self identity value is outside the domain of its scheme",
+      "#/properties/account/x-jsonld-self");
+}
+
+TEST(JSONLD_self_acct_internationalized_host_is_a_resolution_error) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "account": {
+        "type": "string",
+        "x-jsonld-id": "https://schema.org/identifier",
+        "x-jsonld-self": "acct"
+      }
+    }
+  })JSON")};
+
+  const auto instance{sourcemeta::core::parse_json(
+      R"JSON({ "account": "alice@bücher.example" })JSON")};
 
   EXPECT_JSON_LD_RESOLUTION_ERROR(
       schema, instance, "/account", sourcemeta::blaze::JSONLDFacet::Self,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

