### PR TITLE
Don't crash on bundled remotes that rely on the default dialect

### DIFF
--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -369,6 +369,15 @@ auto bundle_schema(sourcemeta::core::JSON &root,
                           : sourcemeta::core::JSON::String{remote_id}};
 
     if (remote.value().is_object()) {
+      // Otherwise the embedded resource would be re-interpreted under the
+      // dialect of the schema it gets embedded into, which can differ from
+      // the default dialect that the remote was resolved with
+      if (!remote.value().defines("$schema")) {
+        remote.value().assign("$schema",
+                              sourcemeta::core::JSON{sourcemeta::blaze::dialect(
+                                  remote.value(), default_dialect)});
+      }
+
       sourcemeta::blaze::reidentify(remote.value(), effective_id,
                                     remote_base_dialect.value());
     }

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -421,7 +421,12 @@ auto compile(const sourcemeta::core::JSON &schema,
         destination;
     const auto &[index, reference_pointer] = target_info;
     const auto location{context.frame.traverse(destination_uri)};
-    assert(location.has_value());
+    if (!location.has_value()) [[unlikely]] {
+      assert(reference_pointer != nullptr);
+      throw CompilerReferenceTargetNotSchemaError(
+          destination_uri, to_pointer(*reference_pointer));
+    }
+
     const auto &entry{location->get()};
 
     if (entry.type != sourcemeta::blaze::SchemaFrame::LocationType::Subschema &&

--- a/test/bundle/bundle_2019_09_test.cc
+++ b/test/bundle/bundle_2019_09_test.cc
@@ -454,6 +454,7 @@ TEST(anonymous_no_dialect) {
     "$ref": "https://www.sourcemeta.com/anonymous",
     "$defs": {
       "https://www.sourcemeta.com/anonymous": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
       }

--- a/test/bundle/bundle_2020_12_test.cc
+++ b/test/bundle/bundle_2020_12_test.cc
@@ -660,6 +660,7 @@ TEST(anonymous_no_dialect) {
     "$ref": "https://www.sourcemeta.com/anonymous",
     "$defs": {
       "https://www.sourcemeta.com/anonymous": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
       }

--- a/test/bundle/bundle_draft4_test.cc
+++ b/test/bundle/bundle_draft4_test.cc
@@ -479,6 +479,7 @@ TEST(anonymous_no_dialect) {
     "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
       }

--- a/test/bundle/bundle_draft6_test.cc
+++ b/test/bundle/bundle_draft6_test.cc
@@ -437,6 +437,7 @@ TEST(anonymous_no_dialect) {
     "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
       }

--- a/test/bundle/bundle_draft7_test.cc
+++ b/test/bundle/bundle_draft7_test.cc
@@ -476,6 +476,7 @@ TEST(anonymous_no_dialect) {
     "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
       }

--- a/test/bundle/bundle_test.cc
+++ b/test/bundle/bundle_test.cc
@@ -40,6 +40,10 @@ static auto test_resolver(std::string_view identifier)
       "id": "https://www.sourcemeta.com/test-4",
       "type": "string"
     })JSON");
+  } else if (identifier == "https://www.sourcemeta.com/anonymous") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "type": "integer"
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/no-dialect") {
     return sourcemeta::core::parse_json(R"JSON({
       "foo": 1
@@ -319,6 +323,58 @@ TEST(without_default_dialect) {
     EXPECT_STREQ(error.what(),
                  "Could not determine the base dialect of the schema");
   }
+}
+
+TEST(anonymous_target_with_draft4_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous"
+  })JSON");
+
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas,
+      "http://json-schema.org/draft-04/schema#");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous",
+    "$defs": {
+      "https://www.sourcemeta.com/anonymous": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/anonymous",
+        "type": "integer"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(anonymous_target_with_draft7_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous"
+  })JSON");
+
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas,
+      "http://json-schema.org/draft-07/schema#");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous",
+    "$defs": {
+      "https://www.sourcemeta.com/anonymous": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://www.sourcemeta.com/anonymous",
+        "type": "integer"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
 }
 
 TEST(target_no_dialect) {

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -39,6 +39,18 @@ static auto test_resolver(std::string_view identifier)
       "$id": "https://example.com/schema",
       "type": "string"
     })JSON");
+  } else if (identifier == "https://example.com/anonymous-draft4") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "minimum": 2,
+      "exclusiveMinimum": true
+    })JSON");
+  } else if (identifier == "https://example.com/anonymous-draft7") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "definitions": {
+        "helper": { "type": "string" }
+      },
+      "allOf": [ { "$ref": "#/definitions/helper", "type": "integer" } ]
+    })JSON");
   } else {
     return sourcemeta::blaze::schema_resolver(identifier);
   }
@@ -180,6 +192,74 @@ TEST(cross_2012_12_ref_2019_09_without_id) {
   EXPECT_TRUE(evaluator.validate(compiled_schema, instance));
 }
 
+TEST(cross_2020_12_ref_anonymous_with_draft4_default_dialect_valid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-draft4"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation,
+      "http://json-schema.org/draft-04/schema#")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{3};
+  EXPECT_TRUE(evaluator.validate(compiled_schema, instance));
+}
+
+TEST(cross_2020_12_ref_anonymous_with_draft4_default_dialect_invalid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-draft4"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation,
+      "http://json-schema.org/draft-04/schema#")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{2};
+  EXPECT_FALSE(evaluator.validate(compiled_schema, instance));
+}
+
+TEST(cross_2020_12_ref_anonymous_with_draft7_default_dialect_valid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-draft7"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation,
+      "http://json-schema.org/draft-07/schema#")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{"foo"};
+  EXPECT_TRUE(evaluator.validate(compiled_schema, instance));
+}
+
+TEST(cross_2020_12_ref_anonymous_with_draft7_default_dialect_invalid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-draft7"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation,
+      "http://json-schema.org/draft-07/schema#")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{5};
+  EXPECT_FALSE(evaluator.validate(compiled_schema, instance));
+}
+
 TEST(explicit_frame) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -228,6 +308,39 @@ TEST(explicit_frame_locations_only) {
     FAIL();
   } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
     EXPECT_STREQ(error.what(), "Could not resolve schema reference");
+  }
+}
+
+TEST(explicit_frame_unaddressable_static_reference_target) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/unaddressable",
+    "$defs": {
+      "https://example.com/unaddressable": {
+        "id": "https://example.com/unaddressable",
+        "type": "string"
+      }
+    }
+  })JSON")};
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_schema_compiler,
+                               frame, frame.root());
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CompilerReferenceTargetNotSchemaError &error) {
+    EXPECT_STREQ(error.what(),
+                 "The referenced schema is not considered to be a valid "
+                 "subschema given the dialect and vocabularies in use");
+    EXPECT_EQ(error.identifier(), "https://example.com/unaddressable");
+    EXPECT_EQ(error.location(), sourcemeta::core::Pointer({"$ref"}));
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

