### PR TITLE
Add `$schema` on elevated embedded resources that lack one

### DIFF
--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -11,7 +11,7 @@
 #include <tuple>         // std::tuple
 #include <unordered_map> // std::unordered_map
 #include <unordered_set> // std::unordered_set
-#include <utility>       // std::move
+#include <utility>       // std::move, std::pair
 #include <vector>        // std::vector
 
 namespace {
@@ -166,6 +166,8 @@ auto elevate_embedded_resources(
   }
 
   auto &defs{remote.at(keyword_string)};
+  const auto remote_dialect_uri{
+      sourcemeta::blaze::dialect(remote, default_dialect)};
 
   // Navigate to the root container once, as it doesn't change per entry
   const sourcemeta::core::JSON *root_container{&root};
@@ -180,7 +182,7 @@ auto elevate_embedded_resources(
     root_container = &root_container->at(token.to_property());
   }
 
-  std::vector<sourcemeta::core::JSON::String> to_extract;
+  std::vector<std::pair<sourcemeta::core::JSON::String, bool>> to_extract;
   std::vector<sourcemeta::core::JSON::String> to_remove;
   for (const auto &entry : defs.as_object()) {
     const auto &key{entry.first};
@@ -196,6 +198,7 @@ auto elevate_embedded_resources(
     }
 
     const sourcemeta::core::JSON::String identifier_string{identifier};
+    const auto defines_dialect{value.defines("$schema")};
     if (bundled.contains(identifier_string)) {
       if (container_exists && root_container->is_object()) {
         for (const auto &root_entry : root_container->as_object()) {
@@ -214,9 +217,23 @@ auto elevate_embedded_resources(
             continue;
           }
 
-          if (root_entry.second != value) {
-            throw sourcemeta::blaze::SchemaError(
-                "Conflicting embedded resources with the same identifier");
+          if (defines_dialect) {
+            if (root_entry.second != value) {
+              throw sourcemeta::blaze::SchemaError(
+                  "Conflicting embedded resources with the same identifier");
+            }
+          } else {
+            // The stored copy of the resource got its dialect stamped on
+            // extraction, so compare against a candidate that is stamped in
+            // the same way
+            auto candidate{value};
+            candidate.assign("$schema",
+                             sourcemeta::core::JSON{sourcemeta::blaze::dialect(
+                                 value, remote_dialect_uri)});
+            if (root_entry.second != candidate) {
+              throw sourcemeta::blaze::SchemaError(
+                  "Conflicting embedded resources with the same identifier");
+            }
           }
 
           break;
@@ -225,14 +242,22 @@ auto elevate_embedded_resources(
 
       to_remove.emplace_back(key);
     } else {
-      to_extract.emplace_back(key);
+      to_extract.emplace_back(key, !defines_dialect);
       bundled.emplace(identifier_string, identifier_string);
     }
   }
 
-  for (const auto &key : to_extract) {
+  for (const auto &[key, needs_dialect] : to_extract) {
     auto value{std::move(defs.at(key))};
     defs.erase(key);
+    // Otherwise the elevated resource would be re-interpreted under the
+    // dialect of the schema it gets embedded into, which can differ from
+    // the dialect it inherited from the remote it was elevated out of
+    if (needs_dialect) {
+      value.assign("$schema", sourcemeta::core::JSON{sourcemeta::blaze::dialect(
+                                  value, remote_dialect_uri)});
+    }
+
     embed_schema(root, container, key, std::move(value));
   }
 

--- a/test/bundle/bundle_2020_12_test.cc
+++ b/test/bundle/bundle_2020_12_test.cc
@@ -1330,6 +1330,7 @@ TEST(default_id_with_different_ref_target_id) {
     "$ref": "https://example.com/schemas/parent",
     "$defs": {
       "https://example.com/schemas/child": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": "https://example.com/schemas/child",
         "type": "string"
       },

--- a/test/bundle/bundle_test.cc
+++ b/test/bundle/bundle_test.cc
@@ -44,6 +44,31 @@ static auto test_resolver(std::string_view identifier)
     return sourcemeta::core::parse_json(R"JSON({
       "type": "integer"
     })JSON");
+  } else if (identifier == "https://www.sourcemeta.com/anonymous-embedded") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://www.sourcemeta.com/anonymous-embedded",
+      "allOf": [ { "$ref": "shared" } ],
+      "definitions": {
+        "https://www.sourcemeta.com/shared": {
+          "id": "https://www.sourcemeta.com/shared",
+          "type": "string"
+        }
+      }
+    })JSON");
+  } else if (identifier ==
+             "https://www.sourcemeta.com/anonymous-embedded-sibling") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://www.sourcemeta.com/anonymous-embedded-sibling",
+      "allOf": [ { "$ref": "shared" } ],
+      "definitions": {
+        "https://www.sourcemeta.com/shared": {
+          "id": "https://www.sourcemeta.com/shared",
+          "type": "string"
+        }
+      }
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/no-dialect") {
     return sourcemeta::core::parse_json(R"JSON({
       "foo": 1
@@ -370,6 +395,81 @@ TEST(anonymous_target_with_draft7_default_dialect) {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(elevate_anonymous_embedded_resource_across_dialects) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous-embedded"
+  })JSON");
+
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://www.sourcemeta.com/anonymous-embedded",
+    "$defs": {
+      "https://www.sourcemeta.com/shared": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/shared",
+        "type": "string"
+      },
+      "https://www.sourcemeta.com/anonymous-embedded": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/anonymous-embedded",
+        "allOf": [ { "$ref": "shared" } ]
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(elevate_anonymous_embedded_resource_deduplication) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "https://www.sourcemeta.com/anonymous-embedded" },
+      "bar": {
+        "$ref": "https://www.sourcemeta.com/anonymous-embedded-sibling"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "https://www.sourcemeta.com/anonymous-embedded" },
+      "bar": {
+        "$ref": "https://www.sourcemeta.com/anonymous-embedded-sibling"
+      }
+    },
+    "$defs": {
+      "https://www.sourcemeta.com/shared": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/shared",
+        "type": "string"
+      },
+      "https://www.sourcemeta.com/anonymous-embedded": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/anonymous-embedded",
+        "allOf": [ { "$ref": "shared" } ]
+      },
+      "https://www.sourcemeta.com/anonymous-embedded-sibling": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/anonymous-embedded-sibling",
+        "allOf": [ { "$ref": "shared" } ]
       }
     }
   })JSON");

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -51,6 +51,18 @@ static auto test_resolver(std::string_view identifier)
       },
       "allOf": [ { "$ref": "#/definitions/helper", "type": "integer" } ]
     })JSON");
+  } else if (identifier == "https://example.com/anonymous-embedded") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://example.com/anonymous-embedded",
+      "allOf": [ { "$ref": "shared" } ],
+      "definitions": {
+        "https://example.com/shared": {
+          "id": "https://example.com/shared",
+          "type": "string"
+        }
+      }
+    })JSON");
   } else {
     return sourcemeta::blaze::schema_resolver(identifier);
   }
@@ -254,6 +266,36 @@ TEST(cross_2020_12_ref_anonymous_with_draft7_default_dialect_invalid) {
       sourcemeta::blaze::default_schema_compiler,
       sourcemeta::blaze::Mode::FastValidation,
       "http://json-schema.org/draft-07/schema#")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{5};
+  EXPECT_FALSE(evaluator.validate(compiled_schema, instance));
+}
+
+TEST(cross_2020_12_ref_draft4_anonymous_embedded_valid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-embedded"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const sourcemeta::core::JSON instance{"foo"};
+  EXPECT_TRUE(evaluator.validate(compiled_schema, instance));
+}
+
+TEST(cross_2020_12_ref_draft4_anonymous_embedded_invalid) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/anonymous-embedded"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::default_schema_compiler)};
 
   sourcemeta::blaze::Evaluator evaluator;
   const sourcemeta::core::JSON instance{5};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

