### PR TITLE
Speed up test parsing by lazily compiling one exhaustive for errors

### DIFF
--- a/src/test/include/sourcemeta/blaze/test.h
+++ b/src/test/include/sourcemeta/blaze/test.h
@@ -132,10 +132,11 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
       TestTimestamp start, TestTimestamp end)>;
 
   /// The compiled schema template for fast validation of the given target
-  auto fast(std::size_t target_index) -> const Template &;
+  [[nodiscard]] auto fast(std::size_t target_index) const -> const Template &;
 
   /// The compiled schema template for exhaustive validation of the given
-  /// target, compiled on the first request and cached from then on
+  /// target, compiled on the first request and cached from then on. A test
+  /// suite must not be shared across threads
   auto exhaustive(std::size_t target_index) -> const Template &;
 
   /// Run all test cases in the suite, invoking the callback for each.

--- a/src/test/include/sourcemeta/blaze/test.h
+++ b/src/test/include/sourcemeta/blaze/test.h
@@ -118,10 +118,6 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
   std::vector<sourcemeta::core::JSON::String> targets;
   /// The list of test cases in the suite
   std::vector<TestCase> tests;
-  /// The compiled schema templates for fast validation
-  std::vector<Template> schemas_fast;
-  /// The compiled schema templates for exhaustive validation
-  std::vector<Template> schemas_exhaustive;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif
@@ -134,6 +130,13 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
       const sourcemeta::core::JSON::String &target, std::size_t index,
       std::size_t total, const TestCase &test_case, const TestOutcome &outcome,
       TestTimestamp start, TestTimestamp end)>;
+
+  /// The compiled schema template for fast validation of the given target
+  auto fast(std::size_t target_index) -> const Template &;
+
+  /// The compiled schema template for exhaustive validation of the given
+  /// target, compiled on the first request and cached from then on
+  auto exhaustive(std::size_t target_index) -> const Template &;
 
   /// Run all test cases in the suite, invoking the callback for each.
   /// For example:
@@ -231,6 +234,26 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
         const sourcemeta::blaze::SchemaWalker &walker, const Compiler &compiler,
         std::string_view default_dialect = "", std::string_view default_id = "",
         const std::optional<Tweaks> &tweaks = std::nullopt) -> TestSuite;
+
+private:
+  [[nodiscard]] auto compile_target(std::size_t target_index, Mode mode) const
+      -> Template;
+
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+  std::vector<Template> schemas_fast;
+  std::vector<std::optional<Template>> schemas_exhaustive;
+  SchemaResolver schema_resolver;
+  SchemaWalker walker;
+  Compiler compiler;
+  sourcemeta::core::JSON::String default_dialect;
+  sourcemeta::core::JSON::String default_id;
+  std::optional<Tweaks> tweaks_fast;
+  std::optional<Tweaks> tweaks_exhaustive;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
 };
 
 } // namespace sourcemeta::blaze

--- a/src/test/test_parser.cc
+++ b/src/test/test_parser.cc
@@ -208,45 +208,73 @@ auto TestSuite::parse(const sourcemeta::core::JSON &document,
         return test_case.rdf.has_value();
       })};
 
-  auto tweaks_fast{tweaks};
+  test_suite.tweaks_fast = tweaks;
+  test_suite.tweaks_exhaustive = tweaks;
   if (with_rdf) {
-    if (!tweaks_fast.has_value()) {
-      tweaks_fast.emplace();
+    if (!test_suite.tweaks_fast.has_value()) {
+      test_suite.tweaks_fast.emplace();
     }
 
-    if (!tweaks_fast.value().annotations.has_value()) {
-      tweaks_fast.value().annotations.emplace();
+    if (!test_suite.tweaks_fast.value().annotations.has_value()) {
+      test_suite.tweaks_fast.value().annotations.emplace();
     }
 
-    tweaks_fast.value().annotations.value().insert(JSONLD_KEYWORDS.cbegin(),
-                                                   JSONLD_KEYWORDS.cend());
+    test_suite.tweaks_fast.value().annotations.value().insert(
+        JSONLD_KEYWORDS.cbegin(), JSONLD_KEYWORDS.cend());
   }
 
+  test_suite.schema_resolver = schema_resolver;
+  test_suite.walker = walker;
+  test_suite.compiler = compiler;
+  test_suite.default_dialect = default_dialect;
+  test_suite.default_id = default_id;
+
   test_suite.schemas_fast.reserve(test_suite.targets.size());
-  test_suite.schemas_exhaustive.reserve(test_suite.targets.size());
+  test_suite.schemas_exhaustive.resize(test_suite.targets.size());
 
-  for (const auto &target : test_suite.targets) {
-    const auto target_schema{wrap_identifier(target)};
-
-    try {
-      test_suite.schemas_fast.push_back(compile(
-          target_schema, walker, schema_resolver, compiler,
-          Mode::FastValidation, default_dialect, default_id, "", tweaks_fast));
-      test_suite.schemas_exhaustive.push_back(
-          compile(target_schema, walker, schema_resolver, compiler,
-                  Mode::Exhaustive, default_dialect, default_id, "", tweaks));
-    } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
-      if (error.location() == sourcemeta::core::Pointer{"$ref"} &&
-          error.identifier() == target) {
-        throw sourcemeta::blaze::SchemaResolutionError{
-            target, "Could not resolve schema under test"};
-      }
-
-      throw;
-    }
+  for (std::size_t target_index = 0; target_index < test_suite.targets.size();
+       ++target_index) {
+    test_suite.schemas_fast.push_back(
+        test_suite.compile_target(target_index, Mode::FastValidation));
   }
 
   return test_suite;
+}
+
+auto TestSuite::compile_target(const std::size_t target_index,
+                               const Mode mode) const -> Template {
+  const auto &target{this->targets[target_index]};
+
+  try {
+    return compile(wrap_identifier(target), this->walker, this->schema_resolver,
+                   this->compiler, mode, this->default_dialect,
+                   this->default_id, "",
+                   mode == Mode::FastValidation ? this->tweaks_fast
+                                                : this->tweaks_exhaustive);
+  } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
+    if (error.location() == sourcemeta::core::Pointer{"$ref"} &&
+        error.identifier() == target) {
+      throw sourcemeta::blaze::SchemaResolutionError{
+          target, "Could not resolve schema under test"};
+    }
+
+    throw;
+  }
+}
+
+auto TestSuite::fast(const std::size_t target_index) -> const Template & {
+  assert(target_index < this->schemas_fast.size());
+  return this->schemas_fast[target_index];
+}
+
+auto TestSuite::exhaustive(const std::size_t target_index) -> const Template & {
+  assert(target_index < this->schemas_exhaustive.size());
+  auto &schema_exhaustive{this->schemas_exhaustive[target_index]};
+  if (!schema_exhaustive.has_value()) {
+    schema_exhaustive = this->compile_target(target_index, Mode::Exhaustive);
+  }
+
+  return schema_exhaustive.value();
 }
 
 } // namespace sourcemeta::blaze

--- a/src/test/test_parser.cc
+++ b/src/test/test_parser.cc
@@ -262,7 +262,7 @@ auto TestSuite::compile_target(const std::size_t target_index,
   }
 }
 
-auto TestSuite::fast(const std::size_t target_index) -> const Template & {
+auto TestSuite::fast(const std::size_t target_index) const -> const Template & {
   assert(target_index < this->schemas_fast.size());
   return this->schemas_fast[target_index];
 }

--- a/src/test/test_runner.cc
+++ b/src/test/test_runner.cc
@@ -57,7 +57,7 @@ auto TestSuite::run(const Callback &callback) -> Result {
   for (std::size_t target_index = 0; target_index < this->targets.size();
        ++target_index) {
     const auto &target = this->targets[target_index];
-    const auto &schema_fast = this->schemas_fast[target_index];
+    const auto &schema_fast = this->fast(target_index);
     for (const auto &test_case : this->tests) {
       const auto start{std::chrono::steady_clock::now()};
       const auto outcome{

--- a/test/test/test_suite_test.cc
+++ b/test/test/test_suite_test.cc
@@ -1,6 +1,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <sourcemeta/blaze/compiler.h>
+#include <sourcemeta/blaze/output.h>
 #include <sourcemeta/blaze/test.h>
 
 #include <sourcemeta/blaze/foundation.h>
@@ -9,9 +10,11 @@
 #include <sourcemeta/core/uri.h>
 #include <sourcemeta/core/yaml.h>
 
+#include <cstddef>    // std::size_t
 #include <filesystem> // std::filesystem::path
 #include <optional>   // std::optional, std::nullopt
 #include <tuple>      // std::get
+#include <vector>     // std::vector
 
 TEST(error_not_an_object) {
   const auto input{"[]"};
@@ -155,8 +158,6 @@ TEST(valid_empty_tests) {
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(),
             "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_TRUE(result.tests.empty());
 }
 
@@ -180,8 +181,6 @@ TEST(valid_with_test_cases) {
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(),
             "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 2);
   EXPECT_TRUE(result.tests[0].description.empty());
   EXPECT_TRUE(result.tests[0].valid);
@@ -254,8 +253,6 @@ TEST(valid_with_file_path_target) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), expected_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 2);
   EXPECT_TRUE(result.tests[0].description.empty());
   EXPECT_TRUE(result.tests[0].valid);
@@ -333,8 +330,6 @@ TEST(valid_with_default_dialect) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), expected_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 2);
   EXPECT_TRUE(result.tests[0].valid);
   EXPECT_EQ(std::get<0>(result.tests[0].position), 4);
@@ -588,8 +583,6 @@ TEST(valid_target_array_single_element) {
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(),
             "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
 }
 
@@ -618,8 +611,6 @@ TEST(valid_target_array_multiple_uris) {
   EXPECT_EQ(result.targets[0], "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(result.targets[1], "https://json-schema.org/draft/2019-09/schema");
   EXPECT_EQ(result.targets[2], "http://json-schema.org/draft-07/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 3);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 3);
   EXPECT_EQ(result.tests.size(), 2);
 }
 
@@ -653,8 +644,6 @@ TEST(valid_target_array_with_file_paths) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), expected_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
 }
 
@@ -692,8 +681,6 @@ TEST(valid_target_array_mixed_uri_and_file_path) {
   EXPECT_EQ(result.targets.size(), 2);
   EXPECT_EQ(result.targets[0], "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(result.targets[1], expected_file_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 2);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 2);
   EXPECT_EQ(result.tests.size(), 1);
 }
 
@@ -732,8 +719,6 @@ TEST(valid_target_array_with_default_dialect) {
   EXPECT_EQ(result.targets.size(), 2);
   EXPECT_EQ(result.targets[0], expected_file_target.recompose());
   EXPECT_EQ(result.targets[1], "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 2);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 2);
   EXPECT_EQ(result.tests.size(), 1);
 }
 
@@ -793,8 +778,6 @@ TEST(valid_rdf_2020_12_target) {
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(),
             "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 2);
   EXPECT_TRUE(result.tests[0].valid);
   EXPECT_TRUE(result.tests[0].rdf.has_value());
@@ -823,8 +806,6 @@ TEST(valid_rdf_2019_09_target) {
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(),
             "https://json-schema.org/draft/2019-09/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
   EXPECT_TRUE(result.tests[0].rdf.has_value());
   EXPECT_EQ(result.tests[0].rdf.value(),
@@ -849,8 +830,6 @@ TEST(valid_rdf_draft7_target) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), "http://json-schema.org/draft-07/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
   EXPECT_TRUE(result.tests[0].rdf.has_value());
   EXPECT_EQ(result.tests[0].rdf.value(),
@@ -875,8 +854,6 @@ TEST(valid_draft7_target_without_rdf) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), "http://json-schema.org/draft-07/schema");
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
   EXPECT_FALSE(result.tests[0].rdf.has_value());
 }
@@ -911,8 +888,6 @@ TEST(valid_rdf_embedded_legacy_root_target) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), expected_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
   EXPECT_TRUE(result.tests[0].rdf.has_value());
   EXPECT_EQ(result.tests[0].rdf.value(),
@@ -950,10 +925,190 @@ TEST(valid_rdf_no_dialect_target_with_2020_12_default) {
 
   EXPECT_EQ(result.targets.size(), 1);
   EXPECT_EQ(result.targets.front(), expected_target.recompose());
-  EXPECT_EQ(result.schemas_fast.size(), 1);
-  EXPECT_EQ(result.schemas_exhaustive.size(), 1);
   EXPECT_EQ(result.tests.size(), 1);
   EXPECT_TRUE(result.tests[0].rdf.has_value());
   EXPECT_EQ(result.tests[0].rdf.value(),
             sourcemeta::core::parse_json(R"JSON([])JSON"));
+}
+
+TEST(fast_template_validates_the_target) {
+  const auto input{R"JSON({
+    "target": "schema.json",
+    "tests": [
+      { "data": { "foo": "bar" }, "valid": true }
+    ]
+  })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON document{nullptr};
+  sourcemeta::core::parse_json(input, document, std::ref(tracker));
+  const auto test_resolver{
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+        const sourcemeta::core::URI uri{identifier};
+        if (uri.is_file()) {
+          return sourcemeta::core::read_yaml_or_json(uri.to_path());
+        }
+
+        return sourcemeta::blaze::schema_resolver(identifier);
+      }};
+
+  auto result{sourcemeta::blaze::TestSuite::parse(
+      document, tracker, std::filesystem::path{STUBS_PATH}, test_resolver,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "bar" })JSON")};
+  sourcemeta::blaze::SimpleOutput output{instance};
+  EXPECT_TRUE(
+      result.evaluator.validate(result.fast(0), instance, std::ref(output)));
+
+  const std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{
+      output.cbegin(), output.cend()};
+  EXPECT_EQ(traces.size(), 0);
+  EXPECT_EQ(output.annotations().size(), 0);
+}
+
+TEST(exhaustive_template_emits_annotations) {
+  const auto input{R"JSON({
+    "target": "schema.json",
+    "tests": [
+      { "data": { "foo": "bar" }, "valid": true }
+    ]
+  })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON document{nullptr};
+  sourcemeta::core::parse_json(input, document, std::ref(tracker));
+  const auto test_resolver{
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+        const sourcemeta::core::URI uri{identifier};
+        if (uri.is_file()) {
+          return sourcemeta::core::read_yaml_or_json(uri.to_path());
+        }
+
+        return sourcemeta::blaze::schema_resolver(identifier);
+      }};
+
+  auto result{sourcemeta::blaze::TestSuite::parse(
+      document, tracker, std::filesystem::path{STUBS_PATH}, test_resolver,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::default_schema_compiler)};
+  const auto expected_target{sourcemeta::core::URI::from_path(
+      std::filesystem::path{STUBS_PATH} / "schema.json")};
+
+  const auto instance{
+      sourcemeta::core::parse_json(R"JSON({ "foo": "bar" })JSON")};
+  sourcemeta::blaze::SimpleOutput output{instance};
+  EXPECT_TRUE(result.evaluator.validate(result.exhaustive(0), instance,
+                                        std::ref(output)));
+
+  const std::vector<sourcemeta::blaze::SimpleOutput::Entry> traces{
+      output.cbegin(), output.cend()};
+  EXPECT_EQ(traces.size(), 0);
+  EXPECT_EQ(output.annotations().size(), 1);
+  EXPECT_EQ(
+      sourcemeta::core::to_string(output.annotations().at(0).instance_location),
+      "");
+  EXPECT_EQ(
+      sourcemeta::core::to_string(output.annotations().at(0).evaluate_path),
+      "/$ref/properties");
+  EXPECT_EQ(output.annotations().at(0).schema_location.get(),
+            expected_target.recompose() + "#/properties");
+  EXPECT_EQ(output.annotations().at(0).value,
+            sourcemeta::core::parse_json(R"JSON("foo")JSON"));
+}
+
+TEST(exhaustive_template_is_compiled_once) {
+  const auto input{R"JSON({
+    "target": "schema.json",
+    "tests": [
+      { "data": {}, "valid": false }
+    ]
+  })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON document{nullptr};
+  sourcemeta::core::parse_json(input, document, std::ref(tracker));
+  const auto test_resolver{
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+        const sourcemeta::core::URI uri{identifier};
+        if (uri.is_file()) {
+          return sourcemeta::core::read_yaml_or_json(uri.to_path());
+        }
+
+        return sourcemeta::blaze::schema_resolver(identifier);
+      }};
+
+  auto result{sourcemeta::blaze::TestSuite::parse(
+      document, tracker, std::filesystem::path{STUBS_PATH}, test_resolver,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  EXPECT_EQ(&result.exhaustive(0), &result.exhaustive(0));
+}
+
+TEST(exhaustive_template_is_only_compiled_on_request) {
+  const auto input{R"JSON({
+    "target": "schema.json",
+    "tests": [
+      { "data": {}, "valid": false }
+    ]
+  })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON document{nullptr};
+  sourcemeta::core::parse_json(input, document, std::ref(tracker));
+  std::size_t resolutions{0};
+  const auto test_resolver{[&resolutions](std::string_view identifier)
+                               -> std::optional<sourcemeta::core::JSON> {
+    resolutions += 1;
+    const sourcemeta::core::URI uri{identifier};
+    if (uri.is_file()) {
+      return sourcemeta::core::read_yaml_or_json(uri.to_path());
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  }};
+
+  auto result{sourcemeta::blaze::TestSuite::parse(
+      document, tracker, std::filesystem::path{STUBS_PATH}, test_resolver,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  const auto resolutions_after_parse{resolutions};
+  [[maybe_unused]] const auto &schema_exhaustive{result.exhaustive(0)};
+  EXPECT_TRUE(resolutions > resolutions_after_parse);
+}
+
+TEST(exhaustive_template_per_target) {
+  const auto input{R"JSON({
+    "target": [ "schema.json", "schema_draft7.json" ],
+    "tests": [
+      { "data": {}, "valid": false }
+    ]
+  })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON document{nullptr};
+  sourcemeta::core::parse_json(input, document, std::ref(tracker));
+  const auto test_resolver{
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+        const sourcemeta::core::URI uri{identifier};
+        if (uri.is_file()) {
+          return sourcemeta::core::read_yaml_or_json(uri.to_path());
+        }
+
+        return sourcemeta::blaze::schema_resolver(identifier);
+      }};
+
+  auto result{sourcemeta::blaze::TestSuite::parse(
+      document, tracker, std::filesystem::path{STUBS_PATH}, test_resolver,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  EXPECT_EQ(result.targets.size(), 2);
+  EXPECT_TRUE(&result.exhaustive(0) != &result.exhaustive(1));
+  EXPECT_EQ(&result.exhaustive(0), &result.exhaustive(0));
+  EXPECT_EQ(&result.exhaustive(1), &result.exhaustive(1));
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

