### PR TITLE
Fix embedded meta-schema resources only consulted on the first hop

### DIFF
--- a/src/foundation/foundation.cc
+++ b/src/foundation/foundation.cc
@@ -260,13 +260,14 @@ auto sourcemeta::blaze::dialect(const sourcemeta::core::JSON &schema,
   return dialect_value.to_string();
 }
 
-// A meta-schema that is not known to the resolver may still be embedded in
-// the document itself. Across every official base dialect, the only
-// containers that can hold embedded resources are `$defs` and `definitions`,
-// which no custom dialect can redefine away. A candidate only counts if its
-// entire meta-schema chain terminates at an official base dialect and every
-// embedded link declares its identifier and sits in a container in a way
-// that is valid for such base dialect
+// A meta-schema that the document embeds takes precedence over what the
+// resolver knows about, at every link of the chain, as the document pins the
+// exact meta-schemas it is described by. Across every official base dialect,
+// the only containers that can hold embedded resources are `$defs` and
+// `definitions`, which no custom dialect can redefine away. A candidate only
+// counts if its entire meta-schema chain terminates at an official base
+// dialect and every embedded link declares its identifier and sits in a
+// container in a way that is valid for such base dialect
 auto sourcemeta::blaze::metaschema_try_embedded(
     const sourcemeta::core::JSON &schema, const std::string_view identifier,
     const SchemaResolver &resolver) -> const sourcemeta::core::JSON * {
@@ -319,28 +320,26 @@ auto sourcemeta::blaze::metaschema_try_embedded(
       break;
     }
 
+    if (sourcemeta::core::URI::is_uri(dialect_uri)) {
+      const auto next{sourcemeta::blaze::embedded_metaschema_candidate(
+          schema, dialect_uri)};
+      if (next.first) {
+        links.push_back({.schema = next.first,
+                         .identifier = dialect_uri,
+                         .container = next.second});
+        current = next.first;
+        current_identifier = dialect_uri;
+        continue;
+      }
+    }
+
     auto remote{resolver(dialect_uri)};
-    if (remote.has_value()) {
-      resolved.push_back(std::move(remote).value());
-      current = &resolved.back();
-      current_identifier = dialect_uri;
-      continue;
-    }
-
-    if (!sourcemeta::core::URI::is_uri(dialect_uri)) {
+    if (!remote.has_value()) {
       return nullptr;
     }
 
-    const auto next{
-        sourcemeta::blaze::embedded_metaschema_candidate(schema, dialect_uri)};
-    if (!next.first) {
-      return nullptr;
-    }
-
-    links.push_back({.schema = next.first,
-                     .identifier = dialect_uri,
-                     .container = next.second});
-    current = next.first;
+    resolved.push_back(std::move(remote).value());
+    current = &resolved.back();
     current_identifier = dialect_uri;
   }
 

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -880,6 +880,47 @@ TEST(embedded_custom_metaschema_chain_draft7) {
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
 }
 
+TEST(embedded_custom_metaschema_chain_precedence) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  // A resolver that knows about the intermediate link of the chain, but
+  // with a different base dialect than the embedded copy
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      })JSON");
+    }
+
+    return test_resolver(identifier);
+  };
+
+  const auto base_dialect{sourcemeta::blaze::base_dialect(document, resolver)};
+  EXPECT_TRUE(base_dialect.has_value());
+  EXPECT_EQ(base_dialect.value(),
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
 TEST(embedded_custom_metaschema_non_canonical_dialect_uri) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta#",

--- a/test/foundation/foundation_metaschema_test.cc
+++ b/test/foundation/foundation_metaschema_test.cc
@@ -280,6 +280,61 @@ TEST(embedded_custom_metaschema_precedence) {
   EXPECT_EQ(metaschema, expected);
 }
 
+TEST(embedded_custom_metaschema_chain_precedence) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  // A resolver that knows about the intermediate link of the chain, but
+  // with a definition that cannot be resolved any further
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://example.com/unknown"
+      })JSON");
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  };
+
+  const auto metaschema{sourcemeta::blaze::metaschema(schema, resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta-a",
+    "$schema": "https://example.com/meta-b",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true
+    },
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(metaschema, expected);
+}
+
 TEST(try_embedded_2020_12) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta",
@@ -516,6 +571,150 @@ TEST(try_embedded_cyclic) {
     EXPECT_STREQ(error.what(),
                  "Could not determine the base dialect of the schema");
   }
+}
+
+TEST(try_embedded_chain_intermediate_precedence) {
+  const auto document{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://example.com/unknown"
+      })JSON");
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  };
+
+  const auto *metaschema{sourcemeta::blaze::metaschema_try_embedded(
+      document, "https://example.com/meta-a", resolver)};
+
+  EXPECT_TRUE(metaschema);
+  EXPECT_EQ(metaschema, &document.at("$defs").at("https://example.com/meta-a"));
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta-a",
+    "$schema": "https://example.com/meta-b",
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(*metaschema, expected);
+}
+
+TEST(try_embedded_chain_intermediate_precedence_cyclic) {
+  const auto document{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://example.com/meta-a"
+      })JSON");
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  };
+
+  const auto *metaschema{sourcemeta::blaze::metaschema_try_embedded(
+      document, "https://example.com/meta-a", resolver)};
+
+  EXPECT_TRUE(metaschema);
+  EXPECT_EQ(metaschema, &document.at("$defs").at("https://example.com/meta-a"));
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta-a",
+    "$schema": "https://example.com/meta-b",
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(*metaschema, expected);
+}
+
+TEST(try_embedded_chain_intermediate_precedence_base_dialect) {
+  const auto document{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON")};
+
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      })JSON");
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  };
+
+  const auto *metaschema{sourcemeta::blaze::metaschema_try_embedded(
+      document, "https://example.com/meta-a", resolver)};
+
+  EXPECT_TRUE(metaschema);
+  EXPECT_EQ(metaschema, &document.at("$defs").at("https://example.com/meta-a"));
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/meta-a",
+    "$schema": "https://example.com/meta-b",
+    "type": "object"
+  })JSON")};
+
+  EXPECT_EQ(*metaschema, expected);
 }
 
 TEST(embedded_custom_metaschema_2019_09) {

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -783,6 +783,52 @@ TEST(embedded_custom_metaschema_chain) {
   EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Validation);
 }
 
+TEST(embedded_custom_metaschema_chain_precedence) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://example.com/meta-a",
+    "$id": "https://example.com/schema",
+    "$defs": {
+      "https://example.com/meta-a": {
+        "$id": "https://example.com/meta-a",
+        "$schema": "https://example.com/meta-b",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://json-schema.org/draft/2020-12/vocab/validation": true
+        },
+        "type": "object"
+      },
+      "https://example.com/meta-b": {
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true
+        },
+        "type": "object"
+      }
+    }
+  })JSON");
+
+  // A resolver that knows about the intermediate link of the chain, but
+  // with a definition that cannot be resolved any further
+  const auto resolver =
+      [](std::string_view identifier) -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/meta-b") {
+      return sourcemeta::core::parse_json(R"JSON({
+        "$id": "https://example.com/meta-b",
+        "$schema": "https://example.com/unknown"
+      })JSON");
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  };
+
+  const sourcemeta::blaze::Vocabularies vocabularies{
+      sourcemeta::blaze::vocabularies(document, resolver)};
+  EXPECT_EQ(vocabularies.size(), 2);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(vocabularies, JSON_Schema_2020_12_Validation);
+}
+
 TEST(embedded_custom_metaschema_without_vocabulary) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

