### PR TITLE
Optimise numeric type bounds with a single instruction

### DIFF
--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -160,6 +160,53 @@ inline auto rephrase(const Context &context, const InstructionIndex type,
           .extra_index = extra_index};
 }
 
+inline auto is_numeric_integer_type_check(const Instruction &instruction)
+    -> bool {
+  return (instruction.type == InstructionIndex::AssertionType ||
+          instruction.type == InstructionIndex::AssertionTypeStrict) &&
+         std::get<ValueType>(instruction.value) ==
+             sourcemeta::core::JSON::Type::Integer;
+}
+
+inline auto is_numeric_bound_check(const Instruction &instruction) -> bool {
+  return instruction.type == InstructionIndex::AssertionGreaterEqual ||
+         instruction.type == InstructionIndex::AssertionGreater ||
+         instruction.type == InstructionIndex::AssertionLessEqual ||
+         instruction.type == InstructionIndex::AssertionLess;
+}
+
+inline auto merge_integer_bound(const Instruction &instruction,
+                                std::optional<std::int64_t> &minimum,
+                                std::optional<std::int64_t> &maximum) -> bool {
+  if (!is_numeric_bound_check(instruction)) {
+    return false;
+  }
+
+  const auto &bound{std::get<ValueJSON>(instruction.value)};
+  if (!bound.is_integer()) {
+    return false;
+  }
+
+  const auto value{bound.to_integer()};
+  if (instruction.type == InstructionIndex::AssertionGreaterEqual) {
+    minimum = minimum.has_value() ? std::max(minimum.value(), value) : value;
+  } else if (instruction.type == InstructionIndex::AssertionGreater) {
+    const auto adjusted{value + 1};
+    minimum =
+        minimum.has_value() ? std::max(minimum.value(), adjusted) : adjusted;
+  } else if (instruction.type == InstructionIndex::AssertionLessEqual) {
+    maximum = maximum.has_value() ? std::min(maximum.value(), value) : value;
+  } else if (instruction.type == InstructionIndex::AssertionLess) {
+    const auto adjusted{value - 1};
+    maximum =
+        maximum.has_value() ? std::min(maximum.value(), adjusted) : adjusted;
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
 // Note that the size keywords that let the type level fuse their bound accept
 // any integral number, including reals with no fractional part like `2.0`, so
 // this must recognise those too or the fused bound would be silently dropped

--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -4,13 +4,18 @@
 #include <sourcemeta/blaze/compiler.h>
 #include <sourcemeta/blaze/evaluator.h>
 
+#include <sourcemeta/core/uri.h>
+
 #include <algorithm>
 #include <cstddef>
-#include <string> // std::string
-#include <tuple>  // std::tuple
+#include <optional> // std::optional
+#include <string>   // std::string
+#include <tuple>    // std::tuple
 #include <unordered_map>
 #include <unordered_set> // std::unordered_set
 #include <vector>
+
+#include "compile_helpers.h"
 
 // TODO: Move all `FastValidation` conditional optimisations from the default
 // compilers here. Only the structural ones from Draft 4 seem to be missing
@@ -177,6 +182,122 @@ inline auto collect_statistics(const Instructions &instructions,
 
     collect_statistics(instruction.children, statistics);
   }
+}
+
+inline auto
+instruction_parent_location(const Instruction &instruction,
+                            const std::vector<InstructionExtra> &extra)
+    -> std::optional<std::pair<sourcemeta::core::Pointer, std::string>> {
+  const auto &metadata{extra[instruction.extra_index]};
+  if (metadata.relative_schema_location.empty()) {
+    return std::nullopt;
+  }
+
+  auto keyword_location{sourcemeta::core::URI{metadata.keyword_location}};
+  auto keyword_pointer{sourcemeta::core::fragment_to_pointer(keyword_location)};
+  if (!keyword_pointer.has_value() || keyword_pointer->empty()) {
+    return std::nullopt;
+  }
+
+  auto parent_pointer{keyword_pointer->initial()};
+  keyword_location.fragment(sourcemeta::core::to_string(parent_pointer));
+  return std::pair{metadata.relative_schema_location.initial(),
+                   keyword_location.recompose()};
+}
+
+inline auto fuse_numeric_bounds(Instructions &instructions,
+                                std::vector<InstructionExtra> &extra) -> bool {
+  for (std::size_t type_index = 0; type_index < instructions.size();
+       ++type_index) {
+    const auto &type_instruction{instructions[type_index]};
+    if (!is_numeric_integer_type_check(type_instruction)) {
+      continue;
+    }
+
+    const auto parent{instruction_parent_location(type_instruction, extra)};
+    if (!parent.has_value()) {
+      continue;
+    }
+
+    const auto &type_metadata{extra[type_instruction.extra_index]};
+    std::vector<std::size_t> bound_indices;
+    std::optional<std::int64_t> minimum;
+    std::optional<std::int64_t> maximum;
+
+    for (std::size_t index = 0; index < instructions.size(); ++index) {
+      const auto &candidate{instructions[index]};
+      if (!is_numeric_bound_check(candidate) ||
+          candidate.relative_instance_location !=
+              type_instruction.relative_instance_location ||
+          extra[candidate.extra_index].schema_resource !=
+              type_metadata.schema_resource ||
+          instruction_parent_location(candidate, extra) != parent) {
+        continue;
+      }
+
+      if (!merge_integer_bound(candidate, minimum, maximum)) {
+        continue;
+      }
+
+      bound_indices.push_back(index);
+    }
+
+    if (bound_indices.empty() ||
+        (!minimum.has_value() && !maximum.has_value())) {
+      continue;
+    }
+
+    const auto is_strict{type_instruction.type ==
+                         InstructionIndex::AssertionTypeStrict};
+    InstructionIndex fused_type;
+    Value fused_value;
+
+    if (minimum.has_value() && maximum.has_value()) {
+      fused_type = is_strict
+                       ? InstructionIndex::AssertionTypeIntegerBoundedStrict
+                       : InstructionIndex::AssertionTypeIntegerBounded;
+      fused_value = ValueIntegerBounds{minimum.value(), maximum.value()};
+    } else if (minimum.has_value()) {
+      fused_type = is_strict
+                       ? InstructionIndex::AssertionTypeIntegerLowerBoundStrict
+                       : InstructionIndex::AssertionTypeIntegerLowerBound;
+      fused_value = ValueIntegerBounds{minimum.value(), 0};
+    } else {
+      continue;
+    }
+
+    const auto first_index{
+        std::min(type_index, *std::ranges::min_element(bound_indices))};
+    const auto extra_index{extra.size()};
+    extra.push_back({.relative_schema_location = parent->first,
+                     .keyword_location = parent->second,
+                     .schema_resource = type_metadata.schema_resource});
+
+    Instructions result;
+    result.reserve(instructions.size() - bound_indices.size());
+    for (std::size_t index = 0; index < instructions.size(); ++index) {
+      if (index == first_index) {
+        result.push_back({.type = fused_type,
+                          .relative_instance_location =
+                              type_instruction.relative_instance_location,
+                          .value = std::move(fused_value),
+                          .children = {},
+                          .extra_index = extra_index});
+      }
+
+      if (index == type_index ||
+          std::ranges::find(bound_indices, index) != bound_indices.cend()) {
+        continue;
+      }
+
+      result.push_back(std::move(instructions[index]));
+    }
+
+    instructions = std::move(result);
+    return true;
+  }
+
+  return false;
 }
 
 inline auto
@@ -467,6 +588,10 @@ inline auto postprocess(std::vector<Instructions> &targets,
                            (owner->type == InstructionIndex::LogicalCondition ||
                             owner->type == InstructionIndex::LogicalOr ||
                             owner->type == InstructionIndex::LogicalXor))};
+
+        if (!disjoint && fuse_numeric_bounds(*current, extra)) {
+          changed = true;
+        }
 
         // A fused simple-properties instruction only enforces that a property
         // is present for the entries it marks as required, so only those may

--- a/test/evaluator/evaluator_2020_12.json
+++ b/test/evaluator/evaluator_2020_12.json
@@ -10,10 +10,22 @@
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/fooBar", "#/fooBar", "" ]
+        [
+          "Annotation",
+          "/fooBar",
+          "#/fooBar",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/fooBar", "#/fooBar", "", "baz" ]
+        [
+          true,
+          "Annotation",
+          "/fooBar",
+          "#/fooBar",
+          "",
+          "baz"
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"fooBar\" was collected as the annotation \"baz\""
@@ -22,16 +34,31 @@
   },
   {
     "description": "unknown_2",
-    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "x-test": 1 },
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "x-test": 1
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/x-test", "#/x-test", "" ]
+        [
+          "Annotation",
+          "/x-test",
+          "#/x-test",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/x-test", "#/x-test", "", 1 ]
+        [
+          true,
+          "Annotation",
+          "/x-test",
+          "#/x-test",
+          "",
+          1
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"x-test\" was collected as the annotation 1"
@@ -42,7 +69,9 @@
     "description": "items_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "instance": 5,
     "valid": true,
@@ -53,22 +82,72 @@
     "description": "items_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -79,20 +158,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -108,20 +254,59 @@
     "description": "items_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", 5, "baz" ],
+    "instance": [
+      "foo",
+      5,
+      "baz"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -131,14 +316,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -151,21 +369,66 @@
     "description": "items_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" },
-      "prefixItems": [ { "type": "boolean" }, { "type": "integer" } ]
+      "items": {
+        "type": "string"
+      },
+      "prefixItems": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5 ],
+    "instance": [
+      true,
+      5
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -175,18 +438,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 1 ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", true ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          1
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -201,27 +521,107 @@
     "description": "items_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" },
-      "prefixItems": [ { "type": "boolean" }, { "type": "integer" } ]
+      "items": {
+        "type": "string"
+      },
+      "prefixItems": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5, "foo", "bar" ],
+    "instance": [
+      true,
+      5,
+      "foo",
+      "bar"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/3" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/3"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/3" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -234,26 +634,127 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/3" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/3"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 1 ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/3" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          1
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -272,25 +773,94 @@
     "description": "items_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" },
-      "prefixItems": [ { "type": "boolean" }, { "type": "integer" } ]
+      "items": {
+        "type": "string"
+      },
+      "prefixItems": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5, 6, "bar" ],
+    "instance": [
+      true,
+      5,
+      6,
+      "bar"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -302,20 +872,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionType", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 1 ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          1
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -331,7 +968,9 @@
     "description": "items_7",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "instance": [],
     "valid": true,
@@ -342,7 +981,11 @@
     "description": "prefixItems_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "string" } ]
+      "prefixItems": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -353,16 +996,34 @@
     "description": "prefixItems_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "integer" }, { "type": "boolean" } ]
+      "prefixItems": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "instance": [],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The first 2 items of the array value were expected to validate against the corresponding subschemas"
@@ -370,10 +1031,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The first 2 items of the array value were expected to validate against the corresponding subschemas"
@@ -384,18 +1056,49 @@
     "description": "prefixItems_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "integer" }, { "type": "boolean" } ]
+      "prefixItems": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5 ],
+    "instance": [
+      5
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -404,14 +1107,48 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 0 ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          0
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -424,20 +1161,64 @@
     "description": "prefixItems_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "integer" }, { "type": "boolean" } ]
+      "prefixItems": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5, true, "extra" ],
+    "instance": [
+      5,
+      true,
+      "extra"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -447,16 +1228,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 1 ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          1
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -470,20 +1296,64 @@
     "description": "prefixItems_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "integer" }, { "type": "boolean" } ]
+      "prefixItems": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5, 1, "extra" ],
+    "instance": [
+      5,
+      1,
+      "extra"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ false, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -493,14 +1363,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ false, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -513,20 +1416,63 @@
     "description": "prefixItems_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "prefixItems": [ { "type": "integer" }, { "type": "boolean" } ]
+      "prefixItems": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5, true ],
+    "instance": [
+      5,
+      true
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -536,18 +1482,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ],
-        [ "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ],
-        [ "Annotation", "/prefixItems", "#/prefixItems", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ],
+        [
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/prefixItems/0/type", "#/prefixItems/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/prefixItems/1/type", "#/prefixItems/1/type", "/1" ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", 1 ],
-        [ true, "Annotation", "/prefixItems", "#/prefixItems", "", true ],
-        [ true, "AssertionArrayPrefix", "/prefixItems", "#/prefixItems", "" ]
+        [
+          true,
+          "AssertionType",
+          "/prefixItems/0/type",
+          "#/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/prefixItems/1/type",
+          "#/prefixItems/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          1
+        ],
+        [
+          true,
+          "Annotation",
+          "/prefixItems",
+          "#/prefixItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/prefixItems",
+          "#/prefixItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -562,7 +1565,9 @@
     "description": "contains_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
     "instance": 2,
     "valid": true,
@@ -573,20 +1578,59 @@
     "description": "contains_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ 1, "bar", 3 ],
+    "instance": [
+      1,
+      "bar",
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -596,18 +1640,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -622,22 +1722,72 @@
     "description": "contains_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -648,16 +1798,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -671,18 +1865,46 @@
     "description": "contains_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -691,22 +1913,102 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -724,20 +2026,59 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "maxContains": 1,
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -747,18 +2088,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -773,18 +2171,47 @@
     "description": "contains_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "boolean" }
+      "contains": {
+        "type": "boolean"
+      }
     },
-    "instance": [ true, 1, false, 2 ],
+    "instance": [
+      true,
+      1,
+      false,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -793,22 +2220,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -825,18 +2331,46 @@
     "description": "contains_7",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "boolean" }
+      "contains": {
+        "type": "boolean"
+      }
     },
-    "instance": [ true, 1, false ],
+    "instance": [
+      true,
+      1,
+      false
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -845,20 +2379,88 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -875,16 +2477,32 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$dynamicRef": "#foo",
-      "$defs": { "string": { "$dynamicAnchor": "foo", "type": "string" } }
+      "$defs": {
+        "string": {
+          "$dynamicAnchor": "foo",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "#/$defs/string/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "#/$defs/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$dynamicRef/type", "#/$defs/string/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "#/$defs/string/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -892,12 +2510,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "#/$defs/string/type", "" ]
+        [
+          "ControlJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "#/$defs/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$dynamicRef/type", "#/$defs/string/type", "" ],
-        [ true, "ControlJump", "/$dynamicRef", "#/$dynamicRef", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "#/$defs/string/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -927,12 +2567,34 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ]
+        [
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ],
-        [ true, "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -941,12 +2603,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ]
+        [
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ],
-        [ true, "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -976,12 +2660,34 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ]
+        [
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ],
-        [ false, "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ],
+        [
+          false,
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean but it was of type integer",
@@ -990,12 +2696,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ]
+        [
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/$dynamicRef/type", "https://example.com/target#/type", "" ],
-        [ false, "ControlDynamicAnchorJump", "/$dynamicRef", "#/$dynamicRef", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/$dynamicRef/type",
+          "https://example.com/target#/type",
+          ""
+        ],
+        [
+          false,
+          "ControlDynamicAnchorJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean but it was of type integer",
@@ -1008,16 +2736,31 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$ref": "#/$defs/https%3A~1~1example.com~1schema~1type",
-      "$defs": { "https://example.com/schema/type": { "type": "string" } }
+      "$defs": {
+        "https://example.com/schema/type": {
+          "type": "string"
+        }
+      }
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$ref/type", "#/$defs/https:~1~1example.com~1schema~1type/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/https:~1~1example.com~1schema~1type/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "#/$defs/https:~1~1example.com~1schema~1type/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/https:~1~1example.com~1schema~1type/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -1025,12 +2768,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "#/$ref", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "#/$defs/https:~1~1example.com~1schema~1type/type", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/https:~1~1example.com~1schema~1type/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "#/$defs/https:~1~1example.com~1schema~1type/type", "" ],
-        [ true, "ControlJump", "/$ref", "#/$ref", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/https:~1~1example.com~1schema~1type/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1044,18 +2809,33 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$ref": "#/definitions/middle",
       "definitions": {
-        "middle": { "$ref": "#/definitions/string" },
-        "string": { "type": "string" }
+        "middle": {
+          "$ref": "#/definitions/string"
+        },
+        "string": {
+          "type": "string"
+        }
       }
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$ref/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$ref/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/$ref/type", "#/definitions/string/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -1063,14 +2843,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "#/$ref", "" ],
-        [ "ControlJump", "/$ref/$ref", "#/definitions/middle/$ref", "" ],
-        [ "AssertionTypeStrict", "/$ref/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/$ref/$ref",
+          "#/definitions/middle/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/$ref/type", "#/definitions/string/type", "" ],
-        [ true, "ControlJump", "/$ref/$ref", "#/definitions/middle/$ref", "" ],
-        [ true, "ControlJump", "/$ref", "#/$ref", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref/$ref",
+          "#/definitions/middle/$ref",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1083,21 +2896,58 @@
     "description": "unevaluatedItems_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "boolean" },
+      "contains": {
+        "type": "boolean"
+      },
       "unevaluatedItems": false
     },
-    "instance": [ false ],
+    "instance": [
+      false
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1107,16 +2957,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1130,27 +3025,103 @@
     "description": "unevaluatedItems_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "items": { "type": "boolean" } }, true ],
+      "anyOf": [
+        {
+          "items": {
+            "type": "boolean"
+          }
+        },
+        true
+      ],
       "unevaluatedItems": false
     },
-    "instance": [ false, 1 ],
+    "instance": [
+      false,
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LoopItemsFrom", "/anyOf/0/items", "#/anyOf/0/items", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/1" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/anyOf/0/items",
+          "#/anyOf/0/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/1"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/1" ],
-        [ false, "LoopItemsFrom", "/anyOf/0/items", "#/anyOf/0/items", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/anyOf/0/items",
+          "#/anyOf/0/items",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1163,20 +3134,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LoopItemsFrom", "/anyOf/0/items", "#/anyOf/0/items", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/1" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/anyOf/0/items",
+          "#/anyOf/0/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/1"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/anyOf/0/items/type", "#/anyOf/0/items/type", "/1" ],
-        [ false, "LoopItemsFrom", "/anyOf/0/items", "#/anyOf/0/items", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/items/type",
+          "#/anyOf/0/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/anyOf/0/items",
+          "#/anyOf/0/items",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1192,25 +3229,92 @@
     "description": "unevaluatedItems_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "prefixItems": [ { "type": "boolean" } ] }, true ],
+      "anyOf": [
+        {
+          "prefixItems": [
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        true
+      ],
       "unevaluatedItems": false
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionArrayPrefixEvaluate", "/anyOf/0/prefixItems", "#/anyOf/0/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/prefixItems/0/type", "#/anyOf/0/prefixItems/0/type", "/0" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/0/prefixItems",
+          "#/anyOf/0/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/prefixItems/0/type",
+          "#/anyOf/0/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/prefixItems/0/type", "#/anyOf/0/prefixItems/0/type", "/0" ],
-        [ false, "AssertionArrayPrefixEvaluate", "/anyOf/0/prefixItems", "#/anyOf/0/prefixItems", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/prefixItems/0/type",
+          "#/anyOf/0/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/0/prefixItems",
+          "#/anyOf/0/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean but it was of type integer",
@@ -1222,18 +3326,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionArrayPrefixEvaluate", "/anyOf/0/prefixItems", "#/anyOf/0/prefixItems", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/prefixItems/0/type", "#/anyOf/0/prefixItems/0/type", "/0" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/0/prefixItems",
+          "#/anyOf/0/prefixItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/prefixItems/0/type",
+          "#/anyOf/0/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/prefixItems/0/type", "#/anyOf/0/prefixItems/0/type", "/0" ],
-        [ false, "AssertionArrayPrefixEvaluate", "/anyOf/0/prefixItems", "#/anyOf/0/prefixItems", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedItems", "#/unevaluatedItems", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/prefixItems/0/type",
+          "#/anyOf/0/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/0/prefixItems",
+          "#/anyOf/0/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean but it was of type integer",
@@ -1248,19 +3407,47 @@
     "description": "unevaluatedItems_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "string" },
-      "unevaluatedItems": { "type": "boolean" }
+      "items": {
+        "type": "string"
+      },
+      "unevaluatedItems": {
+        "type": "boolean"
+      }
     },
-    "instance": [ "foo" ],
+    "instance": [
+      "foo"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1269,16 +3456,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1292,31 +3524,128 @@
     "description": "unevaluatedItems_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "boolean" },
-      "unevaluatedItems": { "type": "number" }
+      "contains": {
+        "type": "boolean"
+      },
+      "unevaluatedItems": {
+        "type": "number"
+      }
     },
-    "instance": [ true, 1, false, 2 ],
+    "instance": [
+      true,
+      1,
+      false,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/3" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/3"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/3" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1331,32 +3660,168 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ "AnnotationToParent", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/3" ],
-        [ "AnnotationToParent", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          "AnnotationToParent",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/3"
+        ],
+        [
+          "AnnotationToParent",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/3" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
-        [ true, "AssertionTypeStrictAny", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/3" ],
-        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/3"
+        ],
+        [
+          true,
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1378,22 +3843,59 @@
     "description": "unevaluatedItems_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "type": "string" },
+      "contains": {
+        "type": "string"
+      },
       "minContains": 0,
       "unevaluatedItems": false
     },
-    "instance": [ "foo" ],
+    "instance": [
+      "foo"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1403,16 +3905,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1426,17 +3973,32 @@
     "description": "unevaluatedProperties_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "additionalProperties": { "type": "string" },
+      "additionalProperties": {
+        "type": "string"
+      },
       "unevaluatedProperties": false
     },
-    "instance": { "foo": "baz" },
+    "instance": {
+      "foo": "baz"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type string"
@@ -1444,14 +4006,48 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ],
-        [ "Annotation", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ],
-        [ true, "Annotation", "/additionalProperties", "#/additionalProperties", "", "foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1469,7 +4065,9 @@
         "schema": {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
           "$id": "https://www.example.com",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1477,10 +4075,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/items/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/items/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/items/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/items/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -1488,12 +4097,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "#/$ref", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/items/type", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/items/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/items/type", "" ],
-        [ true, "ControlJump", "/$ref", "#/$ref", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/items/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1510,7 +4141,9 @@
         "description": "Test",
         "default": "Test",
         "deprecated": true,
-        "examples": [ "foo" ],
+        "examples": [
+          "foo"
+        ],
         "readOnly": true,
         "writeOnly": true,
         "x-foo": "bar",
@@ -1518,25 +4151,60 @@
         "contentEncoding": "base64",
         "contentMediaType": "application/json",
         "contentSchema": true,
-        "prefixItems": [ { "type": "string" } ],
-        "items": { "type": "string" },
-        "unevaluatedItems": { "type": "string" },
-        "contains": { "type": "string" },
-        "properties": { "foo": { "type": "string" } },
-        "patternProperties": { "^f": { "type": "string" } },
-        "additionalProperties": { "type": "string" },
-        "unevaluatedProperties": { "type": "string" }
+        "prefixItems": [
+          {
+            "type": "string"
+          }
+        ],
+        "items": {
+          "type": "string"
+        },
+        "unevaluatedItems": {
+          "type": "string"
+        },
+        "contains": {
+          "type": "string"
+        },
+        "properties": {
+          "foo": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^f": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        },
+        "unevaluatedProperties": {
+          "type": "string"
+        }
       }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property \"foo\" was expected to validate against the given subschema"
@@ -1554,10 +4222,22 @@
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/description", "#/description", "" ]
+        [
+          "Annotation",
+          "/description",
+          "#/description",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/description", "#/description", "", "Foo Bar" ]
+        [
+          true,
+          "Annotation",
+          "/description",
+          "#/description",
+          "",
+          "Foo Bar"
+        ]
       ],
       "descriptions": [
         "The description of the instance was \"Foo Bar\""
@@ -1570,17 +4250,30 @@
       "$id": "https://www.example.com",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$ref": "#/$defs/test",
-      "$defs": { "test": {} }
+      "$defs": {
+        "test": {}
+      }
     },
     "instance": 5,
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ]
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was expected to validate against the referenced schema"
@@ -1591,17 +4284,36 @@
     "description": "openapi_discriminator_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "discriminator": { "propertyName": "petType" }
+      "discriminator": {
+        "propertyName": "petType"
+      }
     },
-    "instance": { "petType": "dog", "name": "Rex" },
+    "instance": {
+      "petType": "dog",
+      "name": "Rex"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/discriminator", "#/discriminator", "" ]
+        [
+          "Annotation",
+          "/discriminator",
+          "#/discriminator",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/discriminator", "#/discriminator", "", {"propertyName": "petType"} ]
+        [
+          true,
+          "Annotation",
+          "/discriminator",
+          "#/discriminator",
+          "",
+          {
+            "propertyName": "petType"
+          }
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"discriminator\" was collected as the annotation {\"propertyName\":\"petType\"}"
@@ -1612,17 +4324,37 @@
     "description": "openapi_xml_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "xml": { "name": "pet", "wrapped": true }
+      "xml": {
+        "name": "pet",
+        "wrapped": true
+      }
     },
-    "instance": { "name": "Rex" },
+    "instance": {
+      "name": "Rex"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/xml", "#/xml", "" ]
+        [
+          "Annotation",
+          "/xml",
+          "#/xml",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/xml", "#/xml", "", {"name": "pet", "wrapped": true} ]
+        [
+          true,
+          "Annotation",
+          "/xml",
+          "#/xml",
+          "",
+          {
+            "name": "pet",
+            "wrapped": true
+          }
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"xml\" was collected as the annotation {\"name\":\"pet\",\"wrapped\":true}"
@@ -1633,17 +4365,33 @@
     "description": "openapi_externalDocs_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "externalDocs": { "url": "https://example.com/docs" }
+      "externalDocs": {
+        "url": "https://example.com/docs"
+      }
     },
     "instance": "foo",
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/externalDocs", "#/externalDocs", "" ]
+        [
+          "Annotation",
+          "/externalDocs",
+          "#/externalDocs",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/externalDocs", "#/externalDocs", "", {"url": "https://example.com/docs"} ]
+        [
+          true,
+          "Annotation",
+          "/externalDocs",
+          "#/externalDocs",
+          "",
+          {
+            "url": "https://example.com/docs"
+          }
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"externalDocs\" was collected as the annotation {\"url\":\"https://example.com/docs\"}"
@@ -1654,17 +4402,38 @@
     "description": "openapi_example_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "example": { "name": "Rex", "petType": "dog" }
+      "example": {
+        "name": "Rex",
+        "petType": "dog"
+      }
     },
-    "instance": { "name": "Fluffy", "petType": "cat" },
+    "instance": {
+      "name": "Fluffy",
+      "petType": "cat"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/example", "#/example", "" ]
+        [
+          "Annotation",
+          "/example",
+          "#/example",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/example", "#/example", "", {"name": "Rex", "petType": "dog"} ]
+        [
+          true,
+          "Annotation",
+          "/example",
+          "#/example",
+          "",
+          {
+            "name": "Rex",
+            "petType": "dog"
+          }
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"example\" was collected as the annotation {\"name\":\"Rex\",\"petType\":\"dog\"}"
@@ -1675,16 +4444,35 @@
     "description": "items_integer_bounded_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 50, 99 ],
+    "instance": [
+      10,
+      50,
+      99
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -1692,32 +4480,165 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1739,16 +4660,35 @@
     "description": "items_integer_bounded_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 200, 50 ],
+    "instance": [
+      10,
+      200,
+      50
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -1756,20 +4696,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1785,16 +4791,33 @@
     "description": "items_integer_bounded_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ "foo" ],
+    "instance": [
+      "foo"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -1802,12 +4825,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string",
@@ -1819,7 +4864,11 @@
     "description": "items_integer_bounded_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": "not an array",
     "valid": true,
@@ -1830,7 +4879,11 @@
     "description": "items_integer_bounded_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": [],
     "valid": true,
@@ -1841,16 +4894,34 @@
     "description": "items_integer_bounded_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10.5, 99.9 ],
+    "instance": [
+      10.5,
+      99.9
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -1858,26 +4929,126 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1896,28 +5067,112 @@
     "description": "items_integer_bounded_7_real_bounds",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0.5, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0.5,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 50 ],
+    "instance": [
+      1,
+      50
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1931,26 +5186,126 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1969,16 +5324,34 @@
     "description": "items_integer_bounded_8_boundary_values",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 0, 100 ],
+    "instance": [
+      0,
+      100
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -1986,26 +5359,126 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -2032,31 +5505,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 50 was expected to be less than or equal to the integer 100",
-        "The integer value 50 was expected to be greater than or equal to the integer 0"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2077,26 +5588,56 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 200 was expected to be less than or equal to the integer 100"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2116,31 +5657,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 0 was expected to be less than or equal to the integer 100",
-        "The integer value 0 was expected to be greater than or equal to the integer 0"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2161,31 +5740,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 100 was expected to be less than or equal to the integer 100",
-        "The integer value 100 was expected to be greater than or equal to the integer 0"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2206,21 +5823,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer but it was of type number"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number"
@@ -2239,21 +5878,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer but it was of type string"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type string"
@@ -2271,26 +5932,56 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 5 was expected to be greater than or equal to the integer 1"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2309,26 +6000,56 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer",
-        "The integer value 0 was expected to be greater than or equal to the integer 1"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ],
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2347,21 +6068,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer but it was of type number"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number"
@@ -2372,16 +6115,35 @@
     "description": "prop_type_integer_bounded_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 50 },
+    "instance": {
+      "x": 50
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2389,18 +6151,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2415,16 +6233,35 @@
     "description": "prop_type_integer_bounded_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 200 },
+    "instance": {
+      "x": 200
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2432,14 +6269,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2452,16 +6322,35 @@
     "description": "prop_type_integer_bounded_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": -1 },
+    "instance": {
+      "x": -1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2469,16 +6358,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2492,16 +6425,35 @@
     "description": "prop_type_integer_bounded_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2509,18 +6461,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2535,16 +6543,35 @@
     "description": "prop_type_integer_bounded_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 100 },
+    "instance": {
+      "x": 100
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2552,18 +6579,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2578,16 +6661,35 @@
     "description": "prop_type_integer_bounded_7",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 3.5 },
+    "instance": {
+      "x": 3.5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2595,12 +6697,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number",
@@ -2612,16 +6736,35 @@
     "description": "prop_type_integer_bounded_8",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": "hello" },
+    "instance": {
+      "x": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -2629,12 +6772,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type string",
@@ -2646,17 +6811,34 @@
     "description": "prop_type_integer_bounded_9",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -2667,16 +6849,34 @@
     "description": "prop_type_integer_lower_bound_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5 },
+    "instance": {
+      "x": 5
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -2684,16 +6884,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2707,16 +6952,34 @@
     "description": "prop_type_integer_lower_bound_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -2724,14 +6987,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2744,16 +7040,34 @@
     "description": "prop_type_integer_lower_bound_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 1 },
+    "instance": {
+      "x": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -2761,16 +7075,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2784,16 +7143,34 @@
     "description": "prop_type_integer_lower_bound_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5.5 },
+    "instance": {
+      "x": 5.5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -2801,12 +7178,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number",
@@ -2818,17 +7217,33 @@
     "description": "prop_type_integer_lower_bound_6",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -2840,17 +7255,41 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": 42 },
+    "instance": {
+      "a": "hello",
+      "b": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -2858,22 +7297,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionType", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -2891,17 +7409,40 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -2909,10 +7450,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -2924,17 +7476,41 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": 123, "b": 42 },
+    "instance": {
+      "a": 123,
+      "b": 42
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -2942,14 +7518,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -2963,16 +7572,37 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "x": "hello", "y": 42 },
+    "instance": {
+      "x": "hello",
+      "y": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -2980,20 +7610,88 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "x" ],
-        [ true, "AssertionType", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "y" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "y"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3010,16 +7708,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3027,12 +7743,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined properties subschemas",
@@ -3045,16 +7783,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": "not an object",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3062,10 +7818,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type string"
@@ -3077,16 +7844,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "extra": 999 },
+    "instance": {
+      "a": "hello",
+      "extra": 999
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3094,16 +7879,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3118,17 +7948,39 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3136,18 +7988,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -3165,14 +8073,27 @@
       "type": "object",
       "properties": {}
     },
-    "instance": { "anything": true },
+    "instance": {
+      "anything": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -3180,10 +8101,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -3195,17 +8127,38 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": "anything" },
+    "instance": {
+      "a": "hello",
+      "b": "anything"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3213,18 +8166,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -3240,17 +8249,37 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3258,10 +8287,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -3274,17 +8314,39 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": "hello" } },
+    "instance": {
+      "inner": {
+        "x": "hello"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3292,22 +8354,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ "Annotation", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          "Annotation",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ true, "Annotation", "/properties/inner/properties", "#/properties/inner/properties", "/inner", "x" ],
-        [ true, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ true, "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "inner" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "inner"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3326,17 +8467,39 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": 123 } },
+    "instance": {
+      "inner": {
+        "x": 123
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3344,14 +8507,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ false, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -3365,21 +8561,64 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "patternProperties": { "^b": { "type": "integer" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -3389,18 +8628,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -3416,21 +8711,60 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3440,18 +8774,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3467,23 +8857,79 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "anyOf": [ { "required": [ "a" ] } ]
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "a"
+          ]
+        }
+      ]
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -3494,20 +8940,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -3524,19 +9037,47 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "minProperties": 1
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -3545,18 +9086,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 1 property and it contained 1 property: \"a\"",
@@ -3573,19 +9170,51 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "$dynamicRef": "#foo",
-      "properties": { "a": { "type": "string" } },
-      "$defs": { "bar": { "$dynamicAnchor": "foo" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "$defs": {
+        "bar": {
+          "$dynamicAnchor": "foo"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3594,18 +9223,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "ControlJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/$dynamicRef", "#/$dynamicRef", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "ControlJump",
+          "/$dynamicRef",
+          "#/$dynamicRef",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the referenced schema",
@@ -3620,26 +9305,59 @@
     "description": "inline_ref_does_not_drop_sibling_required_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "required": [ "x" ],
+      "required": [
+        "x"
+      ],
       "$ref": "#/$defs/sub",
       "$defs": {
         "sub": {
           "type": "object",
-          "properties": { "a": { "type": "string" } },
-          "required": [ "a" ]
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "a"
+          ]
         }
       }
     },
-    "instance": { "a": "hello", "x": 1 },
+    "instance": {
+      "a": "hello",
+      "x": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ true, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -3648,22 +9366,100 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "#/$ref", "" ],
-        [ "AssertionDefinesStrict", "/$ref/required", "#/$defs/sub/required", "" ],
-        [ "LogicalWhenType", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionTypeStrict", "/$ref/properties/a/type", "#/$defs/sub/properties/a/type", "/a" ],
-        [ "Annotation", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "#/$defs/sub/type", "" ],
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/$ref/required",
+          "#/$defs/sub/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/properties/a/type",
+          "#/$defs/sub/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/sub/type",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/$ref/required", "#/$defs/sub/required", "" ],
-        [ true, "AssertionTypeStrict", "/$ref/properties/a/type", "#/$defs/sub/properties/a/type", "/a" ],
-        [ true, "Annotation", "/$ref/properties", "#/$defs/sub/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ true, "AssertionTypeStrict", "/$ref/type", "#/$defs/sub/type", "" ],
-        [ true, "ControlJump", "/$ref", "#/$ref", "" ],
-        [ true, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/$ref/required",
+          "#/$defs/sub/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/properties/a/type",
+          "#/$defs/sub/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/sub/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -3680,26 +9476,58 @@
     "description": "inline_ref_does_not_drop_sibling_required_invalid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "required": [ "x" ],
+      "required": [
+        "x"
+      ],
       "$ref": "#/$defs/sub",
       "$defs": {
         "sub": {
           "type": "object",
-          "properties": { "a": { "type": "string" } },
-          "required": [ "a" ]
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "a"
+          ]
         }
       }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ false, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -3708,22 +9536,100 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "#/$ref", "" ],
-        [ "AssertionDefinesStrict", "/$ref/required", "#/$defs/sub/required", "" ],
-        [ "LogicalWhenType", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionTypeStrict", "/$ref/properties/a/type", "#/$defs/sub/properties/a/type", "/a" ],
-        [ "Annotation", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "#/$defs/sub/type", "" ],
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/$ref/required",
+          "#/$defs/sub/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/properties/a/type",
+          "#/$defs/sub/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/sub/type",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/$ref/required", "#/$defs/sub/required", "" ],
-        [ true, "AssertionTypeStrict", "/$ref/properties/a/type", "#/$defs/sub/properties/a/type", "/a" ],
-        [ true, "Annotation", "/$ref/properties", "#/$defs/sub/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/$ref/properties", "#/$defs/sub/properties", "" ],
-        [ true, "AssertionTypeStrict", "/$ref/type", "#/$defs/sub/type", "" ],
-        [ true, "ControlJump", "/$ref", "#/$ref", "" ],
-        [ false, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/$ref/required",
+          "#/$defs/sub/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/properties/a/type",
+          "#/$defs/sub/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/$ref/properties",
+          "#/$defs/sub/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "#/$defs/sub/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "#/$ref",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -3741,24 +9647,85 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "b": { "$ref": "#/$defs/num" } },
-      "required": [ "a" ],
-      "$defs": { "num": { "type": "number", "minimum": 0 } }
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "$ref": "#/$defs/num"
+        }
+      },
+      "required": [
+        "a"
+      ],
+      "$defs": {
+        "num": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
     },
-    "instance": { "a": "hello", "b": 42 },
+    "instance": {
+      "a": "hello",
+      "b": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionPropertyTypeStrictAny", "/properties/b/$ref/type", "#/$defs/num/type", "/b" ],
-        [ "AssertionGreaterEqual", "/properties/b/$ref/minimum", "#/$defs/num/minimum", "/b" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/properties/b/$ref/type",
+          "#/$defs/num/type",
+          "/b"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/b/$ref/minimum",
+          "#/$defs/num/minimum",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionPropertyTypeStrictAny", "/properties/b/$ref/type", "#/$defs/num/type", "/b" ],
-        [ true, "AssertionGreaterEqual", "/properties/b/$ref/minimum", "#/$defs/num/minimum", "/b" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/properties/b/$ref/type",
+          "#/$defs/num/type",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/b/$ref/minimum",
+          "#/$defs/num/minimum",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -3769,26 +9736,127 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/b/$ref", "#/properties/b/$ref", "/b" ],
-        [ "AssertionTypeStrictAny", "/properties/b/$ref/type", "#/$defs/num/type", "/b" ],
-        [ "AssertionGreaterEqual", "/properties/b/$ref/minimum", "#/$defs/num/minimum", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/b/$ref",
+          "#/properties/b/$ref",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/b/$ref/type",
+          "#/$defs/num/type",
+          "/b"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/b/$ref/minimum",
+          "#/$defs/num/minimum",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionTypeStrictAny", "/properties/b/$ref/type", "#/$defs/num/type", "/b" ],
-        [ true, "AssertionGreaterEqual", "/properties/b/$ref/minimum", "#/$defs/num/minimum", "/b" ],
-        [ true, "ControlJump", "/properties/b/$ref", "#/properties/b/$ref", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/b/$ref/type",
+          "#/$defs/num/type",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/b/$ref/minimum",
+          "#/$defs/num/minimum",
+          "/b"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/b/$ref",
+          "#/properties/b/$ref",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -3809,40 +9877,137 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "p0": { "type": "string" },
-        "p1": { "type": "string" },
-        "p2": { "type": "string" },
-        "p3": { "type": "string" },
-        "p4": { "type": "string" },
-        "p5": { "type": "string" },
-        "p6": { "type": "string" },
-        "p7": { "type": "string" },
-        "p8": { "type": "string" },
-        "p9": { "type": "string" },
-        "p10": { "type": "string" },
-        "p11": { "type": "string" },
-        "p12": { "type": "string" },
-        "p13": { "type": "string" },
-        "p14": { "type": "string" },
-        "p15": { "type": "string" },
-        "p16": { "type": "string" },
-        "p17": { "type": "string" },
-        "p18": { "type": "string" },
-        "p19": { "type": "string" },
-        "p20": { "type": "string" },
-        "p21": { "type": "string" },
-        "p22": { "type": "string" },
-        "p23": { "type": "string" },
-        "p24": { "type": "string" },
-        "p25": { "type": "string" },
-        "p26": { "type": "string" },
-        "p27": { "type": "string" },
-        "p28": { "type": "string" },
-        "p29": { "type": "string" },
-        "p30": { "type": "string" },
-        "p31": { "type": "string" }
+        "p0": {
+          "type": "string"
+        },
+        "p1": {
+          "type": "string"
+        },
+        "p2": {
+          "type": "string"
+        },
+        "p3": {
+          "type": "string"
+        },
+        "p4": {
+          "type": "string"
+        },
+        "p5": {
+          "type": "string"
+        },
+        "p6": {
+          "type": "string"
+        },
+        "p7": {
+          "type": "string"
+        },
+        "p8": {
+          "type": "string"
+        },
+        "p9": {
+          "type": "string"
+        },
+        "p10": {
+          "type": "string"
+        },
+        "p11": {
+          "type": "string"
+        },
+        "p12": {
+          "type": "string"
+        },
+        "p13": {
+          "type": "string"
+        },
+        "p14": {
+          "type": "string"
+        },
+        "p15": {
+          "type": "string"
+        },
+        "p16": {
+          "type": "string"
+        },
+        "p17": {
+          "type": "string"
+        },
+        "p18": {
+          "type": "string"
+        },
+        "p19": {
+          "type": "string"
+        },
+        "p20": {
+          "type": "string"
+        },
+        "p21": {
+          "type": "string"
+        },
+        "p22": {
+          "type": "string"
+        },
+        "p23": {
+          "type": "string"
+        },
+        "p24": {
+          "type": "string"
+        },
+        "p25": {
+          "type": "string"
+        },
+        "p26": {
+          "type": "string"
+        },
+        "p27": {
+          "type": "string"
+        },
+        "p28": {
+          "type": "string"
+        },
+        "p29": {
+          "type": "string"
+        },
+        "p30": {
+          "type": "string"
+        },
+        "p31": {
+          "type": "string"
+        }
       },
-      "required": [ "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18", "p19", "p20", "p21", "p22", "p23", "p24", "p25", "p26", "p27", "p28", "p29", "p30", "p31" ]
+      "required": [
+        "p0",
+        "p1",
+        "p2",
+        "p3",
+        "p4",
+        "p5",
+        "p6",
+        "p7",
+        "p8",
+        "p9",
+        "p10",
+        "p11",
+        "p12",
+        "p13",
+        "p14",
+        "p15",
+        "p16",
+        "p17",
+        "p18",
+        "p19",
+        "p20",
+        "p21",
+        "p22",
+        "p23",
+        "p24",
+        "p25",
+        "p26",
+        "p27",
+        "p28",
+        "p29",
+        "p30",
+        "p31"
+      ]
     },
     "instance": {
       "p0": "x",
@@ -3880,10 +10045,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -3891,10 +10067,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"p0\", \"p1\", \"p10\", \"p11\", \"p12\", \"p13\", \"p14\", \"p15\", \"p16\", \"p17\", \"p18\", \"p19\", \"p2\", \"p20\", \"p21\", \"p22\", \"p23\", \"p24\", \"p25\", \"p26\", \"p27\", \"p28\", \"p29\", \"p3\", \"p30\", \"p31\", \"p4\", \"p5\", \"p6\", \"p7\", \"p8\", and \"p9\""
@@ -3907,41 +10094,141 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "p0": { "type": "string" },
-        "p1": { "type": "string" },
-        "p2": { "type": "string" },
-        "p3": { "type": "string" },
-        "p4": { "type": "string" },
-        "p5": { "type": "string" },
-        "p6": { "type": "string" },
-        "p7": { "type": "string" },
-        "p8": { "type": "string" },
-        "p9": { "type": "string" },
-        "p10": { "type": "string" },
-        "p11": { "type": "string" },
-        "p12": { "type": "string" },
-        "p13": { "type": "string" },
-        "p14": { "type": "string" },
-        "p15": { "type": "string" },
-        "p16": { "type": "string" },
-        "p17": { "type": "string" },
-        "p18": { "type": "string" },
-        "p19": { "type": "string" },
-        "p20": { "type": "string" },
-        "p21": { "type": "string" },
-        "p22": { "type": "string" },
-        "p23": { "type": "string" },
-        "p24": { "type": "string" },
-        "p25": { "type": "string" },
-        "p26": { "type": "string" },
-        "p27": { "type": "string" },
-        "p28": { "type": "string" },
-        "p29": { "type": "string" },
-        "p30": { "type": "string" },
-        "p31": { "type": "string" },
-        "p32": { "type": "string" }
+        "p0": {
+          "type": "string"
+        },
+        "p1": {
+          "type": "string"
+        },
+        "p2": {
+          "type": "string"
+        },
+        "p3": {
+          "type": "string"
+        },
+        "p4": {
+          "type": "string"
+        },
+        "p5": {
+          "type": "string"
+        },
+        "p6": {
+          "type": "string"
+        },
+        "p7": {
+          "type": "string"
+        },
+        "p8": {
+          "type": "string"
+        },
+        "p9": {
+          "type": "string"
+        },
+        "p10": {
+          "type": "string"
+        },
+        "p11": {
+          "type": "string"
+        },
+        "p12": {
+          "type": "string"
+        },
+        "p13": {
+          "type": "string"
+        },
+        "p14": {
+          "type": "string"
+        },
+        "p15": {
+          "type": "string"
+        },
+        "p16": {
+          "type": "string"
+        },
+        "p17": {
+          "type": "string"
+        },
+        "p18": {
+          "type": "string"
+        },
+        "p19": {
+          "type": "string"
+        },
+        "p20": {
+          "type": "string"
+        },
+        "p21": {
+          "type": "string"
+        },
+        "p22": {
+          "type": "string"
+        },
+        "p23": {
+          "type": "string"
+        },
+        "p24": {
+          "type": "string"
+        },
+        "p25": {
+          "type": "string"
+        },
+        "p26": {
+          "type": "string"
+        },
+        "p27": {
+          "type": "string"
+        },
+        "p28": {
+          "type": "string"
+        },
+        "p29": {
+          "type": "string"
+        },
+        "p30": {
+          "type": "string"
+        },
+        "p31": {
+          "type": "string"
+        },
+        "p32": {
+          "type": "string"
+        }
       },
-      "required": [ "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18", "p19", "p20", "p21", "p22", "p23", "p24", "p25", "p26", "p27", "p28", "p29", "p30", "p31", "p32" ]
+      "required": [
+        "p0",
+        "p1",
+        "p2",
+        "p3",
+        "p4",
+        "p5",
+        "p6",
+        "p7",
+        "p8",
+        "p9",
+        "p10",
+        "p11",
+        "p12",
+        "p13",
+        "p14",
+        "p15",
+        "p16",
+        "p17",
+        "p18",
+        "p19",
+        "p20",
+        "p21",
+        "p22",
+        "p23",
+        "p24",
+        "p25",
+        "p26",
+        "p27",
+        "p28",
+        "p29",
+        "p30",
+        "p31",
+        "p32"
+      ]
     },
     "instance": {
       "p0": "x",
@@ -3980,10 +10267,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"p0\", \"p1\", \"p10\", \"p11\", \"p12\", \"p13\", \"p14\", \"p15\", \"p16\", \"p17\", \"p18\", \"p19\", \"p2\", \"p20\", \"p21\", \"p22\", \"p23\", \"p24\", \"p25\", \"p26\", \"p27\", \"p28\", \"p29\", \"p3\", \"p30\", \"p31\", \"p32\", \"p4\", \"p5\", \"p6\", \"p7\", \"p8\", and \"p9\""
@@ -3991,10 +10289,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"p0\", \"p1\", \"p10\", \"p11\", \"p12\", \"p13\", \"p14\", \"p15\", \"p16\", \"p17\", \"p18\", \"p19\", \"p2\", \"p20\", \"p21\", \"p22\", \"p23\", \"p24\", \"p25\", \"p26\", \"p27\", \"p28\", \"p29\", \"p3\", \"p30\", \"p31\", \"p32\", \"p4\", \"p5\", \"p6\", \"p7\", \"p8\", and \"p9\""
@@ -4007,20 +10316,45 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "string" },
-        "c": { "type": "string" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        },
+        "c": {
+          "type": "string"
+        }
       },
-      "required": [ "a", "b", "c" ]
+      "required": [
+        "a",
+        "b",
+        "c"
+      ]
     },
-    "instance": { "a": "x", "b": 42, "c": "z" },
+    "instance": {
+      "a": "x",
+      "b": 42,
+      "c": "z"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4028,18 +10362,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ false, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", \"b\", and \"c\"",
@@ -4055,17 +10445,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "required": [ "a" ]
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a"
+      ]
     },
     "instance": "hello",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4073,10 +10480,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\""
@@ -4088,16 +10506,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4105,12 +10541,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined properties subschemas",
@@ -4124,20 +10582,44 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "string" },
-        "opt": { "type": "integer" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        },
+        "opt": {
+          "type": "integer"
+        }
       },
-      "required": [ "a", "b" ]
+      "required": [
+        "a",
+        "b"
+      ]
     },
-    "instance": { "a": "x", "b": "y", "extra": 99 },
+    "instance": {
+      "a": "x",
+      "b": "y",
+      "extra": 99
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4145,22 +10627,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -4175,15 +10736,29 @@
   },
   {
     "description": "empty_enum_string",
-    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "enum": [] },
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "enum": []
+    },
     "instance": "foo",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was not expected to validate against the empty enumeration"
@@ -4191,10 +10766,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was not expected to validate against the empty enumeration"
@@ -4203,15 +10789,29 @@
   },
   {
     "description": "empty_enum_integer",
-    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "enum": [] },
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "enum": []
+    },
     "instance": 42,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was not expected to validate against the empty enumeration"
@@ -4219,10 +10819,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was not expected to validate against the empty enumeration"
@@ -4240,10 +10851,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4251,10 +10873,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4272,10 +10905,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4283,10 +10927,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4299,16 +10954,32 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.example.com",
       "$ref": "#/$defs/test",
-      "$defs": { "test": { "$id": "", "type": "string" } }
+      "$defs": {
+        "test": {
+          "$id": "",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4316,12 +10987,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ],
-        [ true, "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4335,16 +11028,32 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.example.com",
       "$ref": "#/$defs/test",
-      "$defs": { "test": { "$id": "#", "type": "string" } }
+      "$defs": {
+        "test": {
+          "$id": "#",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4352,12 +11061,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ],
-        [ "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/$ref/type", "https://www.example.com#/$defs/test/type", "" ],
-        [ true, "ControlJump", "/$ref", "https://www.example.com#/$ref", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/$ref/type",
+          "https://www.example.com#/$defs/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://www.example.com#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4387,10 +11118,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4398,10 +11140,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -4430,10 +11183,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -4441,10 +11205,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "https://example.com/schema#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -4461,7 +11236,9 @@
         "https://example.com/meta": {
           "$id": "https://example.com/meta",
           "$schema": "https://json-schema.org/draft/2020-12/schema",
-          "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true },
+          "$vocabulary": {
+            "https://json-schema.org/draft/2020-12/vocab/core": true
+          },
           "type": "object"
         }
       }
@@ -4471,10 +11248,22 @@
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/type", "https://example.com/schema#/type", "" ]
+        [
+          "Annotation",
+          "/type",
+          "https://example.com/schema#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/type", "https://example.com/schema#/type", "", "string" ]
+        [
+          true,
+          "Annotation",
+          "/type",
+          "https://example.com/schema#/type",
+          "",
+          "string"
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"type\" was collected as the annotation \"string\""
@@ -4490,24 +11279,74 @@
         "presets": {
           "type": "array",
           "items": {
-            "type": [ "string", "array" ],
-            "prefixItems": [ { "type": "string" }, { "type": "object" } ]
+            "type": [
+              "string",
+              "array"
+            ],
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
           }
         }
       }
     },
-    "instance": { "presets": [ [ true, {} ] ] },
+    "instance": {
+      "presets": [
+        [
+          true,
+          {}
+        ]
+      ]
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
-        [ "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
-        [ "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ]
+        [
+          "LoopItemsFrom",
+          "/properties/presets/items",
+          "#/properties/presets/items",
+          "/presets"
+        ],
+        [
+          "AssertionArrayPrefix",
+          "/properties/presets/items/prefixItems",
+          "#/properties/presets/items/prefixItems",
+          "/presets/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/presets/items/prefixItems/0/type",
+          "#/properties/presets/items/prefixItems/0/type",
+          "/presets/0/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ],
-        [ false, "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
-        [ false, "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/presets/items/prefixItems/0/type",
+          "#/properties/presets/items/prefixItems/0/type",
+          "/presets/0/0"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/properties/presets/items/prefixItems",
+          "#/properties/presets/items/prefixItems",
+          "/presets/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/properties/presets/items",
+          "#/properties/presets/items",
+          "/presets"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -4517,16 +11356,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
-        [ "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
-        [ "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/presets/items",
+          "#/properties/presets/items",
+          "/presets"
+        ],
+        [
+          "AssertionArrayPrefix",
+          "/properties/presets/items/prefixItems",
+          "#/properties/presets/items/prefixItems",
+          "/presets/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/presets/items/prefixItems/0/type",
+          "#/properties/presets/items/prefixItems/0/type",
+          "/presets/0/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/presets/items/prefixItems/0/type", "#/properties/presets/items/prefixItems/0/type", "/presets/0/0" ],
-        [ false, "AssertionArrayPrefix", "/properties/presets/items/prefixItems", "#/properties/presets/items/prefixItems", "/presets/0" ],
-        [ false, "LoopItemsFrom", "/properties/presets/items", "#/properties/presets/items", "/presets" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/presets/items/prefixItems/0/type",
+          "#/properties/presets/items/prefixItems/0/type",
+          "/presets/0/0"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/properties/presets/items/prefixItems",
+          "#/properties/presets/items/prefixItems",
+          "/presets/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/properties/presets/items",
+          "#/properties/presets/items",
+          "/presets"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -4541,24 +11424,79 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "handle" ],
-      "properties": { "handle": { "enum": [ "filesystem" ] } },
+      "required": [
+        "handle"
+      ],
+      "properties": {
+        "handle": {
+          "enum": [
+            "filesystem"
+          ]
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "extra": "x", "handle": "filesystem" },
+    "instance": {
+      "extra": "x",
+      "handle": "filesystem"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/properties/handle/enum",
+          "#/properties/handle/enum",
+          "/handle"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/extra"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/properties/handle/enum",
+          "#/properties/handle/enum",
+          "/handle"
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/extra"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"handle\"",
@@ -4569,20 +11507,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/properties/handle/enum",
+          "#/properties/handle/enum",
+          "/handle"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/extra"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionEqual", "/properties/handle/enum", "#/properties/handle/enum", "/handle" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "handle" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/extra" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/properties/handle/enum",
+          "#/properties/handle/enum",
+          "/handle"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "handle"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/extra"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"handle\"",
@@ -4598,21 +11603,51 @@
     "description": "properties_closed_object_fast_path",
     "schema": {
       "type": "object",
-      "required": [ "foo" ],
+      "required": [
+        "foo"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "string" } },
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
       "$schema": "https://json-schema.org/draft/2020-12/schema"
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -4621,20 +11656,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -4651,19 +11753,41 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
-        "value": { "if": { "$comment": "always true" }, "then": { "type": "null" } }
+        "value": {
+          "if": {
+            "$comment": "always true"
+          },
+          "then": {
+            "type": "null"
+          }
+        }
       }
     },
-    "instance": { "value": null },
+    "instance": {
+      "value": null
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4671,18 +11795,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4698,26 +11878,68 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
-          "if": { "$comment": "always true" },
-          "then": { "type": "string", "pattern": "^f" }
+          "if": {
+            "$comment": "always true"
+          },
+          "then": {
+            "type": "string",
+            "pattern": "^f"
+          }
         }
       }
     },
-    "instance": { "value": "foo" },
+    "instance": {
+      "value": "foo"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
-        [ "AssertionPropertyTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/properties/value/then/pattern",
+          "#/properties/value/then/pattern",
+          "/value"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/value/then/pattern",
+          "#/properties/value/then/pattern",
+          "/value"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4727,20 +11949,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/properties/value/then/pattern",
+          "#/properties/value/then/pattern",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionRegex", "/properties/value/then/pattern", "#/properties/value/then/pattern", "/value" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/type", "#/properties/value/then/type", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/value/then/pattern",
+          "#/properties/value/then/pattern",
+          "/value"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/type",
+          "#/properties/value/then/type",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4757,21 +12046,36 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
           "$id": "https://example.com/dynamic-wrapper",
           "if": {
             "$id": "first_scope",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "number"
+              }
+            }
           },
           "then": {
             "$id": "second_scope",
             "$ref": "start",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "null"
+              }
+            }
           },
           "$defs": {
-            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "start": {
+              "$id": "start",
+              "$dynamicRef": "inner_scope#thingy"
+            },
             "thingy": {
               "$id": "inner_scope",
               "$dynamicAnchor": "thingy",
@@ -4781,14 +12085,27 @@
         }
       }
     },
-    "instance": { "value": null },
+    "instance": {
+      "value": null
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4796,24 +12113,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
-        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4832,15 +12238,28 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
           "$id": "https://example.com/dynamic-wrapper",
-          "if": { "$comment": "always true" },
-          "then": { "$id": "second_scope", "$ref": "start" },
+          "if": {
+            "$comment": "always true"
+          },
+          "then": {
+            "$id": "second_scope",
+            "$ref": "start"
+          },
           "$defs": {
-            "outer_thingy": { "$dynamicAnchor": "thingy", "type": "null" },
-            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "outer_thingy": {
+              "$dynamicAnchor": "thingy",
+              "type": "null"
+            },
+            "start": {
+              "$id": "start",
+              "$dynamicRef": "inner_scope#thingy"
+            },
             "thingy": {
               "$id": "inner_scope",
               "$dynamicAnchor": "thingy",
@@ -4850,14 +12269,27 @@
         }
       }
     },
-    "instance": { "value": null },
+    "instance": {
+      "value": null
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4865,24 +12297,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type", "/value" ],
-        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/dynamic-wrapper#/$defs/outer_thingy/type",
+          "/value"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4901,26 +12422,62 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value" ],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
           "$id": "https://example.com/static-wrapper",
-          "if": { "$comment": "always true" },
-          "then": { "$id": "second_scope", "$ref": "start" },
-          "$defs": { "start": { "$id": "start", "type": "null" } }
+          "if": {
+            "$comment": "always true"
+          },
+          "then": {
+            "$id": "second_scope",
+            "$ref": "start"
+          },
+          "$defs": {
+            "start": {
+              "$id": "start",
+              "type": "null"
+            }
+          }
         }
       }
     },
-    "instance": { "value": null },
+    "instance": {
+      "value": null
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/value/then/$ref/type",
+          "https://example.com/start#/type",
+          "/value"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/value/then/$ref/type",
+          "https://example.com/start#/type",
+          "/value"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4929,20 +12486,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/type",
+          "https://example.com/start#/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/type", "https://example.com/start#/type", "/value" ],
-        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/type",
+          "https://example.com/start#/type",
+          "/value"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"value\"",
@@ -4958,20 +12582,50 @@
     "description": "if_empty_else_only_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "$comment": "always true" },
-      "else": { "properties": { "x": true } },
+      "if": {
+        "$comment": "always true"
+      },
+      "else": {
+        "properties": {
+          "x": true
+        }
+      },
       "unevaluatedProperties": false
     },
-    "instance": { "x": 1 },
+    "instance": {
+      "x": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ]
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/x"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define the property \"x\"",
@@ -4980,12 +12634,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ]
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/x" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/x"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define the property \"x\"",
@@ -4997,8 +12673,12 @@
     "description": "if_empty_else_only_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "$comment": "always true" },
-      "else": { "type": "string" }
+      "if": {
+        "$comment": "always true"
+      },
+      "else": {
+        "type": "string"
+      }
     },
     "instance": 1,
     "valid": true,
@@ -5010,21 +12690,37 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value", "legacy" ],
+      "required": [
+        "value",
+        "legacy"
+      ],
       "properties": {
         "value": {
           "$id": "https://example.com/dynamic-wrapper",
           "if": {
             "$id": "first_scope",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "number"
+              }
+            }
           },
           "then": {
             "$id": "second_scope",
             "$ref": "start",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "null"
+              }
+            }
           },
           "$defs": {
-            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "start": {
+              "$id": "start",
+              "$dynamicRef": "inner_scope#thingy"
+            },
             "thingy": {
               "$id": "inner_scope",
               "$dynamicAnchor": "thingy",
@@ -5032,40 +12728,151 @@
             }
           }
         },
-        "legacy": { "$ref": "https://example.com/legacy" }
+        "legacy": {
+          "$ref": "https://example.com/legacy"
+        }
       },
       "$defs": {
         "legacy": {
           "$schema": "http://json-schema.org/draft-03/schema#",
           "id": "https://example.com/legacy",
-          "extends": [ { "type": "string" }, { "minLength": 2 } ]
+          "extends": [
+            {
+              "type": "string"
+            },
+            {
+              "minLength": 2
+            }
+          ]
         }
       }
     },
-    "instance": { "value": null, "legacy": "ab" },
+    "instance": {
+      "value": null,
+      "legacy": "ab"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ true, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ true, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ true, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
-        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
@@ -5081,34 +12888,179 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ true, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ true, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ true, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "legacy" ],
-        [ true, "AssertionTypeStrict", "/properties/value/then/$ref/$dynamicRef/type", "https://example.com/second_scope#/$defs/thingy/type", "/value" ],
-        [ true, "ControlDynamicAnchorJump", "/properties/value/then/$ref/$dynamicRef", "https://example.com/start#/$dynamicRef", "/value" ],
-        [ true, "ControlJump", "/properties/value/then/$ref", "https://example.com/second_scope#/$ref", "/value" ],
-        [ true, "LogicalAnd", "/properties/value/then", "https://example.com/dynamic-wrapper#/then", "/value" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "value" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "legacy"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/value/then/$ref/$dynamicRef/type",
+          "https://example.com/second_scope#/$defs/thingy/type",
+          "/value"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/properties/value/then/$ref/$dynamicRef",
+          "https://example.com/start#/$dynamicRef",
+          "/value"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/value/then/$ref",
+          "https://example.com/second_scope#/$ref",
+          "/value"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/value/then",
+          "https://example.com/dynamic-wrapper#/then",
+          "/value"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "value"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
@@ -5132,21 +13084,37 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "value", "legacy" ],
+      "required": [
+        "value",
+        "legacy"
+      ],
       "properties": {
         "value": {
           "$id": "https://example.com/dynamic-wrapper",
           "if": {
             "$id": "first_scope",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "number" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "number"
+              }
+            }
           },
           "then": {
             "$id": "second_scope",
             "$ref": "start",
-            "$defs": { "thingy": { "$dynamicAnchor": "thingy", "type": "null" } }
+            "$defs": {
+              "thingy": {
+                "$dynamicAnchor": "thingy",
+                "type": "null"
+              }
+            }
           },
           "$defs": {
-            "start": { "$id": "start", "$dynamicRef": "inner_scope#thingy" },
+            "start": {
+              "$id": "start",
+              "$dynamicRef": "inner_scope#thingy"
+            },
             "thingy": {
               "$id": "inner_scope",
               "$dynamicAnchor": "thingy",
@@ -5154,32 +13122,99 @@
             }
           }
         },
-        "legacy": { "$ref": "https://example.com/legacy" }
+        "legacy": {
+          "$ref": "https://example.com/legacy"
+        }
       },
       "$defs": {
         "legacy": {
           "$schema": "http://json-schema.org/draft-03/schema#",
           "id": "https://example.com/legacy",
-          "extends": [ { "type": "string" }, { "minLength": 2 } ]
+          "extends": [
+            {
+              "type": "string"
+            },
+            {
+              "minLength": 2
+            }
+          ]
         }
       }
     },
-    "instance": { "value": null, "legacy": "a" },
+    "instance": {
+      "value": null,
+      "legacy": "a"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ false, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ false, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ false, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
@@ -5191,20 +13226,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/legacy/$ref/extends/0/type", "https://example.com/legacy#/extends/0/type", "/legacy" ],
-        [ false, "AssertionStringSizeGreater", "/properties/legacy/$ref/extends/1/minLength", "https://example.com/legacy#/extends/1/minLength", "/legacy" ],
-        [ false, "LogicalAnd", "/properties/legacy/$ref/extends", "https://example.com/legacy#/extends", "/legacy" ],
-        [ false, "ControlJump", "/properties/legacy/$ref", "#/properties/legacy/$ref", "/legacy" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/legacy/$ref/extends/0/type",
+          "https://example.com/legacy#/extends/0/type",
+          "/legacy"
+        ],
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/properties/legacy/$ref/extends/1/minLength",
+          "https://example.com/legacy#/extends/1/minLength",
+          "/legacy"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/properties/legacy/$ref/extends",
+          "https://example.com/legacy#/extends",
+          "/legacy"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/legacy/$ref",
+          "#/properties/legacy/$ref",
+          "/legacy"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"legacy\", and \"value\"",
@@ -5228,10 +13329,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5239,10 +13351,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
@@ -5257,14 +13380,28 @@
       "minItems": 3,
       "maxItems": 1
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5272,10 +13409,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 1 item but it contained 2 items"
@@ -5290,14 +13438,28 @@
       "minProperties": 3,
       "maxProperties": 1
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5305,10 +13467,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
@@ -5322,14 +13495,29 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2, "c": 3 },
+    "instance": {
+      "a": 1,
+      "b": 2,
+      "c": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -5337,10 +13525,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
@@ -5354,14 +13553,28 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -5369,12 +13582,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -5389,14 +13624,27 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -5404,10 +13652,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
@@ -5421,14 +13680,28 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -5436,12 +13709,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -5456,14 +13751,29 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -5471,10 +13781,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -5488,14 +13809,28 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -5503,12 +13838,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -5523,14 +13880,27 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -5538,10 +13908,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items but it contained 1 item"
@@ -5555,14 +13936,28 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -5570,12 +13965,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 2 items",
@@ -5594,10 +14011,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -5605,10 +14033,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
@@ -5626,10 +14065,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -5637,12 +14087,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -5661,10 +14133,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -5672,10 +14155,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
@@ -5693,10 +14187,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -5704,12 +14209,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
@@ -5721,18 +14248,44 @@
     "description": "property_names_type_null",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "null" }
+      "propertyNames": {
+        "type": "null"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5741,12 +14294,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5758,16 +14333,29 @@
     "description": "property_names_type_null_empty_object",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "null" }
+      "propertyNames": {
+        "type": "null"
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object is empty and no properties were expected to validate against the given subschema"
@@ -5775,10 +14363,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object is empty and no properties were expected to validate against the given subschema"
@@ -5789,9 +14388,13 @@
     "description": "property_names_type_string",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "string" }
+      "propertyNames": {
+        "type": "string"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5808,9 +14411,16 @@
     "description": "property_names_type_string_or_boolean",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": [ "string", "boolean" ] }
+      "propertyNames": {
+        "type": [
+          "string",
+          "boolean"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5827,18 +14437,47 @@
     "description": "property_names_type_number_or_boolean",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": [ "number", "boolean" ] }
+      "propertyNames": {
+        "type": [
+          "number",
+          "boolean"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5847,12 +14486,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5864,9 +14525,16 @@
     "description": "property_names_type_string_or_null",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": [ "string", "null" ] }
+      "propertyNames": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5883,20 +14551,59 @@
     "description": "property_names_not_type_null",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "not": { "type": "null" } }
+      "propertyNames": {
+        "not": {
+          "type": "null"
+        }
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
-        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5906,14 +14613,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
-        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5926,18 +14666,45 @@
     "description": "property_names_type_string_max_length",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "string", "maxLength": 3 }
+      "propertyNames": {
+        "type": "string",
+        "maxLength": 3
+      }
     },
-    "instance": { "abcdefgh": 1 },
+    "instance": {
+      "abcdefgh": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
@@ -5946,12 +14713,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
@@ -5963,18 +14752,45 @@
     "description": "property_names_type_string_max_length_within",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "string", "maxLength": 3 }
+      "propertyNames": {
+        "type": "string",
+        "maxLength": 3
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
@@ -5983,12 +14799,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
@@ -6000,18 +14838,45 @@
     "description": "property_names_type_string_min_length",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "string", "minLength": 4 }
+      "propertyNames": {
+        "type": "string",
+        "minLength": 4
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
@@ -6020,12 +14885,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
@@ -6038,16 +14925,31 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
     "instance": "hello",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type string"
@@ -6055,10 +14957,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type string"
@@ -6070,16 +14983,33 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type object"
@@ -6087,10 +15017,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type object"
@@ -6102,16 +15043,31 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
     "instance": null,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type null"
@@ -6119,10 +15075,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type null"
@@ -6134,18 +15101,47 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": [ 2, 3 ],
+    "instance": [
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -6154,28 +15150,139 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -6196,16 +15303,33 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": [ 99 ],
+    "instance": [
+      99
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -6213,14 +15337,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -6233,16 +15390,30 @@
     "description": "type_array_partially_unknown_names",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": [ "string", "foo" ]
+      "type": [
+        "string",
+        "foo"
+      ]
     },
     "instance": "x",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -6250,10 +15421,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -6264,7 +15446,10 @@
     "description": "type_array_unknown_names",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": [ "foo", "bar" ]
+      "type": [
+        "foo",
+        "bar"
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -6283,9 +15468,15 @@
     "description": "property_names_type_unknown_names",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": [ "foo" ] }
+      "propertyNames": {
+        "type": [
+          "foo"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -6294,9 +15485,13 @@
     "description": "property_names_type_unknown_name_scalar",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "propertyNames": { "type": "foo" }
+      "propertyNames": {
+        "type": "foo"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -6312,10 +15507,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type null"
@@ -6323,10 +15529,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type null"
@@ -6340,14 +15557,27 @@
       "type": "object",
       "required": []
     },
-    "instance": { "k": 1 },
+    "instance": {
+      "k": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6355,10 +15585,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6369,21 +15610,62 @@
     "description": "pattern_properties_nonboolean_additional",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "enum": [] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "enum": []
+      }
     },
-    "instance": { "zzz": 1 },
+    "instance": {
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
@@ -6393,14 +15675,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
@@ -6413,21 +15728,62 @@
     "description": "pattern_properties_nonboolean_additional_matching",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "enum": [] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "enum": []
+      }
     },
-    "instance": { "ab": "x" },
+    "instance": {
+      "ab": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6437,16 +15793,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ "Annotation", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          "Annotation",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ true, "Annotation", "/patternProperties", "#/patternProperties", "", "ab" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          true,
+          "Annotation",
+          "/patternProperties",
+          "#/patternProperties",
+          "",
+          "ab"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6460,19 +15861,49 @@
     "description": "pattern_properties_nonboolean_additional_bad_type",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "enum": [] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "enum": []
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -6481,12 +15912,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -6498,21 +15951,65 @@
     "description": "closed_properties_nonboolean_additional",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
-      "additionalProperties": { "enum": [] }
+      "properties": {
+        "a": {},
+        "b": {},
+        "c": {},
+        "d": {},
+        "e": {},
+        "f": {}
+      },
+      "additionalProperties": {
+        "enum": []
+      }
     },
-    "instance": { "zzz": 1 },
+    "instance": {
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6522,14 +16019,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/enum", "#/additionalProperties/enum", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/enum",
+          "#/additionalProperties/enum",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6542,19 +16072,52 @@
     "description": "closed_properties_nonboolean_additional_known",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
-      "additionalProperties": { "enum": [] }
+      "properties": {
+        "a": {},
+        "b": {},
+        "c": {},
+        "d": {},
+        "e": {},
+        "f": {}
+      },
+      "additionalProperties": {
+        "enum": []
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6563,14 +16126,48 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property \"a\" successfully validated against its property subschema",
@@ -6585,27 +16182,80 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "integer" },
-        "c": { "type": "boolean" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        },
+        "c": {
+          "type": "boolean"
+        }
       },
       "patternProperties": {},
       "additionalProperties": false
     },
-    "instance": { "a": "x", "zzz": 1 },
+    "instance": {
+      "a": "x",
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6616,18 +16266,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6644,27 +16350,79 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "integer" },
-        "c": { "type": "boolean" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        },
+        "c": {
+          "type": "boolean"
+        }
       },
       "patternProperties": {},
       "additionalProperties": false
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6675,18 +16433,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6702,18 +16516,53 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "properties": { "c": { "type": "string", "minLength": 2 } } } }
+      "properties": {
+        "a": {
+          "properties": {
+            "c": {
+              "type": "string",
+              "minLength": 2
+            }
+          }
+        }
+      }
     },
-    "instance": { "a": { "c": "xy" } },
+    "instance": {
+      "a": {
+        "c": "xy"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters",
@@ -6722,22 +16571,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/a/properties", "#/properties/a/properties", "/a" ],
-        [ "AssertionStringSizeGreater", "/properties/a/properties/c/minLength", "#/properties/a/properties/c/minLength", "/a/c" ],
-        [ "AssertionTypeStrict", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ],
-        [ "Annotation", "/properties/a/properties", "#/properties/a/properties", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/a/properties/c/minLength",
+          "#/properties/a/properties/c/minLength",
+          "/a/c"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ],
+        [
+          "Annotation",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/properties/a/properties/c/minLength", "#/properties/a/properties/c/minLength", "/a/c" ],
-        [ true, "AssertionTypeStrict", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ],
-        [ true, "Annotation", "/properties/a/properties", "#/properties/a/properties", "/a", "c" ],
-        [ true, "LogicalWhenType", "/properties/a/properties", "#/properties/a/properties", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/a/properties/c/minLength",
+          "#/properties/a/properties/c/minLength",
+          "/a/c"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a",
+          "c"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xy\" was expected to consist of at least 2 characters and it consisted of 2 characters",
@@ -6755,16 +16683,40 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "properties": { "c": { "type": "string", "minLength": 2 } } } }
+      "properties": {
+        "a": {
+          "properties": {
+            "c": {
+              "type": "string",
+              "minLength": 2
+            }
+          }
+        }
+      }
     },
-    "instance": { "a": { "c": "x" } },
+    "instance": {
+      "a": {
+        "c": "x"
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ]
+        [
+          "AssertionTypeStringBounded",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringBounded", "/properties/a/properties/c/type", "#/properties/a/properties/c/type", "/a/c" ]
+        [
+          false,
+          "AssertionTypeStringBounded",
+          "/properties/a/properties/c/type",
+          "#/properties/a/properties/c/type",
+          "/a/c"
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -6772,14 +16724,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/a/properties", "#/properties/a/properties", "/a" ],
-        [ "AssertionStringSizeGreater", "/properties/a/properties/c/minLength", "#/properties/a/properties/c/minLength", "/a/c" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/a/properties/c/minLength",
+          "#/properties/a/properties/c/minLength",
+          "/a/c"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/properties/a/properties/c/minLength", "#/properties/a/properties/c/minLength", "/a/c" ],
-        [ false, "LogicalWhenType", "/properties/a/properties", "#/properties/a/properties", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/properties/a/properties/c/minLength",
+          "#/properties/a/properties/c/minLength",
+          "/a/c"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/a/properties",
+          "#/properties/a/properties",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at least 2 characters but it consisted of 1 character",
@@ -6793,16 +16778,38 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "properties": { "c": { "type": "string", "minLength": 2 } } } }
+      "properties": {
+        "a": {
+          "properties": {
+            "c": {
+              "type": "string",
+              "minLength": 2
+            }
+          }
+        }
+      }
     },
-    "instance": { "other": 1 },
+    "instance": {
+      "other": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6810,12 +16817,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -6833,23 +16862,58 @@
           "allOf": [
             {
               "type": "object",
-              "properties": { "x": { "type": "string", "maxLength": 4 } }
+              "properties": {
+                "x": {
+                  "type": "string",
+                  "maxLength": 4
+                }
+              }
             },
-            { "type": "object", "required": [ "d", "e" ] }
+            {
+              "type": "object",
+              "required": [
+                "d",
+                "e"
+              ]
+            }
           ]
         }
       }
     },
-    "instance": { "p": {} },
+    "instance": {
+      "p": {}
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ false, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -6858,18 +16922,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ false, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ false, "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -6890,23 +17009,60 @@
           "allOf": [
             {
               "type": "object",
-              "properties": { "x": { "type": "string", "maxLength": 4 } }
+              "properties": {
+                "x": {
+                  "type": "string",
+                  "maxLength": 4
+                }
+              }
             },
-            { "type": "object", "required": [ "d", "e" ] }
+            {
+              "type": "object",
+              "required": [
+                "d",
+                "e"
+              ]
+            }
           ]
         }
       }
     },
-    "instance": { "p": { "d": 1 } },
+    "instance": {
+      "p": {
+        "d": 1
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ false, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -6915,18 +17071,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ false, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ false, "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -6947,25 +17158,74 @@
           "allOf": [
             {
               "type": "object",
-              "properties": { "x": { "type": "string", "maxLength": 4 } }
+              "properties": {
+                "x": {
+                  "type": "string",
+                  "maxLength": 4
+                }
+              }
             },
-            { "type": "object", "required": [ "d", "e" ] }
+            {
+              "type": "object",
+              "required": [
+                "d",
+                "e"
+              ]
+            }
           ]
         }
       }
     },
-    "instance": { "p": { "d": 1, "e": 2 } },
+    "instance": {
+      "p": {
+        "d": 1,
+        "e": 2
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ true, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -6975,24 +17235,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/allOf/1/type", "#/properties/p/allOf/1/type", "/p" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/allOf/1/type",
+          "#/properties/p/allOf/1/type",
+          "/p"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/p/allOf/0/properties", "#/properties/p/allOf/0/properties", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/allOf/0/type", "#/properties/p/allOf/0/type", "/p" ],
-        [ true, "AssertionDefinesAllStrict", "/properties/p/allOf/1/required", "#/properties/p/allOf/1/required", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/allOf/1/type", "#/properties/p/allOf/1/type", "/p" ],
-        [ true, "LogicalAnd", "/properties/p/allOf", "#/properties/p/allOf", "/p" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "p" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/p/allOf/0/properties",
+          "#/properties/p/allOf/0/properties",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/allOf/0/type",
+          "#/properties/p/allOf/0/type",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/properties/p/allOf/1/required",
+          "#/properties/p/allOf/1/required",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/allOf/1/type",
+          "#/properties/p/allOf/1/type",
+          "/p"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/properties/p/allOf",
+          "#/properties/p/allOf",
+          "/p"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "p"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -7014,19 +17363,44 @@
       "properties": {
         "p": {
           "type": "object",
-          "properties": { "x": { "type": "string" }, "y": { "type": "string" } },
-          "required": [ "x", "y" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            },
+            "y": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ]
         }
       }
     },
-    "instance": { "p": { "x": "a" } },
+    "instance": {
+      "p": {
+        "x": "a"
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7034,12 +17408,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/required", "#/properties/p/required", "/p" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/required",
+          "#/properties/p/required",
+          "/p"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/properties/p/required", "#/properties/p/required", "/p" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/p/required",
+          "#/properties/p/required",
+          "/p"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"x\", and \"y\"",
@@ -7055,19 +17451,45 @@
       "properties": {
         "p": {
           "type": "object",
-          "properties": { "x": { "type": "string" }, "y": { "type": "string" } },
-          "required": [ "x", "y" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            },
+            "y": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ]
         }
       }
     },
-    "instance": { "p": { "x": "a", "y": "b" } },
+    "instance": {
+      "p": {
+        "x": "a",
+        "y": "b"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7075,28 +17497,141 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesAllStrict", "/properties/p/required", "#/properties/p/required", "/p" ],
-        [ "LogicalWhenType", "/properties/p/properties", "#/properties/p/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/properties/x/type", "#/properties/p/properties/x/type", "/p/x" ],
-        [ "Annotation", "/properties/p/properties", "#/properties/p/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/properties/y/type", "#/properties/p/properties/y/type", "/p/y" ],
-        [ "Annotation", "/properties/p/properties", "#/properties/p/properties", "/p" ],
-        [ "AssertionTypeStrict", "/properties/p/type", "#/properties/p/type", "/p" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/p/required",
+          "#/properties/p/required",
+          "/p"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/properties/x/type",
+          "#/properties/p/properties/x/type",
+          "/p/x"
+        ],
+        [
+          "Annotation",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/properties/y/type",
+          "#/properties/p/properties/y/type",
+          "/p/y"
+        ],
+        [
+          "Annotation",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/p/type",
+          "#/properties/p/type",
+          "/p"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/properties/p/required", "#/properties/p/required", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/properties/x/type", "#/properties/p/properties/x/type", "/p/x" ],
-        [ true, "Annotation", "/properties/p/properties", "#/properties/p/properties", "/p", "x" ],
-        [ true, "AssertionTypeStrict", "/properties/p/properties/y/type", "#/properties/p/properties/y/type", "/p/y" ],
-        [ true, "Annotation", "/properties/p/properties", "#/properties/p/properties", "/p", "y" ],
-        [ true, "LogicalWhenType", "/properties/p/properties", "#/properties/p/properties", "/p" ],
-        [ true, "AssertionTypeStrict", "/properties/p/type", "#/properties/p/type", "/p" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "p" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/properties/p/required",
+          "#/properties/p/required",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/properties/x/type",
+          "#/properties/p/properties/x/type",
+          "/p/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p",
+          "x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/properties/y/type",
+          "#/properties/p/properties/y/type",
+          "/p/y"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p",
+          "y"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/p/properties",
+          "#/properties/p/properties",
+          "/p"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/p/type",
+          "#/properties/p/type",
+          "/p"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "p"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"x\", and \"y\"",
@@ -7117,20 +17652,53 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "allOf": [
-        { "type": "object", "properties": { "foo": { "type": "string" } } },
-        { "required": [ "foo" ] }
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "required": [
+            "foo"
+          ]
+        }
       ]
     },
     "instance": {},
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -7139,16 +17707,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -7163,20 +17775,55 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "allOf": [
-        { "type": "object", "properties": { "foo": { "type": "string" } } },
-        { "required": [ "foo" ] }
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "required": [
+            "foo"
+          ]
+        }
       ]
     },
-    "instance": { "foo": "x" },
+    "instance": {
+      "foo": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -7185,20 +17832,87 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
-        [ "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/properties/foo/type",
+          "#/allOf/0/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
-        [ true, "Annotation", "/allOf/0/properties", "#/allOf/0/properties", "", "foo" ],
-        [ true, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ true, "AssertionDefines", "/allOf/1/required", "#/allOf/1/required", "" ],
-        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/properties/foo/type",
+          "#/allOf/0/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -7215,18 +17929,42 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "allOf": [
-        { "type": "object", "properties": { "foo": { "type": "string" } } },
-        { "required": [ "foo" ] }
+        {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "required": [
+            "foo"
+          ]
+        }
       ]
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/allOf/0/properties", "#/allOf/0/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7234,14 +17972,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/properties/foo/type",
+          "#/allOf/0/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/properties/foo/type", "#/allOf/0/properties/foo/type", "/foo" ],
-        [ false, "LogicalWhenType", "/allOf/0/properties", "#/allOf/0/properties", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/properties/foo/type",
+          "#/allOf/0/properties/foo/type",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/allOf/0/properties",
+          "#/allOf/0/properties",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -7256,8 +18027,19 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "not": {
         "allOf": [
-          { "type": "object", "properties": { "foo": { "type": "string" } } },
-          { "required": [ "foo" ] }
+          {
+            "type": "object",
+            "properties": {
+              "foo": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "required": [
+              "foo"
+            ]
+          }
         ]
       }
     },
@@ -7265,14 +18047,47 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
-        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/not/allOf/0/properties",
+          "#/not/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/not/allOf/1/required",
+          "#/not/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
-        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/not/allOf/0/properties",
+          "#/not/allOf/0/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/not/allOf/1/required",
+          "#/not/allOf/1/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -7282,18 +18097,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
-        [ "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
-        [ "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/not/allOf",
+          "#/not/allOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/not/allOf/0/properties",
+          "#/not/allOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/allOf/0/type",
+          "#/not/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/not/allOf/1/required",
+          "#/not/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/not/allOf/0/properties", "#/not/allOf/0/properties", "" ],
-        [ true, "AssertionTypeStrict", "/not/allOf/0/type", "#/not/allOf/0/type", "" ],
-        [ false, "AssertionDefines", "/not/allOf/1/required", "#/not/allOf/1/required", "" ],
-        [ false, "LogicalAnd", "/not/allOf", "#/not/allOf", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/not/allOf/0/properties",
+          "#/not/allOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/not/allOf/0/type",
+          "#/not/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/not/allOf/1/required",
+          "#/not/allOf/1/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/not/allOf",
+          "#/not/allOf",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -7309,26 +18179,64 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": 5, "b": { "x": "s" } },
+    "instance": {
+      "a": 5,
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7337,14 +18245,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7358,28 +18299,77 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": { "x": "s" } },
+    "instance": {
+      "a": {},
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7389,30 +18379,154 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          "Annotation",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ true, "Annotation", "/properties/b/properties", "#/properties/b/properties", "/b", "x" ],
-        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b",
+          "x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7434,28 +18548,75 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": {} },
+    "instance": {
+      "a": {},
+      "b": {}
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7465,18 +18626,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -7492,17 +18709,36 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7510,18 +18746,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -7537,17 +18829,34 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
     "instance": {},
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7555,10 +18864,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\""
@@ -7569,21 +18889,48 @@
     "description": "fusion_positional_children_dropped_child",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "empty": { "$comment": "x" } },
+      "$defs": {
+        "empty": {
+          "$comment": "x"
+        }
+      },
       "type": "object",
       "properties": {
-        "a": { "items": { "$ref": "#/$defs/empty" } },
-        "b": { "items": { "minLength": 3 } }
+        "a": {
+          "items": {
+            "$ref": "#/$defs/empty"
+          }
+        },
+        "b": {
+          "items": {
+            "minLength": 3
+          }
+        }
       }
     },
-    "instance": { "b": [ "x" ] },
+    "instance": {
+      "b": [
+        "x"
+      ]
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7591,14 +18938,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
-        [ false, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at least 3 characters but it consisted of 1 character",
@@ -7611,21 +18991,48 @@
     "description": "fusion_positional_children_other_property",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "empty": { "$comment": "x" } },
+      "$defs": {
+        "empty": {
+          "$comment": "x"
+        }
+      },
       "type": "object",
       "properties": {
-        "a": { "items": { "$ref": "#/$defs/empty" } },
-        "b": { "items": { "minLength": 3 } }
+        "a": {
+          "items": {
+            "$ref": "#/$defs/empty"
+          }
+        },
+        "b": {
+          "items": {
+            "minLength": 3
+          }
+        }
       }
     },
-    "instance": { "a": [ "x" ] },
+    "instance": {
+      "a": [
+        "x"
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7633,22 +19040,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
-        [ "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "Annotation", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "ControlJump",
+          "/properties/a/items/$ref",
+          "#/properties/a/items/$ref",
+          "/a/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
-        [ true, "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ true, "Annotation", "/properties/a/items", "#/properties/a/items", "/a", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "ControlJump",
+          "/properties/a/items/$ref",
+          "#/properties/a/items/$ref",
+          "/a/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -7665,21 +19151,48 @@
     "description": "fusion_positional_children_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "empty": { "$comment": "x" } },
+      "$defs": {
+        "empty": {
+          "$comment": "x"
+        }
+      },
       "type": "object",
       "properties": {
-        "a": { "items": { "$ref": "#/$defs/empty" } },
-        "b": { "items": { "minLength": 3 } }
+        "a": {
+          "items": {
+            "$ref": "#/$defs/empty"
+          }
+        },
+        "b": {
+          "items": {
+            "minLength": 3
+          }
+        }
       }
     },
-    "instance": { "b": [ "xxx" ] },
+    "instance": {
+      "b": [
+        "xxx"
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7687,22 +19200,101 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
-        [ "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "Annotation", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
-        [ true, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ true, "Annotation", "/properties/b/items", "#/properties/b/items", "/b", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to consist of at least 3 characters and it consisted of 3 characters",
@@ -7719,21 +19311,51 @@
     "description": "fusion_positional_children_both",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "empty": { "$comment": "x" } },
+      "$defs": {
+        "empty": {
+          "$comment": "x"
+        }
+      },
       "type": "object",
       "properties": {
-        "a": { "items": { "$ref": "#/$defs/empty" } },
-        "b": { "items": { "minLength": 3 } }
+        "a": {
+          "items": {
+            "$ref": "#/$defs/empty"
+          }
+        },
+        "b": {
+          "items": {
+            "minLength": 3
+          }
+        }
       }
     },
-    "instance": { "a": [ "x" ], "b": [ "xxx" ] },
+    "instance": {
+      "a": [
+        "x"
+      ],
+      "b": [
+        "xxx"
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -7741,32 +19363,168 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
-        [ "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "Annotation", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
-        [ "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "Annotation", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "ControlJump",
+          "/properties/a/items/$ref",
+          "#/properties/a/items/$ref",
+          "/a/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/properties/a/items/$ref", "#/properties/a/items/$ref", "/a/0" ],
-        [ true, "LoopItemsFrom", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ true, "Annotation", "/properties/a/items", "#/properties/a/items", "/a", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/properties/a/items", "#/properties/a/items", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionStringSizeGreater", "/properties/b/items/minLength", "#/properties/b/items/minLength", "/b/0" ],
-        [ true, "LoopItemsFrom", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ true, "Annotation", "/properties/b/items", "#/properties/b/items", "/b", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/properties/b/items", "#/properties/b/items", "/b" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "ControlJump",
+          "/properties/a/items/$ref",
+          "#/properties/a/items/$ref",
+          "/a/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/properties/a/items",
+          "#/properties/a/items",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/b/items/minLength",
+          "#/properties/b/items/minLength",
+          "/b/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/properties/b/items",
+          "#/properties/b/items",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -7789,21 +19547,63 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "aa": { "type": "string" } },
-      "additionalProperties": { "type": "integer" }
+      "properties": {
+        "aa": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "aa": "x", "aa\u0000": "not-int" },
+    "instance": {
+      "aa": "x",
+      "aa\u0000": "not-int"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/aa/type", "#/properties/aa/type", "/aa" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionType", "/additionalProperties/type", "#/additionalProperties/type", "/aa\u0000" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/aa/type",
+          "#/properties/aa/type",
+          "/aa"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/aa\u0000"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/aa/type", "#/properties/aa/type", "/aa" ],
-        [ false, "AssertionType", "/additionalProperties/type", "#/additionalProperties/type", "/aa\u0000" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/aa/type",
+          "#/properties/aa/type",
+          "/aa"
+        ],
+        [
+          false,
+          "AssertionType",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/aa\u0000"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -7813,18 +19613,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/aa/type", "#/properties/aa/type", "/aa" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionType", "/additionalProperties/type", "#/additionalProperties/type", "/aa\u0000" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/aa/type",
+          "#/properties/aa/type",
+          "/aa"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/aa\u0000"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/aa/type", "#/properties/aa/type", "/aa" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "aa" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ false, "AssertionType", "/additionalProperties/type", "#/additionalProperties/type", "/aa\u0000" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/aa/type",
+          "#/properties/aa/type",
+          "/aa"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "aa"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/aa\u0000"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -7839,16 +19695,31 @@
     "description": "false_subschema_named_after_keyword",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "unevaluatedItems": false }
+      "properties": {
+        "unevaluatedItems": false
+      }
     },
-    "instance": { "unevaluatedItems": 1 },
+    "instance": {
+      "unevaluatedItems": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+        [
+          "AssertionFail",
+          "/properties/unevaluatedItems",
+          "#/properties/unevaluatedItems",
+          "/unevaluatedItems"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+        [
+          false,
+          "AssertionFail",
+          "/properties/unevaluatedItems",
+          "#/properties/unevaluatedItems",
+          "/unevaluatedItems"
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -7856,12 +19727,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/properties/unevaluatedItems",
+          "#/properties/unevaluatedItems",
+          "/unevaluatedItems"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/properties/unevaluatedItems", "#/properties/unevaluatedItems", "/unevaluatedItems" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/properties/unevaluatedItems",
+          "#/properties/unevaluatedItems",
+          "/unevaluatedItems"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -7873,18 +19766,44 @@
     "description": "false_subschema_named_after_keyword_pattern",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "patternProperties": { "unevaluatedItems": false }
+      "patternProperties": {
+        "unevaluatedItems": false
+      }
     },
-    "instance": { "unevaluatedItems": 1 },
+    "instance": {
+      "unevaluatedItems": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/patternProperties/unevaluatedItems",
+          "#/patternProperties/unevaluatedItems",
+          "/unevaluatedItems"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/patternProperties/unevaluatedItems",
+          "#/patternProperties/unevaluatedItems",
+          "/unevaluatedItems"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -7893,12 +19812,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/patternProperties/unevaluatedItems",
+          "#/patternProperties/unevaluatedItems",
+          "/unevaluatedItems"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/patternProperties/unevaluatedItems", "#/patternProperties/unevaluatedItems", "/unevaluatedItems" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/patternProperties/unevaluatedItems",
+          "#/patternProperties/unevaluatedItems",
+          "/unevaluatedItems"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -7910,20 +19851,57 @@
     "description": "false_subschema_named_after_keyword_dependent",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "dependentSchemas": { "additionalProperties": false }
+      "dependentSchemas": {
+        "additionalProperties": false
+      }
     },
-    "instance": { "additionalProperties": 1 },
+    "instance": {
+      "additionalProperties": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/dependentSchemas/additionalProperties",
+          "#/dependentSchemas/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ],
-        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/dependentSchemas/additionalProperties",
+          "#/dependentSchemas/additionalProperties",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -7933,14 +19911,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/dependentSchemas/additionalProperties",
+          "#/dependentSchemas/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/dependentSchemas/additionalProperties", "#/dependentSchemas/additionalProperties", "" ],
-        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/dependentSchemas/additionalProperties",
+          "#/dependentSchemas/additionalProperties",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -7953,9 +19964,13 @@
     "description": "false_subschema_named_after_keyword_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": { "unevaluatedItems": false }
+      "properties": {
+        "unevaluatedItems": false
+      }
     },
-    "instance": { "other": 1 },
+    "instance": {
+      "other": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -7964,10 +19979,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -7976,7 +20002,10 @@
   },
   {
     "description": "annotation_title_not_a_string",
-    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "title": 42 },
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": 42
+    },
     "instance": 1,
     "valid": true,
     "fast": {
@@ -7986,10 +20015,22 @@
     },
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/title", "#/title", "" ]
+        [
+          "Annotation",
+          "/title",
+          "#/title",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/title", "#/title", "", 42 ]
+        [
+          true,
+          "Annotation",
+          "/title",
+          "#/title",
+          "",
+          42
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"title\" was collected as the annotation 42"
@@ -8011,10 +20052,22 @@
     },
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/examples", "#/examples", "" ]
+        [
+          "Annotation",
+          "/examples",
+          "#/examples",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/examples", "#/examples", "", "x" ]
+        [
+          true,
+          "Annotation",
+          "/examples",
+          "#/examples",
+          "",
+          "x"
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"examples\" was collected as the annotation \"x\""
@@ -8037,12 +20090,36 @@
     },
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/contentEncoding", "#/contentEncoding", "" ],
-        [ "Annotation", "/contentMediaType", "#/contentMediaType", "" ]
+        [
+          "Annotation",
+          "/contentEncoding",
+          "#/contentEncoding",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contentMediaType",
+          "#/contentMediaType",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/contentEncoding", "#/contentEncoding", "", 42 ],
-        [ true, "Annotation", "/contentMediaType", "#/contentMediaType", "", "text/plain" ]
+        [
+          true,
+          "Annotation",
+          "/contentEncoding",
+          "#/contentEncoding",
+          "",
+          42
+        ],
+        [
+          true,
+          "Annotation",
+          "/contentMediaType",
+          "#/contentMediaType",
+          "",
+          "text/plain"
+        ]
       ],
       "descriptions": [
         "The unrecognized keyword \"contentEncoding\" was collected as the annotation 42",
@@ -8052,7 +20129,10 @@
   },
   {
     "description": "annotation_title_a_string",
-    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "x" },
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "title": "x"
+    },
     "instance": 1,
     "valid": true,
     "fast": {
@@ -8062,10 +20142,22 @@
     },
     "exhaustive": {
       "pre": [
-        [ "Annotation", "/title", "#/title", "" ]
+        [
+          "Annotation",
+          "/title",
+          "#/title",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/title", "#/title", "", "x" ]
+        [
+          true,
+          "Annotation",
+          "/title",
+          "#/title",
+          "",
+          "x"
+        ]
       ],
       "descriptions": [
         "The title of the instance was \"x\""
@@ -8079,18 +20171,48 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -8099,10 +20221,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -8116,16 +20249,31 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": [],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of 1 to 2 items"
@@ -8133,12 +20281,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 0 items",
@@ -8153,18 +20323,47 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -8173,32 +20372,165 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -8223,16 +20555,34 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 999 ],
+    "instance": [
+      1,
+      999
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -8240,24 +20590,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -8276,16 +20714,37 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+      "properties": {
+        "aa": {
+          "type": "string"
+        },
+        "bb": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "aa\u0000": 123, "bb": "ok" },
+    "instance": {
+      "aa\u0000": 123,
+      "bb": "ok"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -8293,16 +20752,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bb/type",
+          "#/properties/bb/type",
+          "/bb"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "bb" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bb/type",
+          "#/properties/bb/type",
+          "/bb"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "bb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -8317,18 +20821,41 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "aa", "bb", "cc" ],
+      "required": [
+        "aa",
+        "bb",
+        "cc"
+      ],
       "additionalProperties": false,
-      "properties": { "aa": {}, "bb": {}, "cc": {} }
+      "properties": {
+        "aa": {},
+        "bb": {},
+        "cc": {}
+      }
     },
-    "instance": { "aa\u0000": 1, "bb\u0000": 2, "cc\u0000": 3 },
+    "instance": {
+      "aa\u0000": 1,
+      "bb\u0000": 2,
+      "cc\u0000": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties, but it also defines properties \"aa\u0000\", \"bb\u0000\", and \"cc\u0000\""
@@ -8336,10 +20863,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"aa\", \"bb\", and \"cc\", but it also defines properties \"aa\u0000\", \"bb\u0000\", and \"cc\u0000\""
@@ -8351,18 +20889,41 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "required": [ "aa", "bb", "cc" ],
+      "required": [
+        "aa",
+        "bb",
+        "cc"
+      ],
       "additionalProperties": false,
-      "properties": { "aa": {}, "bb": {}, "cc": {} }
+      "properties": {
+        "aa": {},
+        "bb": {},
+        "cc": {}
+      }
     },
-    "instance": { "aa": 1, "bb": 2, "cc": 3 },
+    "instance": {
+      "aa": 1,
+      "bb": 2,
+      "cc": 3
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties"
@@ -8370,22 +20931,102 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "aa" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "bb" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "cc" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "aa"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "bb"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "cc"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"aa\", \"bb\", and \"cc\"",
@@ -8404,10 +21045,17 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a_property_name_that_is_definitely_over_thirty_two_chars_one": { "type": "string" },
-        "a_property_name_that_is_definitely_over_thirty_two_chars_two": { "type": "string" }
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one": {
+          "type": "string"
+        },
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two": {
+          "type": "string"
+        }
       },
-      "required": [ "a_property_name_that_is_definitely_over_thirty_two_chars_one", "a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
+      "required": [
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one",
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two"
+      ],
       "additionalProperties": false
     },
     "instance": {
@@ -8417,10 +21065,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8428,24 +21087,114 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type", "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type", "/a_property_name_that_is_definitely_over_thirty_two_chars_one" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type", "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type", "/a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type",
+          "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type",
+          "/a_property_name_that_is_definitely_over_thirty_two_chars_one"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type",
+          "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type",
+          "/a_property_name_that_is_definitely_over_thirty_two_chars_two"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type", "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type", "/a_property_name_that_is_definitely_over_thirty_two_chars_one" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a_property_name_that_is_definitely_over_thirty_two_chars_one" ],
-        [ true, "AssertionTypeStrict", "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type", "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type", "/a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type",
+          "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_one/type",
+          "/a_property_name_that_is_definitely_over_thirty_two_chars_one"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a_property_name_that_is_definitely_over_thirty_two_chars_one"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type",
+          "#/properties/a_property_name_that_is_definitely_over_thirty_two_chars_two/type",
+          "/a_property_name_that_is_definitely_over_thirty_two_chars_two"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a_property_name_that_is_definitely_over_thirty_two_chars_two"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a_property_name_that_is_definitely_over_thirty_two_chars_one\", and \"a_property_name_that_is_definitely_over_thirty_two_chars_two\"",
@@ -8465,10 +21214,17 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a_property_name_that_is_definitely_over_thirty_two_chars_one": { "type": "string" },
-        "a_property_name_that_is_definitely_over_thirty_two_chars_two": { "type": "string" }
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one": {
+          "type": "string"
+        },
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two": {
+          "type": "string"
+        }
       },
-      "required": [ "a_property_name_that_is_definitely_over_thirty_two_chars_one", "a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
+      "required": [
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one",
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two"
+      ],
       "additionalProperties": false
     },
     "instance": {
@@ -8478,10 +21234,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8489,10 +21256,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a_property_name_that_is_definitely_over_thirty_two_chars_one\", and \"a_property_name_that_is_definitely_over_thirty_two_chars_two\", but it also defines properties \"WRONG_KEY_alpha_alpha_alpha_alpha_alpha_alpha\", and \"WRONG_KEY_bravo_bravo_bravo_bravo_bravo_bravo\""
@@ -8505,10 +21283,17 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
-        "a_property_name_that_is_definitely_over_thirty_two_chars_one": { "type": "string" },
-        "a_property_name_that_is_definitely_over_thirty_two_chars_two": { "type": "string" }
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one": {
+          "type": "string"
+        },
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two": {
+          "type": "string"
+        }
       },
-      "required": [ "a_property_name_that_is_definitely_over_thirty_two_chars_one", "a_property_name_that_is_definitely_over_thirty_two_chars_two" ],
+      "required": [
+        "a_property_name_that_is_definitely_over_thirty_two_chars_one",
+        "a_property_name_that_is_definitely_over_thirty_two_chars_two"
+      ],
       "additionalProperties": false
     },
     "instance": {
@@ -8518,10 +21303,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8529,10 +21325,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a_property_name_that_is_definitely_over_thirty_two_chars_one\", and \"a_property_name_that_is_definitely_over_thirty_two_chars_two\", but it also defines the property \"WRONG_KEY_bravo_bravo_bravo_bravo_bravo_bravo\""
@@ -8544,18 +21351,42 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "bb": { "type": "string" } },
-      "required": [ "a", "bb" ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "bb": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "bb"
+      ],
       "additionalProperties": false
     },
-    "instance": { "a": "x", "bb": "y" },
+    "instance": {
+      "a": "x",
+      "bb": "y"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8563,24 +21394,114 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
-        [ "Annotation", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bb/type",
+          "#/properties/bb/type",
+          "/bb"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "a" ],
-        [ true, "AssertionTypeStrict", "/properties/bb/type", "#/properties/bb/type", "/bb" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "bb" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bb/type",
+          "#/properties/bb/type",
+          "/bb"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "bb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a\", and \"bb\"",
@@ -8599,18 +21520,42 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "bb": { "type": "string" } },
-      "required": [ "a", "bb" ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "bb": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "bb"
+      ],
       "additionalProperties": false
     },
-    "instance": { "a\u0000": "x", "bb": "y" },
+    "instance": {
+      "a\u0000": "x",
+      "bb": "y"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8618,10 +21563,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a\", and \"bb\", but it also defines the property \"a\u0000\""
@@ -8635,21 +21591,58 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [ "aa", "bb" ],
+        "required": [
+          "aa",
+          "bb"
+        ],
         "additionalProperties": false,
-        "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+        "properties": {
+          "aa": {
+            "type": "string"
+          },
+          "bb": {
+            "type": "string"
+          }
+        }
       }
     },
-    "instance": [ { "aa\u0000": "x", "bb\u0000": "y" } ],
+    "instance": [
+      {
+        "aa\u0000": "x",
+        "bb\u0000": "y"
+      }
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "LoopPropertiesExactlyTypeStrictHash", "/items/properties", "#/items/properties", "/0" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrictHash", "/items/properties", "#/items/properties", "/0" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string",
@@ -8658,12 +21651,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ false, "LoopItemsFrom", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"aa\", and \"bb\", but it also defines properties \"aa\u0000\", and \"bb\u0000\"",
@@ -8678,23 +21693,71 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [ "aa", "bb" ],
+        "required": [
+          "aa",
+          "bb"
+        ],
         "additionalProperties": false,
-        "properties": { "aa": { "type": "string" }, "bb": { "type": "string" } }
+        "properties": {
+          "aa": {
+            "type": "string"
+          },
+          "bb": {
+            "type": "string"
+          }
+        }
       }
     },
-    "instance": [ { "aa": "x", "bb": "y" } ],
+    "instance": [
+      {
+        "aa": "x",
+        "bb": "y"
+      }
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "LoopPropertiesExactlyTypeStrictHash", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/items/properties", "#/items/properties", "/0" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string",
@@ -8704,32 +21767,167 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItemsFrom", "/items", "#/items", "" ],
-        [ "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/items/properties/aa/type", "#/items/properties/aa/type", "/0/aa" ],
-        [ "Annotation", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/items/properties/bb/type", "#/items/properties/bb/type", "/0/bb" ],
-        [ "Annotation", "/items/properties", "#/items/properties", "/0" ],
-        [ "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ "Annotation", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/aa/type",
+          "#/items/properties/aa/type",
+          "/0/aa"
+        ],
+        [
+          "Annotation",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/bb/type",
+          "#/items/properties/bb/type",
+          "/0/bb"
+        ],
+        [
+          "Annotation",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "Annotation",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/properties/aa/type", "#/items/properties/aa/type", "/0/aa" ],
-        [ true, "Annotation", "/items/properties", "#/items/properties", "/0", "aa" ],
-        [ true, "AssertionTypeStrict", "/items/properties/bb/type", "#/items/properties/bb/type", "/0/bb" ],
-        [ true, "Annotation", "/items/properties", "#/items/properties", "/0", "bb" ],
-        [ true, "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ true, "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItemsFrom", "/items", "#/items", "" ],
-        [ true, "Annotation", "/items", "#/items", "", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/aa/type",
+          "#/items/properties/aa/type",
+          "/0/aa"
+        ],
+        [
+          true,
+          "Annotation",
+          "/items/properties",
+          "#/items/properties",
+          "/0",
+          "aa"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/bb/type",
+          "#/items/properties/bb/type",
+          "/0/bb"
+        ],
+        [
+          true,
+          "Annotation",
+          "/items/properties",
+          "#/items/properties",
+          "/0",
+          "bb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/items",
+          "#/items",
+          "",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"aa\", and \"bb\"",
@@ -8752,18 +21950,42 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-      "required": [ "a", "b" ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
       "additionalProperties": false
     },
-    "instance": { "b": "x", "a": 1 },
+    "instance": {
+      "b": "x",
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -8771,14 +21993,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a\", and \"b\"",
@@ -8791,27 +22046,94 @@
     "description": "if_then_else_inlined_shared_ref_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "number" },
-      "then": { "$ref": "#/$defs/shared", "const": 7 },
-      "else": { "$ref": "#/$defs/shared" },
-      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+      "if": {
+        "type": "number"
+      },
+      "then": {
+        "$ref": "#/$defs/shared",
+        "const": 7
+      },
+      "else": {
+        "$ref": "#/$defs/shared"
+      },
+      "$defs": {
+        "shared": {
+          "minimum": 5,
+          "multipleOf": 1
+        }
+      }
     },
     "instance": 999,
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -8823,20 +22145,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -8852,27 +22240,94 @@
     "description": "if_then_else_inlined_shared_ref_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "number" },
-      "then": { "$ref": "#/$defs/shared", "const": 7 },
-      "else": { "$ref": "#/$defs/shared" },
-      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+      "if": {
+        "type": "number"
+      },
+      "then": {
+        "$ref": "#/$defs/shared",
+        "const": 7
+      },
+      "else": {
+        "$ref": "#/$defs/shared"
+      },
+      "$defs": {
+        "shared": {
+          "minimum": 5,
+          "multipleOf": 1
+        }
+      }
     },
     "instance": 7,
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -8884,20 +22339,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDivisible", "/then/$ref/multipleOf", "#/$defs/shared/multipleOf", "" ],
-        [ true, "AssertionGreaterEqual", "/then/$ref/minimum", "#/$defs/shared/minimum", "" ],
-        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/then/$ref/multipleOf",
+          "#/$defs/shared/multipleOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/then/$ref/minimum",
+          "#/$defs/shared/minimum",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -8913,21 +22434,55 @@
     "description": "if_then_else_inlined_shared_ref_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "number" },
-      "then": { "$ref": "#/$defs/shared", "const": 7 },
-      "else": { "$ref": "#/$defs/shared" },
-      "$defs": { "shared": { "minimum": 5, "multipleOf": 1 } }
+      "if": {
+        "type": "number"
+      },
+      "then": {
+        "$ref": "#/$defs/shared",
+        "const": 7
+      },
+      "else": {
+        "$ref": "#/$defs/shared"
+      },
+      "$defs": {
+        "shared": {
+          "minimum": 5,
+          "multipleOf": 1
+        }
+      }
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string",
@@ -8936,14 +22491,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/else/$ref", "#/else/$ref", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/else/$ref",
+          "#/else/$ref",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/if/type", "#/if/type", "" ],
-        [ true, "ControlJump", "/else/$ref", "#/else/$ref", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/else/$ref",
+          "#/else/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string",
@@ -8957,30 +22545,89 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
-        "left": { "$ref": "#/$defs/shared" },
-        "right": { "$ref": "#/$defs/shared" }
+        "left": {
+          "$ref": "#/$defs/shared"
+        },
+        "right": {
+          "$ref": "#/$defs/shared"
+        }
       },
       "$defs": {
         "shared": {
-          "if": { "type": "array" },
-          "then": { "items": { "type": "string", "minLength": 1 } }
+          "if": {
+            "type": "array"
+          },
+          "then": {
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
       }
     },
-    "instance": { "left": [ "x" ] },
+    "instance": {
+      "left": [
+        "x"
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ]
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          "AssertionTypeStringBounded",
+          "/properties/left/$ref/then/items/type",
+          "#/$defs/shared/then/items/type",
+          "/left/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ true, "AssertionTypeStringBounded", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
-        [ true, "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/properties/left/$ref/then/items/type",
+          "#/$defs/shared/then/items/type",
+          "/left/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -8991,28 +22638,140 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
-        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
-        [ "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
-        [ "LogicalWhenArraySizeGreater", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/left/$ref",
+          "#/properties/left/$ref",
+          "/left"
+        ],
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          "LoopItemsFrom",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/properties/left/$ref/then/items/minLength",
+          "#/$defs/shared/then/items/minLength",
+          "/left/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/left/$ref/then/items/type",
+          "#/$defs/shared/then/items/type",
+          "/left/0"
+        ],
+        [
+          "LogicalWhenArraySizeGreater",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          "Annotation",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ true, "AssertionStringSizeGreater", "/properties/left/$ref/then/items/minLength", "#/$defs/shared/then/items/minLength", "/left/0" ],
-        [ true, "AssertionTypeStrict", "/properties/left/$ref/then/items/type", "#/$defs/shared/then/items/type", "/left/0" ],
-        [ true, "LoopItemsFrom", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ true, "Annotation", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left", true ],
-        [ true, "LogicalWhenArraySizeGreater", "/properties/left/$ref/then/items", "#/$defs/shared/then/items", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/properties/left/$ref/then/items/minLength",
+          "#/$defs/shared/then/items/minLength",
+          "/left/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/left/$ref/then/items/type",
+          "#/$defs/shared/then/items/type",
+          "/left/0"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left",
+          true
+        ],
+        [
+          true,
+          "LogicalWhenArraySizeGreater",
+          "/properties/left/$ref/then/items",
+          "#/$defs/shared/then/items",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/left/$ref",
+          "#/properties/left/$ref",
+          "/left"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "left"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -9033,32 +22792,104 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
-        "left": { "$ref": "#/$defs/shared" },
-        "right": { "$ref": "#/$defs/shared" }
+        "left": {
+          "$ref": "#/$defs/shared"
+        },
+        "right": {
+          "$ref": "#/$defs/shared"
+        }
       },
       "$defs": {
         "shared": {
-          "if": { "type": "array" },
-          "then": { "if": { "minItems": 1 }, "then": { "maxItems": 3 } }
+          "if": {
+            "type": "array"
+          },
+          "then": {
+            "if": {
+              "minItems": 1
+            },
+            "then": {
+              "maxItems": 3
+            }
+          }
         }
       }
     },
-    "instance": { "left": [ "x" ] },
+    "instance": {
+      "left": [
+        "x"
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
-        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
-        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ]
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/then/if",
+          "#/$defs/shared/then/if",
+          "/left"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/properties/left/$ref/then/if/minItems",
+          "#/$defs/shared/then/if/minItems",
+          "/left"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/properties/left/$ref/then/then/maxItems",
+          "#/$defs/shared/then/then/maxItems",
+          "/left"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
-        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/properties/left/$ref/then/if/minItems",
+          "#/$defs/shared/then/if/minItems",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/properties/left/$ref/then/then/maxItems",
+          "#/$defs/shared/then/then/maxItems",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/then/if",
+          "#/$defs/shared/then/if",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -9070,24 +22901,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
-        [ "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
-        [ "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
-        [ "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
-        [ "Annotation", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/left/$ref",
+          "#/properties/left/$ref",
+          "/left"
+        ],
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          "LogicalCondition",
+          "/properties/left/$ref/then/if",
+          "#/$defs/shared/then/if",
+          "/left"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/properties/left/$ref/then/if/minItems",
+          "#/$defs/shared/then/if/minItems",
+          "/left"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/properties/left/$ref/then/then/maxItems",
+          "#/$defs/shared/then/then/maxItems",
+          "/left"
+        ],
+        [
+          "Annotation",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/left/$ref/if/type", "#/$defs/shared/if/type", "/left" ],
-        [ true, "AssertionArraySizeGreater", "/properties/left/$ref/then/if/minItems", "#/$defs/shared/then/if/minItems", "/left" ],
-        [ true, "AssertionArraySizeLess", "/properties/left/$ref/then/then/maxItems", "#/$defs/shared/then/then/maxItems", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/then/if", "#/$defs/shared/then/if", "/left" ],
-        [ true, "LogicalCondition", "/properties/left/$ref/if", "#/$defs/shared/if", "/left" ],
-        [ true, "ControlJump", "/properties/left/$ref", "#/properties/left/$ref", "/left" ],
-        [ true, "Annotation", "/properties", "#/properties", "", "left" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/left/$ref/if/type",
+          "#/$defs/shared/if/type",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/properties/left/$ref/then/if/minItems",
+          "#/$defs/shared/then/if/minItems",
+          "/left"
+        ],
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/properties/left/$ref/then/then/maxItems",
+          "#/$defs/shared/then/then/maxItems",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/then/if",
+          "#/$defs/shared/then/if",
+          "/left"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/properties/left/$ref/if",
+          "#/$defs/shared/if",
+          "/left"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/left/$ref",
+          "#/properties/left/$ref",
+          "/left"
+        ],
+        [
+          true,
+          "Annotation",
+          "/properties",
+          "#/properties",
+          "",
+          "left"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -9106,20 +23026,48 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifref",
-      "if": { "$ref": "#/$defs/always" },
-      "then": { "minLength": 3 },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "then": {
+        "minLength": 3
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": "",
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
-        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
@@ -9128,14 +23076,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifref#/if/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
-        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
-        [ false, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifref#/if/$ref",
+          ""
+        ],
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -9149,20 +23130,48 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifref",
-      "if": { "$ref": "#/$defs/always" },
-      "then": { "minLength": 3 },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "then": {
+        "minLength": 3
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": "abcd",
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
@@ -9171,14 +23180,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifref#/if/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifref#/if/$ref", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifref#/then/minLength", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifref#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifref#/if/$ref",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifref#/then/minLength",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifref#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -9192,21 +23234,51 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifrefelse",
-      "if": { "$ref": "#/$defs/always" },
-      "then": { "minLength": 3 },
-      "else": { "const": "never" },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "then": {
+        "minLength": 3
+      },
+      "else": {
+        "const": "never"
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": "",
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
-        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"\" was expected to consist of at least 3 characters but it consisted of 0 characters",
@@ -9215,14 +23287,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifrefelse#/if/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
-        [ false, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
-        [ false, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifrefelse#/if/$ref",
+          ""
+        ],
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -9236,21 +23341,51 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifrefelse",
-      "if": { "$ref": "#/$defs/always" },
-      "then": { "minLength": 3 },
-      "else": { "const": "never" },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "then": {
+        "minLength": 3
+      },
+      "else": {
+        "const": "never"
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": "abcd",
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at least 3 characters and it consisted of 4 characters",
@@ -9259,14 +23394,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
-        [ "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifrefelse#/if/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifrefelse#/if/$ref", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/minLength", "https://example.com/ifrefelse#/then/minLength", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifrefelse#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifrefelse#/if/$ref",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/minLength",
+          "https://example.com/ifrefelse#/then/minLength",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifrefelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -9280,9 +23448,15 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifelse",
-      "if": { "$ref": "#/$defs/always" },
-      "else": { "type": "string" },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "else": {
+        "type": "string"
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": 0,
     "valid": true,
@@ -9293,12 +23467,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifelse#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifelse#/if/$ref",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifelse#/if/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was expected to validate against the referenced schema",
@@ -9311,9 +23507,15 @@
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/ifelse",
-      "if": { "$ref": "#/$defs/always" },
-      "else": { "type": "string" },
-      "$defs": { "always": {} }
+      "if": {
+        "$ref": "#/$defs/always"
+      },
+      "else": {
+        "type": "string"
+      },
+      "$defs": {
+        "always": {}
+      }
     },
     "instance": "hi",
     "valid": true,
@@ -9324,12 +23526,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ],
-        [ "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifelse#/if",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifelse#/if/$ref",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/if/$ref", "https://example.com/ifelse#/if/$ref", "" ],
-        [ true, "LogicalCondition", "/if", "https://example.com/ifelse#/if", "" ]
+        [
+          true,
+          "ControlJump",
+          "/if/$ref",
+          "https://example.com/ifelse#/if/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "https://example.com/ifelse#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -9341,20 +23565,41 @@
     "description": "contains_empty_target_dropped_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "$ref": "#/$defs/maybe" },
+      "contains": {
+        "$ref": "#/$defs/maybe"
+      },
       "minContains": 2,
       "maxContains": 3,
-      "properties": { "x": { "$ref": "#/$defs/maybe" } },
-      "$defs": { "maybe": {} }
+      "properties": {
+        "x": {
+          "$ref": "#/$defs/maybe"
+        }
+      },
+      "$defs": {
+        "maybe": {}
+      }
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain 2 to 3 items that validate against the given subschema"
@@ -9362,14 +23607,48 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was expected to validate against the referenced schema",
@@ -9382,20 +23661,42 @@
     "description": "contains_empty_target_dropped_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "$ref": "#/$defs/maybe" },
+      "contains": {
+        "$ref": "#/$defs/maybe"
+      },
       "minContains": 2,
       "maxContains": 3,
-      "properties": { "x": { "$ref": "#/$defs/maybe" } },
-      "$defs": { "maybe": {} }
+      "properties": {
+        "x": {
+          "$ref": "#/$defs/maybe"
+        }
+      },
+      "$defs": {
+        "maybe": {}
+      }
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain 2 to 3 items that validate against the given subschema"
@@ -9403,18 +23704,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was expected to validate against the referenced schema",
@@ -9429,20 +23787,44 @@
     "description": "contains_empty_target_dropped_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "$ref": "#/$defs/maybe" },
+      "contains": {
+        "$ref": "#/$defs/maybe"
+      },
       "minContains": 2,
       "maxContains": 3,
-      "properties": { "x": { "$ref": "#/$defs/maybe" } },
-      "$defs": { "maybe": {} }
+      "properties": {
+        "x": {
+          "$ref": "#/$defs/maybe"
+        }
+      },
+      "$defs": {
+        "maybe": {}
+      }
     },
-    "instance": [ 1, 2, 3, 4 ],
+    "instance": [
+      1,
+      2,
+      3,
+      4
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain 2 to 3 items that validate against the given subschema"
@@ -9450,26 +23832,129 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/3"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ true, "ControlJump", "/contains/$ref", "#/contains/$ref", "/3" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 3 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          true,
+          "ControlJump",
+          "/contains/$ref",
+          "#/contains/$ref",
+          "/3"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          3
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value was expected to validate against the referenced schema",
@@ -9488,25 +23973,80 @@
     "description": "evaluate_marking_additionalproperties",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
-      "then": { "additionalProperties": { "$ref": "#/$defs/e" } },
+      "if": {
+        "type": "object"
+      },
+      "then": {
+        "additionalProperties": {
+          "$ref": "#/$defs/e"
+        }
+      },
       "unevaluatedProperties": false,
-      "$defs": { "e": {} }
+      "$defs": {
+        "e": {}
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "LoopPropertiesEvaluate",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesEvaluate",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -9517,24 +24057,114 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
-        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
-        [ "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "LoopPropertiesEvaluate",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/additionalProperties/$ref",
+          "#/then/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/additionalProperties/$ref",
+          "#/then/additionalProperties/$ref",
+          "/bar"
+        ],
+        [
+          "Annotation",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/foo" ],
-        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "foo" ],
-        [ true, "ControlJump", "/then/additionalProperties/$ref", "#/then/additionalProperties/$ref", "/bar" ],
-        [ true, "Annotation", "/then/additionalProperties", "#/then/additionalProperties", "", "bar" ],
-        [ true, "LoopPropertiesEvaluate", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/additionalProperties/$ref",
+          "#/then/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/additionalProperties/$ref",
+          "#/then/additionalProperties/$ref",
+          "/bar"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          "",
+          "bar"
+        ],
+        [
+          true,
+          "LoopPropertiesEvaluate",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -9552,25 +24182,81 @@
     "description": "evaluate_marking_unevaluateditems",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "array" },
-      "then": { "unevaluatedItems": { "$ref": "#/$defs/e" } },
+      "if": {
+        "type": "array"
+      },
+      "then": {
+        "unevaluatedItems": {
+          "$ref": "#/$defs/e"
+        }
+      },
       "unevaluatedItems": false,
-      "$defs": { "e": {} }
+      "$defs": {
+        "e": {}
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -9581,28 +24267,141 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
-        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
-        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
-        [ "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/0" ],
-        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
-        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/1" ],
-        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
-        [ true, "ControlJump", "/then/unevaluatedItems/$ref", "#/then/unevaluatedItems/$ref", "/2" ],
-        [ true, "Annotation", "/then/unevaluatedItems", "#/then/unevaluatedItems", "", true ],
-        [ true, "LoopItemsUnevaluated", "/then/unevaluatedItems", "#/then/unevaluatedItems", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/unevaluatedItems/$ref",
+          "#/then/unevaluatedItems/$ref",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/then/unevaluatedItems",
+          "#/then/unevaluatedItems",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -9626,14 +24425,27 @@
       "contains": {},
       "minContains": 2
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items that validate against the given subschema"
@@ -9641,12 +24453,35 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The item at index 0 of the array value successfully validated against the containment check subschema",
@@ -9662,16 +24497,41 @@
       "contains": {},
       "minContains": 2
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items that validate against the given subschema",
@@ -9680,16 +24540,62 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The item at index 0 of the array value successfully validated against the containment check subschema",
@@ -9712,12 +24618,34 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain up to 1 item that validates against the given subschema",
@@ -9726,12 +24654,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopContains", "/contains", "#/contains", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain up to 1 item that validates against the given subschema",
@@ -9748,14 +24698,28 @@
       "minContains": 0,
       "maxContains": 1
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain up to 1 item that validates against the given subschema"
@@ -9763,14 +24727,49 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The item at index 0 of the array value successfully validated against the containment check subschema",
@@ -9783,22 +24782,63 @@
     "description": "conditional_additional_array_unevaluated_invalid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "additionalProperties": true },
+      "if": {
+        "additionalProperties": true
+      },
       "unevaluatedProperties": false,
-      "unevaluatedItems": { "type": "integer" }
+      "unevaluatedItems": {
+        "type": "integer"
+      }
     },
-    "instance": [ { "a": 1 } ],
+    "instance": [
+      {
+        "a": 1
+      }
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to validate against the given conditional",
@@ -9808,14 +24848,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ false, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to validate against the given conditional",
@@ -9828,24 +24901,75 @@
     "description": "conditional_additional_array_unevaluated_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "additionalProperties": true },
+      "if": {
+        "additionalProperties": true
+      },
       "unevaluatedProperties": false,
-      "unevaluatedItems": { "type": "integer" }
+      "unevaluatedItems": {
+        "type": "integer"
+      }
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to validate against the given conditional",
@@ -9856,20 +24980,88 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "" ],
-        [ "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/0" ],
-        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
-        [ true, "AssertionType", "/unevaluatedItems/type", "#/unevaluatedItems/type", "/1" ],
-        [ true, "Annotation", "/unevaluatedItems", "#/unevaluatedItems", "", true ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "AssertionType",
+          "/unevaluatedItems/type",
+          "#/unevaluatedItems/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to validate against the given conditional",
@@ -9885,22 +25077,60 @@
     "description": "contains_min_zero_max_zero_matches_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": 1 },
+      "contains": {
+        "const": 1
+      },
       "minContains": 0,
       "maxContains": 1
     },
-    "instance": [ 2, 3 ],
+    "instance": [
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -9910,14 +25140,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -9930,22 +25193,60 @@
     "description": "contains_min_zero_max_too_many_invalid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": 1 },
+      "contains": {
+        "const": 1
+      },
       "minContains": 0,
       "maxContains": 1
     },
-    "instance": [ 1, 1 ],
+    "instance": [
+      1,
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1",
@@ -9955,18 +25256,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1",
@@ -9984,8 +25342,16 @@
       "$id": "https://example.com/root",
       "$ref": "https://example.com/inner",
       "$defs": {
-        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
-        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "a": {
+          "$id": "https://example.com/a",
+          "$dynamicAnchor": "T",
+          "title": "x"
+        },
+        "b": {
+          "$id": "https://example.com/b",
+          "$dynamicAnchor": "T",
+          "title": "y"
+        },
         "inner": {
           "$id": "https://example.com/inner",
           "$dynamicRef": "https://example.com/a#T",
@@ -9994,20 +25360,66 @@
         }
       }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ false, "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ],
-        [ false, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ false, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          "/a"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
@@ -10018,18 +25430,74 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
-        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ false, "AssertionFail", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "/a" ],
-        [ false, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ false, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          "/a"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The title of the instance was \"x\"",
@@ -10047,8 +25515,16 @@
       "$id": "https://example.com/root",
       "$ref": "https://example.com/inner",
       "$defs": {
-        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
-        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "a": {
+          "$id": "https://example.com/a",
+          "$dynamicAnchor": "T",
+          "title": "x"
+        },
+        "b": {
+          "$id": "https://example.com/b",
+          "$dynamicAnchor": "T",
+          "title": "y"
+        },
         "inner": {
           "$id": "https://example.com/inner",
           "$dynamicRef": "https://example.com/a#T",
@@ -10061,14 +25537,47 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
@@ -10078,16 +25587,61 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
-        [ "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/$ref/unevaluatedProperties", "https://example.com/inner#/unevaluatedProperties", "" ],
-        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/$ref/unevaluatedProperties",
+          "https://example.com/inner#/unevaluatedProperties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The title of the instance was \"x\"",
@@ -10104,8 +25658,16 @@
       "$id": "https://example.com/root",
       "$ref": "https://example.com/inner",
       "$defs": {
-        "a": { "$id": "https://example.com/a", "$dynamicAnchor": "T", "title": "x" },
-        "b": { "$id": "https://example.com/b", "$dynamicAnchor": "T", "title": "y" },
+        "a": {
+          "$id": "https://example.com/a",
+          "$dynamicAnchor": "T",
+          "title": "x"
+        },
+        "b": {
+          "$id": "https://example.com/b",
+          "$dynamicAnchor": "T",
+          "title": "y"
+        },
         "inner": {
           "$id": "https://example.com/inner",
           "$dynamicRef": "https://example.com/a#T",
@@ -10114,18 +25676,53 @@
         }
       }
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ true, "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
-        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to validate against the first subschema in scope that declared the dynamic anchor \"T\"",
@@ -10135,18 +25732,75 @@
     },
     "exhaustive": {
       "pre": [
-        [ "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ],
-        [ "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "" ],
-        [ "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
-        [ "Annotation", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ]
+        [
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ],
+        [
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          ""
+        ],
+        [
+          "Annotation",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/$ref/$dynamicRef/title", "https://example.com/a#/title", "", "x" ],
-        [ true, "ControlDynamicAnchorJump", "/$ref/$dynamicRef", "https://example.com/inner#/$dynamicRef", "" ],
-        [ true, "Annotation", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "", true ],
-        [ true, "LoopItemsUnevaluated", "/$ref/unevaluatedItems", "https://example.com/inner#/unevaluatedItems", "" ],
-        [ true, "ControlJump", "/$ref", "https://example.com/root#/$ref", "" ]
+        [
+          true,
+          "Annotation",
+          "/$ref/$dynamicRef/title",
+          "https://example.com/a#/title",
+          "",
+          "x"
+        ],
+        [
+          true,
+          "ControlDynamicAnchorJump",
+          "/$ref/$dynamicRef",
+          "https://example.com/inner#/$dynamicRef",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/$ref/unevaluatedItems",
+          "https://example.com/inner#/unevaluatedItems",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/$ref",
+          "https://example.com/root#/$ref",
+          ""
+        ]
       ],
       "descriptions": [
         "The title of the instance was \"x\"",
@@ -10161,10 +25815,14 @@
     "description": "contains_unsatisfiable_object",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
-    "instance": { "role": "user" },
+    "instance": {
+      "role": "user"
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -10181,7 +25839,9 @@
     "description": "contains_unsatisfiable_string",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
     "instance": "hello",
@@ -10201,7 +25861,9 @@
     "description": "contains_unsatisfiable_null",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
     "instance": null,
@@ -10221,19 +25883,45 @@
     "description": "contains_unsatisfiable_matching_array",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
-    "instance": [ "admin" ],
+    "instance": [
+      "admin"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"admin\" was expected to equal the string constant \"admin\"",
@@ -10242,14 +25930,48 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"admin\" was expected to equal the string constant \"admin\"",
@@ -10262,19 +25984,45 @@
     "description": "contains_unsatisfiable_other_array",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
-    "instance": [ "user" ],
+    "instance": [
+      "user"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"user\" was expected to equal the string constant \"admin\"",
@@ -10283,12 +26031,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionEqual", "/contains/const", "#/contains/const", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/contains/const", "#/contains/const", "/0" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/contains/const",
+          "#/contains/const",
+          "/0"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"user\" was expected to equal the string constant \"admin\"",
@@ -10300,17 +26070,30 @@
     "description": "contains_unsatisfiable_empty_array",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "contains": { "const": "admin" },
+      "contains": {
+        "const": "admin"
+      },
       "maxContains": 0
     },
     "instance": [],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain 1 to 0 items that validate against the given subschema"
@@ -10318,10 +26101,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain 1 to 0 items that validate against the given subschema"
@@ -10334,9 +26128,13 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "minContains": 3,
       "maxContains": 2,
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -10355,22 +26153,72 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "minContains": 3,
       "maxContains": 2,
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -10381,22 +26229,102 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "Annotation", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ "Annotation", "/contains", "#/contains", "" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          "Annotation",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 0 ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 1 ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ true, "Annotation", "/contains", "#/contains", "", 2 ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          0
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          1
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          true,
+          "Annotation",
+          "/contains",
+          "#/contains",
+          "",
+          2
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -10413,33 +26341,114 @@
     "description": "conditional_properties_fusion_tracked_valid",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
+      "if": {
+        "type": "object"
+      },
       "then": {
         "type": "object",
-        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-        "required": [ "a", "b" ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
         "additionalProperties": false
       },
       "unevaluatedProperties": false
     },
-    "instance": { "a": "x", "b": "y" },
+    "instance": {
+      "a": "x",
+      "b": "y"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10452,34 +26461,179 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
-        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "Evaluate", "/then/properties", "#/then/properties", "/b" ],
-        [ "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/b"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/type",
+          "#/then/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
-        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
-        [ true, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "b" ],
-        [ true, "Evaluate", "/then/properties", "#/then/properties", "/b" ],
-        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/then/additionalProperties", "#/then/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/then/additionalProperties",
+          "#/then/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/type",
+          "#/then/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10502,31 +26656,101 @@
     "description": "conditional_properties_fusion_tracked_bad_type",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
+      "if": {
+        "type": "object"
+      },
       "then": {
         "type": "object",
-        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-        "required": [ "a", "b" ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
         "additionalProperties": false
       },
       "unevaluatedProperties": false
     },
-    "instance": { "a": "x", "b": 1 },
+    "instance": {
+      "a": "x",
+      "b": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionPropertyTypeStrictEvaluate", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ false, "AssertionPropertyTypeStrictEvaluate", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10538,24 +26762,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "Evaluate", "/then/properties", "#/then/properties", "/a" ],
-        [ "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
-        [ true, "Evaluate", "/then/properties", "#/then/properties", "/a" ],
-        [ false, "AssertionTypeStrict", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ false, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10573,27 +26886,74 @@
     "description": "conditional_properties_fusion_tracked_missing",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
+      "if": {
+        "type": "object"
+      },
       "then": {
         "type": "object",
-        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-        "required": [ "a", "b" ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
         "additionalProperties": false
       },
       "unevaluatedProperties": false
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10603,14 +26963,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10623,27 +27016,76 @@
     "description": "conditional_properties_fusion_tracked_additional",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
+      "if": {
+        "type": "object"
+      },
       "then": {
         "type": "object",
-        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-        "required": [ "a", "b" ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
         "additionalProperties": false
       },
       "unevaluatedProperties": false
     },
-    "instance": { "a": "x", "b": "y", "c": 1 },
+    "instance": {
+      "a": "x",
+      "b": "y",
+      "c": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionDefinesExactlyStrict", "/then/required", "#/then/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesExactlyStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10653,14 +27095,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesExactly", "/then/required", "#/then/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionDefinesExactly", "/then/required", "#/then/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10673,11 +27148,23 @@
     "description": "conditional_properties_fusion_tracked_non_object",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
+      "if": {
+        "type": "object"
+      },
       "then": {
         "type": "object",
-        "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-        "required": [ "a", "b" ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
         "additionalProperties": false
       },
       "unevaluatedProperties": false
@@ -10686,12 +27173,34 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type integer",
@@ -10700,12 +27209,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type integer",
@@ -10717,24 +27248,85 @@
     "description": "any_of_reference_branch_evaluates",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
-      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "$defs": {
+        "D": {
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/D"
+        }
+      ],
       "unevaluatedProperties": false
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10745,24 +27337,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
-        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
-        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10780,26 +27461,99 @@
     "description": "any_of_reference_branch_unrelated_property",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
-      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "$defs": {
+        "D": {
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/D"
+        }
+      ],
       "unevaluatedProperties": false
     },
-    "instance": { "a": 1, "zzz": 2 },
+    "instance": {
+      "a": 1,
+      "zzz": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10811,26 +27565,126 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ true, "Annotation", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "", "a" ],
-        [ true, "Evaluate", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "/a" ],
-        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/zzz" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10849,26 +27703,98 @@
     "description": "any_of_reference_branch_failing",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
-      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "$defs": {
+        "D": {
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/D"
+        }
+      ],
       "unevaluatedProperties": false
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ false, "AssertionPropertyTypeEvaluate", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/a"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10880,22 +27806,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ false, "AssertionType", "/anyOf/1/$ref/properties/a/type", "#/$defs/D/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ false, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/a" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/anyOf/1/$ref/properties/a/type",
+          "#/$defs/D/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/a"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10912,22 +27915,70 @@
     "description": "any_of_reference_branch_empty",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "D": { "properties": { "a": { "type": "integer" } } } },
-      "anyOf": [ { "type": "object" }, { "$ref": "#/$defs/D" } ],
+      "$defs": {
+        "D": {
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/D"
+        }
+      ],
       "unevaluatedProperties": false
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10937,18 +27988,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "LogicalWhenType", "/anyOf/1/$ref/properties", "#/$defs/D/properties", "" ],
-        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/$ref/properties",
+          "#/$defs/D/properties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -10963,26 +28069,98 @@
     "description": "any_of_reference_branch_items",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$defs": { "D": { "prefixItems": [ { "type": "integer" } ] } },
-      "anyOf": [ { "type": "array" }, { "$ref": "#/$defs/D" } ],
+      "$defs": {
+        "D": {
+          "prefixItems": [
+            {
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/D"
+        }
+      ],
       "unevaluatedItems": false
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/$ref/prefixItems/0/type",
+          "#/$defs/D/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
-        [ true, "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/anyOf/1/$ref/prefixItems/0/type",
+          "#/$defs/D/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -10994,24 +28172,114 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
-        [ "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/$ref/prefixItems/0/type",
+          "#/$defs/D/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionType", "/anyOf/1/$ref/prefixItems/0/type", "#/$defs/D/prefixItems/0/type", "/0" ],
-        [ true, "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "", 0 ],
-        [ true, "Annotation", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "", true ],
-        [ true, "AssertionArrayPrefixEvaluate", "/anyOf/1/$ref/prefixItems", "#/$defs/D/prefixItems", "" ],
-        [ true, "ControlJump", "/anyOf/1/$ref", "#/anyOf/1/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopItemsUnevaluated", "/unevaluatedItems", "#/unevaluatedItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/anyOf/1/$ref/prefixItems/0/type",
+          "#/$defs/D/prefixItems/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          "",
+          0
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          "",
+          true
+        ],
+        [
+          true,
+          "AssertionArrayPrefixEvaluate",
+          "/anyOf/1/$ref/prefixItems",
+          "#/$defs/D/prefixItems",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/anyOf/1/$ref",
+          "#/anyOf/1/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopItemsUnevaluated",
+          "/unevaluatedItems",
+          "#/unevaluatedItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array",
@@ -11029,26 +28297,79 @@
     "description": "assertion_object_properties_simple_no_fusion_conditional_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "required": [ "flag" ] },
+      "if": {
+        "required": [
+          "flag"
+        ]
+      },
       "then": {
         "type": "object",
-        "required": [ "a", "b" ],
-        "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+        "required": [
+          "a",
+          "b"
+        ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "integer"
+          }
+        }
       },
-      "else": { "required": [ "a" ] }
+      "else": {
+        "required": [
+          "a"
+        ]
+      }
     },
-    "instance": { "bar": 1 },
+    "instance": {
+      "bar": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ false, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11058,14 +28379,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ false, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11078,28 +28432,94 @@
     "description": "assertion_object_properties_simple_no_fusion_conditional_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "required": [ "flag" ] },
+      "if": {
+        "required": [
+          "flag"
+        ]
+      },
       "then": {
         "type": "object",
-        "required": [ "a", "b" ],
-        "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+        "required": [
+          "a",
+          "b"
+        ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "integer"
+          }
+        }
       },
-      "else": { "required": [ "a" ] }
+      "else": {
+        "required": [
+          "a"
+        ]
+      }
     },
-    "instance": { "flag": true, "a": "x", "b": 1 },
+    "instance": {
+      "flag": true,
+      "a": "x",
+      "b": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefinesAllStrict", "/then/required", "#/then/required", "" ],
-        [ "AssertionObjectPropertiesSimple", "/then/properties", "#/then/properties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ true, "AssertionDefinesAllStrict", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionObjectPropertiesSimple", "/then/properties", "#/then/properties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11110,26 +28530,127 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefinesAllStrict", "/then/required", "#/then/required", "" ],
-        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "AssertionType", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "AssertionTypeStrict", "/then/type", "#/then/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/type",
+          "#/then/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ true, "AssertionDefinesAllStrict", "/then/required", "#/then/required", "" ],
-        [ true, "AssertionTypeStrict", "/then/properties/a/type", "#/then/properties/a/type", "/a" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "a" ],
-        [ true, "AssertionType", "/then/properties/b/type", "#/then/properties/b/type", "/b" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "b" ],
-        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ true, "AssertionTypeStrict", "/then/type", "#/then/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/then/required",
+          "#/then/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/properties/a/type",
+          "#/then/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/then/properties/b/type",
+          "#/then/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/then/type",
+          "#/then/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11148,26 +28669,80 @@
     "description": "assertion_object_properties_simple_no_fusion_conditional_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "required": [ "flag" ] },
+      "if": {
+        "required": [
+          "flag"
+        ]
+      },
       "then": {
         "type": "object",
-        "required": [ "a", "b" ],
-        "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+        "required": [
+          "a",
+          "b"
+        ],
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "integer"
+          }
+        }
       },
-      "else": { "required": [ "a" ] }
+      "else": {
+        "required": [
+          "a"
+        ]
+      }
     },
-    "instance": { "bar": 1, "a": "x" },
+    "instance": {
+      "bar": 1,
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ true, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11177,14 +28752,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ true, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11197,30 +28805,89 @@
     "description": "assertion_object_properties_simple_no_fusion_conditional_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "required": [ "flag" ] },
-      "then": { "$ref": "#/$defs/shared" },
-      "else": { "required": [ "a" ] },
-      "properties": { "other": { "$ref": "#/$defs/shared" } },
+      "if": {
+        "required": [
+          "flag"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/shared"
+      },
+      "else": {
+        "required": [
+          "a"
+        ]
+      },
+      "properties": {
+        "other": {
+          "$ref": "#/$defs/shared"
+        }
+      },
       "$defs": {
         "shared": {
           "type": "object",
-          "required": [ "a", "b" ],
-          "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+          "required": [
+            "a",
+            "b"
+          ],
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "type": "integer"
+            }
+          }
         }
       }
     },
-    "instance": { "bar": 1 },
+    "instance": {
+      "bar": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ false, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11230,14 +28897,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ "AssertionDefines", "/else/required", "#/else/required", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/if/required", "#/if/required", "" ],
-        [ false, "AssertionDefines", "/else/required", "#/else/required", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/if/required",
+          "#/if/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefines",
+          "/else/required",
+          "#/else/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"flag\"",
@@ -11250,32 +28950,97 @@
     "description": "assertion_object_properties_simple_no_fusion_conditional_5",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "object" },
-      "then": { "$ref": "#/$defs/shared" },
+      "if": {
+        "type": "object"
+      },
+      "then": {
+        "$ref": "#/$defs/shared"
+      },
       "else": true,
-      "properties": { "other": { "$ref": "#/$defs/shared" } },
+      "properties": {
+        "other": {
+          "$ref": "#/$defs/shared"
+        }
+      },
       "$defs": {
         "shared": {
           "type": "object",
-          "required": [ "a", "b" ],
-          "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+          "required": [
+            "a",
+            "b"
+          ],
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "type": "integer"
+            }
+          }
         }
       }
     },
-    "instance": { "a": 1, "b": 1 },
+    "instance": {
+      "a": 1,
+      "b": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionDefinesAllStrict", "/then/$ref/required", "#/$defs/shared/required", "" ],
-        [ "AssertionObjectPropertiesSimple", "/then/$ref/properties", "#/$defs/shared/properties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/then/$ref/required",
+          "#/$defs/shared/required",
+          ""
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/then/$ref/properties",
+          "#/$defs/shared/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesAllStrict", "/then/$ref/required", "#/$defs/shared/required", "" ],
-        [ false, "AssertionObjectPropertiesSimple", "/then/$ref/properties", "#/$defs/shared/properties", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/then/$ref/required",
+          "#/$defs/shared/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/then/$ref/properties",
+          "#/$defs/shared/properties",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -11286,20 +29051,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ "AssertionDefinesAllStrict", "/then/$ref/required", "#/$defs/shared/required", "" ],
-        [ "LogicalWhenType", "/then/$ref/properties", "#/$defs/shared/properties", "" ],
-        [ "AssertionTypeStrict", "/then/$ref/properties/a/type", "#/$defs/shared/properties/a/type", "/a" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/then/$ref/required",
+          "#/$defs/shared/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/then/$ref/properties",
+          "#/$defs/shared/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/then/$ref/properties/a/type",
+          "#/$defs/shared/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionDefinesAllStrict", "/then/$ref/required", "#/$defs/shared/required", "" ],
-        [ false, "AssertionTypeStrict", "/then/$ref/properties/a/type", "#/$defs/shared/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/then/$ref/properties", "#/$defs/shared/properties", "" ],
-        [ false, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/then/$ref/required",
+          "#/$defs/shared/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/then/$ref/properties/a/type",
+          "#/$defs/shared/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/then/$ref/properties",
+          "#/$defs/shared/properties",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -11317,30 +29148,105 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "dependentSchemas": {
         "foo": {
-          "properties": { "foo": { "type": "number" } },
+          "properties": {
+            "foo": {
+              "type": "number"
+            }
+          },
           "additionalProperties": false
         }
       },
-      "unevaluatedProperties": { "type": "integer" }
+      "unevaluatedProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "foo": 1, "az": 1 },
+    "instance": {
+      "foo": 1,
+      "az": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "AssertionPropertyTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ "AssertionFail", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "/az" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          "/az"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ true, "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ false, "AssertionFail", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "/az" ],
-        [ false, "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          "/az"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -11353,22 +29259,100 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "AssertionTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ "Annotation", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ "AssertionFail", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "/az" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          "/az"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ true, "Annotation", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "", "foo" ],
-        [ true, "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ false, "AssertionFail", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "/az" ],
-        [ false, "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ false, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          "/az"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -11387,30 +29371,104 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "dependentSchemas": {
         "foo": {
-          "properties": { "foo": { "type": "number" } },
+          "properties": {
+            "foo": {
+              "type": "number"
+            }
+          },
           "additionalProperties": false
         }
       },
-      "unevaluatedProperties": { "type": "integer" }
+      "unevaluatedProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "AssertionPropertyTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ true, "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ true, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ true, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -11423,22 +29481,100 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "AssertionTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ "Annotation", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "Annotation",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/dependentSchemas/foo/properties/foo/type", "#/dependentSchemas/foo/properties/foo/type", "/foo" ],
-        [ true, "Annotation", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "", "foo" ],
-        [ true, "LoopPropertiesMatch", "/dependentSchemas/foo/properties", "#/dependentSchemas/foo/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/dependentSchemas/foo/additionalProperties", "#/dependentSchemas/foo/additionalProperties", "" ],
-        [ true, "LogicalWhenDefines", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ true, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/dependentSchemas/foo/properties/foo/type",
+          "#/dependentSchemas/foo/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "Annotation",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          "",
+          "foo"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/dependentSchemas/foo/properties",
+          "#/dependentSchemas/foo/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/dependentSchemas/foo/additionalProperties",
+          "#/dependentSchemas/foo/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenDefines",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -11457,24 +29593,65 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "dependentSchemas": {
         "foo": {
-          "properties": { "foo": { "type": "number" } },
+          "properties": {
+            "foo": {
+              "type": "number"
+            }
+          },
           "additionalProperties": false
         }
       },
-      "unevaluatedProperties": { "type": "integer" }
+      "unevaluatedProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "bar": "x" },
+    "instance": {
+      "bar": "x"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionType", "/unevaluatedProperties/type", "#/unevaluatedProperties/type", "/bar" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedProperties/type",
+          "#/unevaluatedProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "AssertionType", "/unevaluatedProperties/type", "#/unevaluatedProperties/type", "/bar" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/unevaluatedProperties/type",
+          "#/unevaluatedProperties/type",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\"",
@@ -11484,14 +29661,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionType", "/unevaluatedProperties/type", "#/unevaluatedProperties/type", "/bar" ]
+        [
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/unevaluatedProperties/type",
+          "#/unevaluatedProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/dependentSchemas", "#/dependentSchemas", "" ],
-        [ false, "AssertionType", "/unevaluatedProperties/type", "#/unevaluatedProperties/type", "/bar" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/dependentSchemas",
+          "#/dependentSchemas",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/unevaluatedProperties/type",
+          "#/unevaluatedProperties/type",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\"",
@@ -11506,31 +29716,122 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "anyOf": [
-        { "properties": { "aaa": true, "bbb": { "type": "string" } } },
-        { "properties": { "bbb": true } }
+        {
+          "properties": {
+            "aaa": true,
+            "bbb": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bbb": true
+          }
+        }
       ],
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "bbb": 2 },
+    "instance": {
+      "aaa": 1,
+      "bbb": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ true, "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ false, "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The instance location was marked as evaluated",
@@ -11544,30 +29845,153 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "", "aaa" ],
-        [ true, "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ false, "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ false, "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ true, "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "", "bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "",
+          "aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property \"aaa\" successfully validated against its property subschema",
@@ -11590,27 +30014,95 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "anyOf": [
-        { "properties": { "aaa": true, "bbb": { "type": "string" } } },
-        { "properties": { "bbb": true } }
+        {
+          "properties": {
+            "aaa": true,
+            "bbb": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bbb": true
+          }
+        }
       ],
       "unevaluatedProperties": false
     },
-    "instance": { "bbb": 2 },
+    "instance": {
+      "bbb": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -11622,24 +30114,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ false, "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ true, "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "", "bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -11659,29 +30240,109 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "anyOf": [
-        { "properties": { "aaa": true, "bbb": { "type": "string" } } },
-        { "properties": { "bbb": true } }
+        {
+          "properties": {
+            "aaa": true,
+            "bbb": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "properties": {
+            "bbb": true
+          }
+        }
       ],
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "bbb": "x" },
+    "instance": {
+      "aaa": 1,
+      "bbb": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ true, "AssertionPropertyTypeStrictEvaluate", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The instance location was marked as evaluated",
@@ -11694,32 +30355,167 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/bbb" ],
-        [ "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/bbb"
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "", "aaa" ],
-        [ true, "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/aaa" ],
-        [ true, "AssertionTypeStrict", "/anyOf/0/properties/bbb/type", "#/anyOf/0/properties/bbb/type", "/bbb" ],
-        [ true, "Annotation", "/anyOf/0/properties", "#/anyOf/0/properties", "", "bbb" ],
-        [ true, "Evaluate", "/anyOf/0/properties", "#/anyOf/0/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ true, "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "", "bbb" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "",
+          "aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/aaa"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/properties/bbb/type",
+          "#/anyOf/0/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property \"aaa\" successfully validated against its property subschema",
@@ -11744,31 +30540,111 @@
       "type": "object",
       "oneOf": [
         {
-          "properties": { "aaa": true, "bbb": { "type": "string" } },
-          "required": [ "zzz" ]
+          "properties": {
+            "aaa": true,
+            "bbb": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "zzz"
+          ]
         },
-        { "properties": { "bbb": true } }
+        {
+          "properties": {
+            "bbb": true
+          }
+        }
       ],
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "bbb": 2 },
+    "instance": {
+      "aaa": 1,
+      "bbb": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionDefines", "/oneOf/0/required", "#/oneOf/0/required", "" ],
-        [ "Evaluate", "/oneOf/1/properties", "#/oneOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/oneOf/0/required",
+          "#/oneOf/0/required",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/oneOf/0/required", "#/oneOf/0/required", "" ],
-        [ true, "Evaluate", "/oneOf/1/properties", "#/oneOf/1/properties", "/bbb" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/oneOf/0/required",
+          "#/oneOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "Evaluate",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"zzz\"",
@@ -11781,24 +30657,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionDefines", "/oneOf/0/required", "#/oneOf/0/required", "" ],
-        [ "LogicalWhenType", "/oneOf/1/properties", "#/oneOf/1/properties", "" ],
-        [ "Annotation", "/oneOf/1/properties", "#/oneOf/1/properties", "" ],
-        [ "Evaluate", "/oneOf/1/properties", "#/oneOf/1/properties", "/bbb" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/oneOf/0/required",
+          "#/oneOf/0/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          "/bbb"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/oneOf/0/required", "#/oneOf/0/required", "" ],
-        [ true, "Annotation", "/oneOf/1/properties", "#/oneOf/1/properties", "", "bbb" ],
-        [ true, "Evaluate", "/oneOf/1/properties", "#/oneOf/1/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/oneOf/1/properties", "#/oneOf/1/properties", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/oneOf/0/required",
+          "#/oneOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"zzz\"",
@@ -11816,28 +30781,108 @@
     "description": "failed_condition_does_not_evaluate",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "properties": { "aaa": true, "bbb": { "type": "string" } } },
-      "else": { "properties": { "bbb": true } },
+      "if": {
+        "properties": {
+          "aaa": true,
+          "bbb": {
+            "type": "string"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "bbb": true
+        }
+      },
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "bbb": 2 },
+    "instance": {
+      "aaa": 1,
+      "bbb": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ "AssertionPropertyTypeStrictEvaluate", "/if/properties/bbb/type", "#/if/properties/bbb/type", "/bbb" ],
-        [ "Evaluate", "/else/properties", "#/else/properties", "/bbb" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionPropertyTypeStrictEvaluate",
+          "/if/properties/bbb/type",
+          "#/if/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "Evaluate",
+          "/else/properties",
+          "#/else/properties",
+          "/bbb"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ true, "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ false, "AssertionPropertyTypeStrictEvaluate", "/if/properties/bbb/type", "#/if/properties/bbb/type", "/bbb" ],
-        [ true, "Evaluate", "/else/properties", "#/else/properties", "/bbb" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrictEvaluate",
+          "/if/properties/bbb/type",
+          "#/if/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/else/properties",
+          "#/else/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The instance location was marked as evaluated",
@@ -11850,28 +30895,140 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ "Annotation", "/if/properties", "#/if/properties", "" ],
-        [ "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ "AssertionTypeStrict", "/if/properties/bbb/type", "#/if/properties/bbb/type", "/bbb" ],
-        [ "LogicalWhenType", "/else/properties", "#/else/properties", "" ],
-        [ "Annotation", "/else/properties", "#/else/properties", "" ],
-        [ "Evaluate", "/else/properties", "#/else/properties", "/bbb" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/properties/bbb/type",
+          "#/if/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          "LogicalWhenType",
+          "/else/properties",
+          "#/else/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/else/properties",
+          "#/else/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/else/properties",
+          "#/else/properties",
+          "/bbb"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ]
       ],
       "post": [
-        [ true, "Annotation", "/if/properties", "#/if/properties", "", "aaa" ],
-        [ true, "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ false, "AssertionTypeStrict", "/if/properties/bbb/type", "#/if/properties/bbb/type", "/bbb" ],
-        [ false, "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ true, "Annotation", "/else/properties", "#/else/properties", "", "bbb" ],
-        [ true, "Evaluate", "/else/properties", "#/else/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/else/properties", "#/else/properties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/aaa" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          "",
+          "aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/properties/bbb/type",
+          "#/if/properties/bbb/type",
+          "/bbb"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/else/properties",
+          "#/else/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/else/properties",
+          "#/else/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/else/properties",
+          "#/else/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/aaa"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property \"aaa\" successfully validated against its property subschema",
@@ -11891,24 +31048,81 @@
     "description": "passing_condition_evaluates",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "properties": { "aaa": { "type": "integer" } } },
-      "then": { "properties": { "bbb": true } },
+      "if": {
+        "properties": {
+          "aaa": {
+            "type": "integer"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "bbb": true
+        }
+      },
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "bbb": 2 },
+    "instance": {
+      "aaa": 1,
+      "bbb": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ "Evaluate", "/then/properties", "#/then/properties", "/bbb" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/bbb"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeEvaluate", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ true, "Evaluate", "/then/properties", "#/then/properties", "/bbb" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeEvaluate",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -11919,26 +31133,127 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ "AssertionType", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ "Annotation", "/if/properties", "#/if/properties", "" ],
-        [ "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ "Annotation", "/then/properties", "#/then/properties", "" ],
-        [ "Evaluate", "/then/properties", "#/then/properties", "/bbb" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/bbb"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ true, "Annotation", "/if/properties", "#/if/properties", "", "aaa" ],
-        [ true, "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ true, "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ true, "Annotation", "/then/properties", "#/then/properties", "", "bbb" ],
-        [ true, "Evaluate", "/then/properties", "#/then/properties", "/bbb" ],
-        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          true,
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          "",
+          "aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          true,
+          "Annotation",
+          "/then/properties",
+          "#/then/properties",
+          "",
+          "bbb"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/then/properties",
+          "#/then/properties",
+          "/bbb"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -11957,24 +31272,81 @@
     "description": "passing_condition_evaluates_unknown",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "properties": { "aaa": { "type": "integer" } } },
-      "then": { "properties": { "bbb": true } },
+      "if": {
+        "properties": {
+          "aaa": {
+            "type": "integer"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "bbb": true
+        }
+      },
       "unevaluatedProperties": false
     },
-    "instance": { "aaa": 1, "ccc": 2 },
+    "instance": {
+      "aaa": 1,
+      "ccc": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/ccc" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/ccc"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeEvaluate", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/ccc" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeEvaluate",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/ccc"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -11985,24 +31357,113 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ "AssertionType", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ "Annotation", "/if/properties", "#/if/properties", "" ],
-        [ "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ],
-        [ "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/ccc" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/ccc"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/if/properties/aaa/type", "#/if/properties/aaa/type", "/aaa" ],
-        [ true, "Annotation", "/if/properties", "#/if/properties", "", "aaa" ],
-        [ true, "Evaluate", "/if/properties", "#/if/properties", "/aaa" ],
-        [ true, "LogicalWhenType", "/if/properties", "#/if/properties", "" ],
-        [ true, "LogicalWhenType", "/then/properties", "#/then/properties", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ],
-        [ false, "AssertionFail", "/unevaluatedProperties", "#/unevaluatedProperties", "/ccc" ],
-        [ false, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/if/properties/aaa/type",
+          "#/if/properties/aaa/type",
+          "/aaa"
+        ],
+        [
+          true,
+          "Annotation",
+          "/if/properties",
+          "#/if/properties",
+          "",
+          "aaa"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/if/properties",
+          "#/if/properties",
+          "/aaa"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/if/properties",
+          "#/if/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/then/properties",
+          "#/then/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          "/ccc"
+        ],
+        [
+          false,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -12020,23 +31481,80 @@
     "description": "any_of_inlined_branch_evaluates",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "type": "object" }, { "properties": { "a": { "type": "integer" } } } ],
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "properties": {
+            "a": {
+              "type": "integer"
+            }
+          }
+        }
+      ],
       "unevaluatedProperties": false
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionPropertyTypeEvaluate", "/anyOf/1/properties/a/type", "#/anyOf/1/properties/a/type", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/properties/a/type",
+          "#/anyOf/1/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionPropertyTypeEvaluate", "/anyOf/1/properties/a/type", "#/anyOf/1/properties/a/type", "/a" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeEvaluate",
+          "/anyOf/1/properties/a/type",
+          "#/anyOf/1/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -12047,22 +31565,100 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "AssertionType", "/anyOf/1/properties/a/type", "#/anyOf/1/properties/a/type", "/a" ],
-        [ "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/a" ],
-        [ "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/anyOf/1/properties/a/type",
+          "#/anyOf/1/properties/a/type",
+          "/a"
+        ],
+        [
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/a"
+        ],
+        [
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionType", "/anyOf/1/properties/a/type", "#/anyOf/1/properties/a/type", "/a" ],
-        [ true, "Annotation", "/anyOf/1/properties", "#/anyOf/1/properties", "", "a" ],
-        [ true, "Evaluate", "/anyOf/1/properties", "#/anyOf/1/properties", "/a" ],
-        [ true, "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "LoopPropertiesUnevaluated", "/unevaluatedProperties", "#/unevaluatedProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/anyOf/1/properties/a/type",
+          "#/anyOf/1/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "Annotation",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "",
+          "a"
+        ],
+        [
+          true,
+          "Evaluate",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesUnevaluated",
+          "/unevaluatedProperties",
+          "#/unevaluatedProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -12079,27 +31675,94 @@
     "description": "if_then_else_inlined_ref_1",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "string" },
-      "then": { "$ref": "#/$defs/library", "const": "abcde" },
-      "else": { "type": "integer" },
-      "$defs": { "library": { "minLength": 2, "maxLength": 10 } }
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "$ref": "#/$defs/library",
+        "const": "abcde"
+      },
+      "else": {
+        "type": "integer"
+      },
+      "$defs": {
+        "library": {
+          "minLength": 2,
+          "maxLength": 10
+        }
+      }
     },
     "instance": "abcde",
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -12111,20 +31774,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ true, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -12140,27 +31869,94 @@
     "description": "if_then_else_inlined_ref_2",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "string" },
-      "then": { "$ref": "#/$defs/library", "const": "abcde" },
-      "else": { "type": "integer" },
-      "$defs": { "library": { "minLength": 2, "maxLength": 10 } }
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "$ref": "#/$defs/library",
+        "const": "abcde"
+      },
+      "else": {
+        "type": "integer"
+      },
+      "$defs": {
+        "library": {
+          "minLength": 2,
+          "maxLength": 10
+        }
+      }
     },
     "instance": "abcdef",
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -12172,20 +31968,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ "AssertionEqual", "/then/const", "#/then/const", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionStringSizeLess", "/then/$ref/maxLength", "#/$defs/library/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/then/$ref/minLength", "#/$defs/library/minLength", "" ],
-        [ true, "ControlJump", "/then/$ref", "#/then/$ref", "" ],
-        [ false, "AssertionEqual", "/then/const", "#/then/const", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/then/$ref/maxLength",
+          "#/$defs/library/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/then/$ref/minLength",
+          "#/$defs/library/minLength",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/then/$ref",
+          "#/then/$ref",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/then/const",
+          "#/then/const",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -12201,23 +32063,68 @@
     "description": "if_then_else_inlined_ref_3",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "string" },
-      "then": { "$ref": "#/$defs/library", "const": "abcde" },
-      "else": { "type": "integer" },
-      "$defs": { "library": { "minLength": 2, "maxLength": 10 } }
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "$ref": "#/$defs/library",
+        "const": "abcde"
+      },
+      "else": {
+        "type": "integer"
+      },
+      "$defs": {
+        "library": {
+          "minLength": 2,
+          "maxLength": 10
+        }
+      }
     },
     "instance": 7,
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionType", "/else/type", "#/else/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionType", "/else/type", "#/else/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -12227,14 +32134,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionType", "/else/type", "#/else/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ true, "AssertionType", "/else/type", "#/else/type", "" ],
-        [ true, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -12247,23 +32187,68 @@
     "description": "if_then_else_inlined_ref_4",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "if": { "type": "string" },
-      "then": { "$ref": "#/$defs/library", "const": "abcde" },
-      "else": { "type": "integer" },
-      "$defs": { "library": { "minLength": 2, "maxLength": 10 } }
+      "if": {
+        "type": "string"
+      },
+      "then": {
+        "$ref": "#/$defs/library",
+        "const": "abcde"
+      },
+      "else": {
+        "type": "integer"
+      },
+      "$defs": {
+        "library": {
+          "minLength": 2,
+          "maxLength": 10
+        }
+      }
     },
     "instance": true,
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionType", "/else/type", "#/else/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionType", "/else/type", "#/else/type", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -12273,14 +32258,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalCondition", "/if", "#/if", "" ],
-        [ "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ "AssertionType", "/else/type", "#/else/type", "" ]
+        [
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/if/type", "#/if/type", "" ],
-        [ false, "AssertionType", "/else/type", "#/else/type", "" ],
-        [ false, "LogicalCondition", "/if", "#/if", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/if/type",
+          "#/if/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/else/type",
+          "#/else/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalCondition",
+          "/if",
+          "#/if",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -190,27 +190,13 @@ TEST(type_integer_bounded_5) {
   })JSON")};
 
   const sourcemeta::core::JSON instance{3.0};
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3, "");
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1, "");
 
-  EVALUATE_TRACE_PRE(0, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_PRE(1, AssertionLessEqual, "/maximum", "#/maximum", "");
-  EVALUATE_TRACE_PRE(2, AssertionGreaterEqual, "/minimum", "#/minimum", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionLessEqual, "/maximum", "#/maximum",
-                              "");
-  EVALUATE_TRACE_POST_SUCCESS(2, AssertionGreaterEqual, "/minimum", "#/minimum",
-                              "");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The value was expected to be of type integer");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The number value 3.0 was expected to be less "
-                               "than or equal to the integer 100");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The number value 3.0 was expected to be "
-                               "greater than or equal to the integer 0");
+  EVALUATE_TRACE_PRE(0, AssertionTypeIntegerBounded, "", "#", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeIntegerBounded, "", "#", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an integer within the given range");
 }
 
 TEST(type_integer_lower_bound_3) {
@@ -221,20 +207,13 @@ TEST(type_integer_lower_bound_3) {
   })JSON")};
 
   const sourcemeta::core::JSON instance{5.0};
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 2, "");
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1, "");
 
-  EVALUATE_TRACE_PRE(0, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_PRE(1, AssertionGreaterEqual, "/minimum", "#/minimum", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionGreaterEqual, "/minimum", "#/minimum",
-                              "");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The value was expected to be of type integer");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The number value 5.0 was expected to be "
-                               "greater than or equal to the integer 1");
+  EVALUATE_TRACE_PRE(0, AssertionTypeIntegerLowerBound, "", "#", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeIntegerLowerBound, "", "#", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an integer above the given minimum");
 }
 
 TEST(prop_type_integer_bounded_6) {

--- a/test/evaluator/evaluator_draft3_test.cc
+++ b/test/evaluator/evaluator_draft3_test.cc
@@ -37,7 +37,7 @@ TEST(metaschema_self) {
   const auto metaschema{sourcemeta::blaze::schema_resolver(
       "http://json-schema.org/draft-03/schema#")};
   EXPECT_TRUE(metaschema.has_value());
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(metaschema.value(), metaschema.value(), 312,
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(metaschema.value(), metaschema.value(), 311,
                                    "");
 }
 

--- a/test/evaluator/evaluator_draft4.json
+++ b/test/evaluator/evaluator_draft4.json
@@ -1,7 +1,10 @@
 [
   {
     "description": "unknown_keyword",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "foobar": "baz" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "foobar": "baz"
+    },
     "instance": "foo bar",
     "valid": true,
     "fast": {},
@@ -9,7 +12,10 @@
   },
   {
     "description": "annotation_keyword",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "title": "foo" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "foo"
+    },
     "instance": "foo bar",
     "valid": true,
     "fast": {},
@@ -17,15 +23,29 @@
   },
   {
     "description": "type_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "string" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string"
+    },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -33,10 +53,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -53,10 +84,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -64,10 +106,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -76,15 +129,29 @@
   },
   {
     "description": "type_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "string" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "string"
+    },
     "instance": 5,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -92,10 +159,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -104,15 +182,29 @@
   },
   {
     "description": "type_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "number" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "number"
+    },
     "instance": 5,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -120,10 +212,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -132,15 +235,29 @@
   },
   {
     "description": "type_4",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "number" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "number"
+    },
     "instance": 3.14,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -148,10 +265,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -160,15 +288,29 @@
   },
   {
     "description": "type_5",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "number" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "number"
+    },
     "instance": "3.14",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string"
@@ -176,10 +318,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string"
@@ -190,16 +343,29 @@
     "description": "type_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "string" ]
+      "type": [
+        "string"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -207,10 +373,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -221,16 +398,29 @@
     "description": "type_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "string" ]
+      "type": [
+        "string"
+      ]
     },
     "instance": 5,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -238,10 +428,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -252,16 +453,31 @@
     "description": "type_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "string", "number", "object" ]
+      "type": [
+        "string",
+        "number",
+        "object"
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, string, or object and it was of type number"
@@ -269,10 +485,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, string, or object and it was of type number"
@@ -283,16 +510,31 @@
     "description": "type_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "string", "number", "object" ]
+      "type": [
+        "string",
+        "number",
+        "object"
+      ]
     },
     "instance": true,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, string, or object but it was of type boolean"
@@ -300,10 +542,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, string, or object but it was of type boolean"
@@ -312,15 +565,29 @@
   },
   {
     "description": "type_10",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "type": "integer" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "type": "integer"
+    },
     "instance": 12345678910111213141516171819202122232425262728293031,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -328,10 +595,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -342,16 +620,30 @@
     "description": "type_12",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "integer", "string" ]
+      "type": [
+        "integer",
+        "string"
+      ]
     },
     "instance": 12345678910111213141516171819202122232425262728293031,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer"
@@ -359,10 +651,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer"
@@ -373,7 +676,9 @@
     "description": "required_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo" ]
+      "required": [
+        "foo"
+      ]
     },
     "instance": "foo bar",
     "valid": true,
@@ -384,16 +689,32 @@
     "description": "required_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo" ]
+      "required": [
+        "foo"
+      ]
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"foo\""
@@ -401,10 +722,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefines", "/required", "#/required", "" ]
+        [
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"foo\""
@@ -415,16 +747,33 @@
     "description": "required_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "baz" ]
+      "required": [
+        "foo",
+        "baz"
+      ]
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAll", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAll", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define properties \"baz\", and \"foo\" but did not define the property \"baz\""
@@ -432,10 +781,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAll", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAll", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define properties \"baz\", and \"foo\" but did not define the property \"baz\""
@@ -447,16 +807,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ]
+      "required": [
+        "foo",
+        "bar"
+      ]
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"foo\""
@@ -464,12 +841,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"foo\"",
@@ -482,21 +881,55 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": true, "bar": true },
-      "patternProperties": { "^@": {} },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": true,
+        "bar": true
+      },
+      "patternProperties": {
+        "^@": {}
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": true, "bar": true, "@baz": true },
+    "instance": {
+      "foo": true,
+      "bar": true,
+      "@baz": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"foo\"",
@@ -505,14 +938,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"foo\"",
@@ -526,16 +992,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "foo": { "required": "bar" } }
+      "properties": {
+        "foo": {
+          "required": "bar"
+        }
+      }
     },
-    "instance": { "foo": {} },
+    "instance": {
+      "foo": {}
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -543,10 +1026,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -557,18 +1051,53 @@
     "description": "allOf_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [ { "type": "object" }, { "required": [ "foo", "bar" ] } ]
+      "allOf": [
+        {
+          "type": "object"
+        },
+        {
+          "required": [
+            "foo",
+            "bar"
+          ]
+        }
+      ]
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ true, "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -577,14 +1106,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ true, "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ],
-        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -597,18 +1159,53 @@
     "description": "allOf_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [ { "type": "object" }, { "required": [ "foo", "bar" ] } ]
+      "allOf": [
+        {
+          "type": "object"
+        },
+        {
+          "required": [
+            "foo",
+            "bar"
+          ]
+        }
+      ]
     },
-    "instance": { "foo": 1, "baz": 2 },
+    "instance": {
+      "foo": 1,
+      "baz": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -617,14 +1214,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "AssertionDefinesAll", "/allOf/1/required", "#/allOf/1/required", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionDefinesAll",
+          "/allOf/1/required",
+          "#/allOf/1/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -637,17 +1267,36 @@
     "description": "ref_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [ { "$ref": "#/definitions/string" } ],
-      "definitions": { "string": { "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/string"
+        }
+      ],
+      "definitions": {
+        "string": {
+          "type": "string"
+        }
+      }
     },
     "instance": 5,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -655,14 +1304,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ],
-        [ false, "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -675,17 +1357,36 @@
     "description": "ref_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [ { "$ref": "#/definitions/string" } ],
-      "definitions": { "string": { "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/string"
+        }
+      ],
+      "definitions": {
+        "string": {
+          "type": "string"
+        }
+      }
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -693,14 +1394,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/definitions/string/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/definitions/string/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -715,20 +1449,59 @@
       "id": "https://example.com",
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "foo": { "$ref": "https://example.com" } }
+      "properties": {
+        "foo": {
+          "$ref": "https://example.com"
+        }
+      }
     },
-    "instance": { "foo": {} },
+    "instance": {
+      "foo": {}
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ true, "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -738,18 +1511,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "https://example.com#/properties", "" ],
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "https://example.com#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -766,24 +1594,87 @@
       "id": "https://example.com",
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "foo": { "$ref": "https://example.com" } }
+      "properties": {
+        "foo": {
+          "$ref": "https://example.com"
+        }
+      }
     },
-    "instance": { "foo": { "foo": {} } },
+    "instance": {
+      "foo": {
+        "foo": {}
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ true, "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -795,24 +1686,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "https://example.com#/properties", "" ],
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/properties/foo/$ref/properties", "https://example.com#/properties", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/foo/$ref/properties/foo/$ref/properties", "https://example.com#/properties", "/foo/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ true, "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "https://example.com#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "https://example.com#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "https://example.com#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "https://example.com#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -832,20 +1811,61 @@
       "id": "https://example.com",
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "foo": { "$ref": "https://example.com" } }
+      "properties": {
+        "foo": {
+          "$ref": "https://example.com"
+        }
+      }
     },
-    "instance": { "foo": { "foo": 1 } },
+    "instance": {
+      "foo": {
+        "foo": 1
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ]
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ false, "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ false, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type integer",
@@ -855,18 +1875,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "https://example.com#/properties", "" ],
-        [ "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/foo/$ref/properties/foo/$ref/type", "https://example.com#/type", "/foo/foo" ],
-        [ false, "ControlJump", "/properties/foo/$ref/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo/foo" ],
-        [ false, "LogicalWhenType", "/properties/foo/$ref/properties", "https://example.com#/properties", "/foo" ],
-        [ false, "ControlJump", "/properties/foo/$ref", "https://example.com#/properties/foo/$ref", "/foo" ],
-        [ false, "LogicalWhenType", "/properties", "https://example.com#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/properties/foo/$ref/type",
+          "https://example.com#/type",
+          "/foo/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/foo/$ref/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "https://example.com#/properties",
+          "/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "https://example.com#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "https://example.com#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type integer",
@@ -882,20 +1957,59 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "foo": { "$ref": "#" } }
+      "properties": {
+        "foo": {
+          "$ref": "#"
+        }
+      }
     },
-    "instance": { "foo": {} },
+    "instance": {
+      "foo": {}
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object",
@@ -905,18 +2019,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/properties", "#/properties", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/$ref/type", "#/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "#/properties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "#/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/foo/$ref/properties", "#/properties", "/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/$ref/type", "#/type", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/$ref/properties",
+          "#/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/$ref/type",
+          "#/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -932,22 +2101,47 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "a": { "$ref": "#" },
-        "b": { "$ref": "#" },
-        "c": { "$ref": "#" },
-        "d": { "$ref": "#" },
-        "e": { "$ref": "#" },
-        "f": { "$ref": "#" }
+        "a": {
+          "$ref": "#"
+        },
+        "b": {
+          "$ref": "#"
+        },
+        "c": {
+          "$ref": "#"
+        },
+        "d": {
+          "$ref": "#"
+        },
+        "e": {
+          "$ref": "#"
+        },
+        "f": {
+          "$ref": "#"
+        }
       }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas"
@@ -955,10 +2149,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas"
@@ -969,10 +2174,22 @@
     "description": "ref_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "allOf": [ { "$ref": "#/definitions/foo" } ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/foo"
+        }
+      ],
       "definitions": {
-        "foo": { "additionalProperties": { "$ref": "#/definitions/bar" } },
-        "bar": { "additionalProperties": { "$ref": "#/definitions/foo" } }
+        "foo": {
+          "additionalProperties": {
+            "$ref": "#/definitions/bar"
+          }
+        },
+        "bar": {
+          "additionalProperties": {
+            "$ref": "#/definitions/foo"
+          }
+        }
       }
     },
     "instance": true,
@@ -980,12 +2197,34 @@
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value was expected to validate against the referenced schema",
@@ -997,17 +2236,39 @@
     "description": "ref_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalProperties": { "$ref": "#/definitions/one" },
-      "definitions": { "one": { "$ref": "#/definitions/two" }, "two": { "type": "boolean" } }
+      "additionalProperties": {
+        "$ref": "#/definitions/one"
+      },
+      "definitions": {
+        "one": {
+          "$ref": "#/definitions/two"
+        },
+        "two": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true },
+    "instance": {
+      "foo": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type boolean"
@@ -1015,16 +2276,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ "ControlJump", "/additionalProperties/$ref/$ref", "#/definitions/one/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "/foo" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref/$ref",
+          "#/definitions/one/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "/foo" ],
-        [ true, "ControlJump", "/additionalProperties/$ref/$ref", "#/definitions/one/$ref", "/foo" ],
-        [ true, "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/additionalProperties/$ref/$ref",
+          "#/definitions/one/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1038,18 +2343,42 @@
     "description": "ref_10",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "$ref": "#/definitions/one" },
-      "additionalProperties": { "$ref": "#/definitions/one" },
-      "definitions": { "one": { "$ref": "#/definitions/two" }, "two": { "type": "boolean" } }
+      "items": {
+        "$ref": "#/definitions/one"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/one"
+      },
+      "definitions": {
+        "one": {
+          "$ref": "#/definitions/two"
+        },
+        "two": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true },
+    "instance": {
+      "foo": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type boolean"
@@ -1057,16 +2386,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ "ControlJump", "/additionalProperties/$ref/$ref", "#/definitions/one/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "/foo" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref/$ref",
+          "#/definitions/one/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/$ref/$ref/type", "#/definitions/two/type", "/foo" ],
-        [ true, "ControlJump", "/additionalProperties/$ref/$ref", "#/definitions/one/$ref", "/foo" ],
-        [ true, "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/$ref/type",
+          "#/definitions/two/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/additionalProperties/$ref/$ref",
+          "#/definitions/one/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -1080,23 +2453,52 @@
     "description": "ref_15",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "$ref": "#/definitions/three" } },
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/three"
+        }
+      },
       "definitions": {
-        "three": { "$ref": "#/definitions/four" },
-        "four": { "$ref": "#/definitions/five" },
+        "three": {
+          "$ref": "#/definitions/four"
+        },
+        "four": {
+          "$ref": "#/definitions/five"
+        },
         "five": {
-          "properties": { "requires": { "additionalProperties": { "type": "string" } } }
+          "properties": {
+            "requires": {
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
-    "instance": { "foo": { "bar": {} } },
+    "instance": {
+      "foo": {
+        "bar": {}
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "ControlJump", "/properties/foo/$ref/$ref", "#/definitions/three/$ref", "/foo" ]
+        [
+          "ControlJump",
+          "/properties/foo/$ref/$ref",
+          "#/definitions/three/$ref",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/properties/foo/$ref/$ref", "#/definitions/three/$ref", "/foo" ]
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref/$ref",
+          "#/definitions/three/$ref",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the referenced schema"
@@ -1104,18 +2506,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/$ref", "#/definitions/three/$ref", "/foo" ],
-        [ "ControlJump", "/properties/foo/$ref/$ref/$ref", "#/definitions/four/$ref", "/foo" ],
-        [ "LogicalWhenType", "/properties/foo/$ref/$ref/$ref/properties", "#/definitions/five/properties", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/$ref",
+          "#/definitions/three/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/foo/$ref/$ref/$ref",
+          "#/definitions/four/$ref",
+          "/foo"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/$ref/$ref/$ref/properties",
+          "#/definitions/five/properties",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/foo/$ref/$ref/$ref/properties", "#/definitions/five/properties", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref/$ref/$ref", "#/definitions/four/$ref", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref/$ref", "#/definitions/three/$ref", "/foo" ],
-        [ true, "ControlJump", "/properties/foo/$ref", "#/properties/foo/$ref", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/$ref/$ref/$ref/properties",
+          "#/definitions/five/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref/$ref/$ref",
+          "#/definitions/four/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref/$ref",
+          "#/definitions/three/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/foo/$ref",
+          "#/properties/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -1130,18 +2587,50 @@
     "description": "properties_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "string" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ false, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1150,14 +2639,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ false, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1170,18 +2692,50 @@
     "description": "properties_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "string" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "bar": 2, "foo": "xxx" },
+    "instance": {
+      "bar": 2,
+      "foo": "xxx"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1190,14 +2744,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1210,17 +2797,37 @@
     "description": "properties_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "string" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "baz": [] },
+    "instance": {
+      "baz": []
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined properties subschemas"
@@ -1231,16 +2838,39 @@
     "description": "properties_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "properties": { "bar": { "type": "string" } } } }
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
-    "instance": { "foo": { "bar": "baz" } },
+    "instance": {
+      "foo": {
+        "bar": "baz"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -1248,14 +2878,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ],
-        [ true, "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1269,17 +2932,41 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": { "type": "string" }, "bar": { "type": "integer" } }
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": "xxx", "bar": 2 },
+    "instance": {
+      "foo": "xxx",
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -1287,18 +2974,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"foo\"",
@@ -1315,20 +3057,39 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
         "image": {
-          "required": [ "file" ],
-          "properties": { "file": { "type": "string" } }
+          "required": [
+            "file"
+          ],
+          "properties": {
+            "file": {
+              "type": "string"
+            }
+          }
         }
       }
     },
-    "instance": { "image": "foo" },
+    "instance": {
+      "image": "foo"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -1340,22 +3101,63 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "foo": { "type": "string", "pattern": "^a" },
-        "bar": { "type": "integer" }
+        "foo": {
+          "type": "string",
+          "pattern": "^a"
+        },
+        "bar": {
+          "type": "integer"
+        }
       }
     },
-    "instance": { "bar": 2, "foo": "abc" },
+    "instance": {
+      "bar": 2,
+      "foo": "abc"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionRegex", "/properties/foo/pattern", "#/properties/foo/pattern", "/foo" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionRegex",
+          "/properties/foo/pattern",
+          "#/properties/foo/pattern",
+          "/foo"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionRegex", "/properties/foo/pattern", "#/properties/foo/pattern", "/foo" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/foo/pattern",
+          "#/properties/foo/pattern",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1365,16 +3167,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionRegex", "/properties/foo/pattern", "#/properties/foo/pattern", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionRegex",
+          "/properties/foo/pattern",
+          "#/properties/foo/pattern",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionRegex", "/properties/foo/pattern", "#/properties/foo/pattern", "/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/foo/pattern",
+          "#/properties/foo/pattern",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1389,22 +3235,63 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "bar": { "type": "string", "pattern": "^a" },
-        "foo": { "type": "integer" }
+        "bar": {
+          "type": "string",
+          "pattern": "^a"
+        },
+        "foo": {
+          "type": "integer"
+        }
       }
     },
-    "instance": { "foo": 2, "bar": "abc" },
+    "instance": {
+      "foo": 2,
+      "bar": "abc"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1414,16 +3301,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1437,16 +3368,39 @@
     "description": "properties_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "properties": { "bar": { "type": "number" } } } }
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {
+              "type": "number"
+            }
+          }
+        }
+      }
     },
-    "instance": { "foo": { "bar": 1 } },
+    "instance": {
+      "foo": {
+        "bar": 1
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrictAny", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrictAny", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -1454,14 +3408,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ],
-        [ "AssertionTypeStrictAny", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/properties/foo/properties/bar/type", "#/properties/foo/properties/bar/type", "/foo/bar" ],
-        [ true, "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/foo/properties/bar/type",
+          "#/properties/foo/properties/bar/type",
+          "/foo/bar"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1474,16 +3461,33 @@
     "description": "properties_10",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "number" } }
+      "properties": {
+        "foo": {
+          "type": "number"
+        }
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number"
@@ -1491,12 +3495,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -1509,28 +3535,108 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "foo": { "items": { "type": "number", "multipleOf": 3, "maximum": 100 } },
-        "bar": { "type": "string", "pattern": "^a" }
+        "foo": {
+          "items": {
+            "type": "number",
+            "multipleOf": 3,
+            "maximum": 100
+          }
+        },
+        "bar": {
+          "type": "string",
+          "pattern": "^a"
+        }
       }
     },
-    "instance": { "foo": [ 3 ], "bar": "abc" },
+    "instance": {
+      "foo": [
+        3
+      ],
+      "bar": "abc"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "LoopItems", "/properties/foo/items", "#/properties/foo/items", "/foo" ],
-        [ "AssertionLessEqual", "/properties/foo/items/maximum", "#/properties/foo/items/maximum", "/foo/0" ],
-        [ "AssertionDivisible", "/properties/foo/items/multipleOf", "#/properties/foo/items/multipleOf", "/foo/0" ],
-        [ "AssertionTypeStrictAny", "/properties/foo/items/type", "#/properties/foo/items/type", "/foo/0" ]
+        [
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "LoopItems",
+          "/properties/foo/items",
+          "#/properties/foo/items",
+          "/foo"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/foo/items/maximum",
+          "#/properties/foo/items/maximum",
+          "/foo/0"
+        ],
+        [
+          "AssertionDivisible",
+          "/properties/foo/items/multipleOf",
+          "#/properties/foo/items/multipleOf",
+          "/foo/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/foo/items/type",
+          "#/properties/foo/items/type",
+          "/foo/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionLessEqual", "/properties/foo/items/maximum", "#/properties/foo/items/maximum", "/foo/0" ],
-        [ true, "AssertionDivisible", "/properties/foo/items/multipleOf", "#/properties/foo/items/multipleOf", "/foo/0" ],
-        [ true, "AssertionTypeStrictAny", "/properties/foo/items/type", "#/properties/foo/items/type", "/foo/0" ],
-        [ true, "LoopItems", "/properties/foo/items", "#/properties/foo/items", "/foo" ]
+        [
+          true,
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/foo/items/maximum",
+          "#/properties/foo/items/maximum",
+          "/foo/0"
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/properties/foo/items/multipleOf",
+          "#/properties/foo/items/multipleOf",
+          "/foo/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/foo/items/type",
+          "#/properties/foo/items/type",
+          "/foo/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/properties/foo/items",
+          "#/properties/foo/items",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The string value \"abc\" was expected to match the regular expression \"^a\"",
@@ -1543,22 +3649,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "LoopItems", "/properties/foo/items", "#/properties/foo/items", "/foo" ],
-        [ "AssertionLessEqual", "/properties/foo/items/maximum", "#/properties/foo/items/maximum", "/foo/0" ],
-        [ "AssertionDivisible", "/properties/foo/items/multipleOf", "#/properties/foo/items/multipleOf", "/foo/0" ],
-        [ "AssertionTypeStrictAny", "/properties/foo/items/type", "#/properties/foo/items/type", "/foo/0" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "LoopItems",
+          "/properties/foo/items",
+          "#/properties/foo/items",
+          "/foo"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/foo/items/maximum",
+          "#/properties/foo/items/maximum",
+          "/foo/0"
+        ],
+        [
+          "AssertionDivisible",
+          "/properties/foo/items/multipleOf",
+          "#/properties/foo/items/multipleOf",
+          "/foo/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/foo/items/type",
+          "#/properties/foo/items/type",
+          "/foo/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionRegex", "/properties/bar/pattern", "#/properties/bar/pattern", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionLessEqual", "/properties/foo/items/maximum", "#/properties/foo/items/maximum", "/foo/0" ],
-        [ true, "AssertionDivisible", "/properties/foo/items/multipleOf", "#/properties/foo/items/multipleOf", "/foo/0" ],
-        [ true, "AssertionTypeStrictAny", "/properties/foo/items/type", "#/properties/foo/items/type", "/foo/0" ],
-        [ true, "LoopItems", "/properties/foo/items", "#/properties/foo/items", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionRegex",
+          "/properties/bar/pattern",
+          "#/properties/bar/pattern",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/foo/items/maximum",
+          "#/properties/foo/items/maximum",
+          "/foo/0"
+        ],
+        [
+          true,
+          "AssertionDivisible",
+          "/properties/foo/items/multipleOf",
+          "#/properties/foo/items/multipleOf",
+          "/foo/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/foo/items/type",
+          "#/properties/foo/items/type",
+          "/foo/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/properties/foo/items",
+          "#/properties/foo/items",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abc\" was expected to match the regular expression \"^a\"",
@@ -1576,20 +3759,52 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "bar": { "type": "string" },
-        "foo": { "type": "string", "enum": [ "baz" ] }
+        "bar": {
+          "type": "string"
+        },
+        "foo": {
+          "type": "string",
+          "enum": [
+            "baz"
+          ]
+        }
       }
     },
-    "instance": { "bar": "foo", "foo": "baz" },
+    "instance": {
+      "bar": "foo",
+      "foo": "baz"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          true,
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "descriptions": [
         "The string value \"baz\" was expected to equal the string constant \"baz\"",
@@ -1598,16 +3813,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1622,21 +3881,58 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": {
-        "bar": { "$ref": "#/definitions/helper" },
-        "foo": { "enum": [ "foo" ] }
+        "bar": {
+          "$ref": "#/definitions/helper"
+        },
+        "foo": {
+          "enum": [
+            "foo"
+          ]
+        }
       },
-      "definitions": { "helper": { "enum": [ "test" ] } }
+      "definitions": {
+        "helper": {
+          "enum": [
+            "test"
+          ]
+        }
+      }
     },
-    "instance": { "bar": "test", "foo": "foo" },
+    "instance": {
+      "bar": "test",
+      "foo": "foo"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ "AssertionEqual", "/properties/bar/$ref/enum", "#/definitions/helper/enum", "/bar" ]
+        [
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          "AssertionEqual",
+          "/properties/bar/$ref/enum",
+          "#/definitions/helper/enum",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ true, "AssertionEqual", "/properties/bar/$ref/enum", "#/definitions/helper/enum", "/bar" ]
+        [
+          true,
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/properties/bar/$ref/enum",
+          "#/definitions/helper/enum",
+          "/bar"
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -1645,16 +3941,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ "ControlJump", "/properties/bar/$ref", "#/properties/bar/$ref", "/bar" ],
-        [ "AssertionEqual", "/properties/bar/$ref/enum", "#/definitions/helper/enum", "/bar" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/properties/bar/$ref",
+          "#/properties/bar/$ref",
+          "/bar"
+        ],
+        [
+          "AssertionEqual",
+          "/properties/bar/$ref/enum",
+          "#/definitions/helper/enum",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/properties/foo/enum", "#/properties/foo/enum", "/foo" ],
-        [ true, "AssertionEqual", "/properties/bar/$ref/enum", "#/definitions/helper/enum", "/bar" ],
-        [ true, "ControlJump", "/properties/bar/$ref", "#/properties/bar/$ref", "/bar" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/properties/foo/enum",
+          "#/properties/foo/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/properties/bar/$ref/enum",
+          "#/definitions/helper/enum",
+          "/bar"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/properties/bar/$ref",
+          "#/properties/bar/$ref",
+          "/bar"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -1670,44 +4010,120 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "additionalProperties": false,
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "string" },
-        "c": { "type": "string" },
-        "d": { "type": "string" },
-        "e": { "type": "string" },
-        "f": { "type": "string" },
-        "g": { "type": "string" },
-        "h": { "type": "string" },
-        "i": { "type": "string" },
-        "j": { "type": "string" },
-        "k": { "type": "string" },
-        "l": { "type": "string" },
-        "m": { "type": "string" },
-        "n": { "type": "string" },
-        "o": { "type": "string" },
-        "p": { "type": "string" },
-        "q": { "type": "string" },
-        "r": { "type": "string" },
-        "s": { "type": "string" },
-        "t": { "type": "string" },
-        "u": { "type": "string" },
-        "v": { "type": "string" },
-        "w": { "type": "string" },
-        "x": { "type": "string" },
-        "y": { "type": "string" },
-        "z": { "type": "string" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        },
+        "c": {
+          "type": "string"
+        },
+        "d": {
+          "type": "string"
+        },
+        "e": {
+          "type": "string"
+        },
+        "f": {
+          "type": "string"
+        },
+        "g": {
+          "type": "string"
+        },
+        "h": {
+          "type": "string"
+        },
+        "i": {
+          "type": "string"
+        },
+        "j": {
+          "type": "string"
+        },
+        "k": {
+          "type": "string"
+        },
+        "l": {
+          "type": "string"
+        },
+        "m": {
+          "type": "string"
+        },
+        "n": {
+          "type": "string"
+        },
+        "o": {
+          "type": "string"
+        },
+        "p": {
+          "type": "string"
+        },
+        "q": {
+          "type": "string"
+        },
+        "r": {
+          "type": "string"
+        },
+        "s": {
+          "type": "string"
+        },
+        "t": {
+          "type": "string"
+        },
+        "u": {
+          "type": "string"
+        },
+        "v": {
+          "type": "string"
+        },
+        "w": {
+          "type": "string"
+        },
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "string"
+        },
+        "z": {
+          "type": "string"
+        }
       }
     },
-    "instance": { "f": "foo" },
+    "instance": {
+      "f": "foo"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/f/type", "#/properties/f/type", "/f" ]
+        [
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/f/type",
+          "#/properties/f/type",
+          "/f"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/f/type", "#/properties/f/type", "/f" ],
-        [ true, "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/f/type",
+          "#/properties/f/type",
+          "/f"
+        ],
+        [
+          true,
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1716,14 +4132,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/f/type", "#/properties/f/type", "/f" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/f/type",
+          "#/properties/f/type",
+          "/f"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/f/type", "#/properties/f/type", "/f" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/f/type",
+          "#/properties/f/type",
+          "/f"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -1738,17 +4187,36 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "additionalProperties": false,
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": {}, "bar": { "type": "object" } }
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {},
+        "bar": {
+          "type": "object"
+        }
+      }
     },
     "instance": "baz",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines properties \"bar\", and \"foo\""
@@ -1756,10 +4224,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type string"
@@ -1772,21 +4251,42 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "additionalProperties": false,
-      "required": [ "foo", "bar", "baz" ],
+      "required": [
+        "foo",
+        "bar",
+        "baz"
+      ],
       "properties": {
-        "foo": { "type": "string" },
-        "bar": { "type": "array" },
-        "baz": { "type": "object" }
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "array"
+        },
+        "baz": {
+          "type": "object"
+        }
       }
     },
     "instance": "baz",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties"
@@ -1794,10 +4294,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type string"
@@ -1819,16 +4330,33 @@
     "description": "properties_19",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 12345678910111213141516171819202122232425262728293031 },
+    "instance": {
+      "foo": 12345678910111213141516171819202122232425262728293031
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -1836,12 +4364,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -1853,16 +4403,36 @@
     "description": "properties_21",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": [ "integer", "string" ] } }
+      "properties": {
+        "foo": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        }
+      }
     },
-    "instance": { "foo": 12345678910111213141516171819202122232425262728293031 },
+    "instance": {
+      "foo": 12345678910111213141516171819202122232425262728293031
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer"
@@ -1870,12 +4440,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer",
@@ -1885,15 +4477,29 @@
   },
   {
     "description": "pattern_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "pattern": "^x" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "pattern": "^x"
+    },
     "instance": "xxx",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          true,
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to match the regular expression \"^x\""
@@ -1901,10 +4507,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          true,
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to match the regular expression \"^x\""
@@ -1913,15 +4530,29 @@
   },
   {
     "description": "pattern_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "pattern": "^x" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "pattern": "^x"
+    },
     "instance": "aaa",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"aaa\" was expected to match the regular expression \"^x\""
@@ -1929,10 +4560,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/pattern", "#/pattern", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/pattern",
+          "#/pattern",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"aaa\" was expected to match the regular expression \"^x\""
@@ -1941,7 +4583,10 @@
   },
   {
     "description": "pattern_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "pattern": "^x" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "pattern": "^x"
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -1949,7 +4594,10 @@
   },
   {
     "description": "pattern_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "pattern": 123 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "pattern": 123
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -1961,7 +4609,10 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "patternProperties": {}
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -1970,9 +4621,14 @@
     "description": "patternProperties_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^v": true }
+      "patternProperties": {
+        "^v": true
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -1981,9 +4637,14 @@
     "description": "patternProperties_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^f": true }
+      "patternProperties": {
+        "^f": true
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -1992,18 +4653,47 @@
     "description": "patternProperties_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^f": { "type": "integer" } }
+      "patternProperties": {
+        "^f": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2012,12 +4702,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2029,18 +4741,47 @@
     "description": "patternProperties_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^f": { "type": "string" } }
+      "patternProperties": {
+        "^f": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ false, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -2049,12 +4790,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ false, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -2066,22 +4829,76 @@
     "description": "patternProperties_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "o$": { "type": "integer" }, "^f": { "type": "integer" } }
+      "patternProperties": {
+        "o$": {
+          "type": "integer"
+        },
+        "^f": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/o$/type", "#/patternProperties/o$/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/o$/type",
+          "#/patternProperties/o$/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/patternProperties/o$/type", "#/patternProperties/o$/type", "/foo" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/o$/type",
+          "#/patternProperties/o$/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2092,16 +4909,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/o$/type", "#/patternProperties/o$/type", "/foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/o$/type",
+          "#/patternProperties/o$/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/type", "#/patternProperties/%5Ef/type", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/patternProperties/o$/type", "#/patternProperties/o$/type", "/foo" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/type",
+          "#/patternProperties/%5Ef/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/o$/type",
+          "#/patternProperties/o$/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2115,20 +4976,65 @@
     "description": "patternProperties_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^f": { "patternProperties": { "^b": { "type": "integer" } } } }
+      "patternProperties": {
+        "^f": {
+          "patternProperties": {
+            "^b": {
+              "type": "integer"
+            }
+          }
+        }
+      }
     },
-    "instance": { "foo": { "bar": 2 } },
+    "instance": {
+      "foo": {
+        "bar": 2
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesStartsWith", "/patternProperties/^f/patternProperties", "#/patternProperties/%5Ef/patternProperties", "/foo" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/patternProperties/^b/type", "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties/^f/patternProperties",
+          "#/patternProperties/%5Ef/patternProperties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/patternProperties/^b/type",
+          "#/patternProperties/%5Ef/patternProperties/%5Eb/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/patternProperties/^b/type", "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties/^f/patternProperties", "#/patternProperties/%5Ef/patternProperties", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/patternProperties/^b/type",
+          "#/patternProperties/%5Ef/patternProperties/%5Eb/type",
+          "/foo/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties/^f/patternProperties",
+          "#/patternProperties/%5Ef/patternProperties",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2138,14 +5044,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesStartsWith", "/patternProperties/^f/patternProperties", "#/patternProperties/%5Ef/patternProperties", "/foo" ],
-        [ "AssertionTypeStrict", "/patternProperties/^f/patternProperties/^b/type", "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties/^f/patternProperties",
+          "#/patternProperties/%5Ef/patternProperties",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^f/patternProperties/^b/type",
+          "#/patternProperties/%5Ef/patternProperties/%5Eb/type",
+          "/foo/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^f/patternProperties/^b/type", "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties/^f/patternProperties", "#/patternProperties/%5Ef/patternProperties", "/foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^f/patternProperties/^b/type",
+          "#/patternProperties/%5Ef/patternProperties/%5Eb/type",
+          "/foo/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties/^f/patternProperties",
+          "#/patternProperties/%5Ef/patternProperties",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2158,19 +5097,48 @@
     "description": "patternProperties_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^@": true },
-      "additionalProperties": { "type": "string" }
+      "patternProperties": {
+        "^@": true
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     },
-    "instance": { "@foo": 1, "bar": "baz" },
+    "instance": {
+      "@foo": 1,
+      "bar": "baz"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ]
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -2179,12 +5147,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ]
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -2196,18 +5186,47 @@
     "description": "patternProperties_10",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^/": { "type": "integer" } }
+      "patternProperties": {
+        "^/": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "/foo": 1, "bar": 2 },
+    "instance": {
+      "/foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^~1/type", "#/patternProperties/%5E~1/type", "/~1foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^~1/type",
+          "#/patternProperties/%5E~1/type",
+          "/~1foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^~1/type", "#/patternProperties/%5E~1/type", "/~1foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^~1/type",
+          "#/patternProperties/%5E~1/type",
+          "/~1foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2216,12 +5235,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^~1/type", "#/patternProperties/%5E~1/type", "/~1foo" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^~1/type",
+          "#/patternProperties/%5E~1/type",
+          "/~1foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^~1/type", "#/patternProperties/%5E~1/type", "/~1foo" ],
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^~1/type",
+          "#/patternProperties/%5E~1/type",
+          "/~1foo"
+        ],
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2233,19 +5274,47 @@
     "description": "patternProperties_11",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^[a-z]+$": { "type": "string" } },
+      "patternProperties": {
+        "^[a-z]+$": {
+          "type": "string"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^[a-z]+$/type", "#/patternProperties/%5E%5Ba-z%5D+$/type", "/foo" ]
+        [
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^[a-z]+$/type",
+          "#/patternProperties/%5E%5Ba-z%5D+$/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^[a-z]+$/type", "#/patternProperties/%5E%5Ba-z%5D+$/type", "/foo" ],
-        [ true, "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^[a-z]+$/type",
+          "#/patternProperties/%5E%5Ba-z%5D+$/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -2254,14 +5323,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^[a-z]+$/type", "#/patternProperties/%5E%5Ba-z%5D+$/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^[a-z]+$/type",
+          "#/patternProperties/%5E%5Ba-z%5D+$/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^[a-z]+$/type", "#/patternProperties/%5E%5Ba-z%5D+$/type", "/foo" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^[a-z]+$/type",
+          "#/patternProperties/%5E%5Ba-z%5D+$/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -2274,17 +5376,32 @@
     "description": "patternProperties_13",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^[a-z]+$": true },
+      "patternProperties": {
+        "^[a-z]+$": true
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          true,
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to match the regular expression \"^[a-z]+$\" and validate against the defined pattern property subschema"
@@ -2292,10 +5409,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define additional properties"
@@ -2306,17 +5434,33 @@
     "description": "patternProperties_14",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "patternProperties": { "^[a-z]+$": true },
+      "patternProperties": {
+        "^[a-z]+$": true
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": "bar", "@bar": 1 },
+    "instance": {
+      "foo": "bar",
+      "@bar": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to match the regular expression \"^[a-z]+$\" and validate against the defined pattern property subschema"
@@ -2324,12 +5468,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/@bar" ]
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/@bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/@bar" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/@bar"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define the property \"@bar\"",
@@ -2343,17 +5509,33 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "properties": {},
-      "patternProperties": { "^[a-z]+$": true },
+      "patternProperties": {
+        "^[a-z]+$": true
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": "bar", "@bar": 1 },
+    "instance": {
+      "foo": "bar",
+      "@bar": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesRegexClosed", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "LoopPropertiesRegexClosed",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to match the regular expression \"^[a-z]+$\" and validate against the defined pattern property subschema"
@@ -2361,12 +5543,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/@bar" ]
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/@bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/@bar" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/@bar"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define the property \"@bar\"",
@@ -2389,16 +5593,32 @@
     "description": "additionalProperties_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalProperties": { "type": "integer" }
+      "additionalProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type integer"
@@ -2406,14 +5626,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2426,21 +5679,63 @@
     "description": "additionalProperties_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "boolean" } },
-      "additionalProperties": { "type": "integer" }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": {
+        "type": "integer"
+      }
     },
-    "instance": { "foo": true, "bar": 2 },
+    "instance": {
+      "foo": true,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ]
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -2450,16 +5745,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -2473,26 +5812,95 @@
     "description": "additionalProperties_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "boolean" } },
-      "patternProperties": { "^bar$": { "type": "integer" } },
-      "additionalProperties": { "type": "string" }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^bar$": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     },
-    "instance": { "foo": true, "bar": 2, "baz": "qux" },
+    "instance": {
+      "foo": true,
+      "bar": 2,
+      "baz": "qux"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/baz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/baz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/baz" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/baz"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2504,20 +5912,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/baz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/baz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/type", "#/additionalProperties/type", "/baz" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/baz"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2533,22 +6007,67 @@
     "description": "additionalProperties_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "boolean" } },
-      "patternProperties": { "^bar$": { "type": "integer" } },
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^bar$": {
+          "type": "integer"
+        }
+      },
       "additionalProperties": {}
     },
-    "instance": { "foo": true, "bar": 2, "baz": "qux" },
+    "instance": {
+      "foo": true,
+      "bar": 2,
+      "baz": "qux"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2558,16 +6077,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2581,22 +6144,67 @@
     "description": "additionalProperties_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "type": "boolean" } },
-      "patternProperties": { "^bar$": { "type": "integer" } },
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^bar$": {
+          "type": "integer"
+        }
+      },
       "additionalProperties": true
     },
-    "instance": { "foo": true, "bar": 2, "baz": "qux" },
+    "instance": {
+      "foo": true,
+      "bar": 2,
+      "baz": "qux"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2606,16 +6214,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^bar$/type", "#/patternProperties/%5Ebar$/type", "/bar" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^bar$/type",
+          "#/patternProperties/%5Ebar$/type",
+          "/bar"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2631,7 +6283,11 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "additionalProperties": {}
     },
-    "instance": { "foo": true, "bar": 2, "baz": "qux" },
+    "instance": {
+      "foo": true,
+      "bar": 2,
+      "baz": "qux"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -2642,7 +6298,11 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "additionalProperties": true
     },
-    "instance": { "foo": true, "bar": 2, "baz": "qux" },
+    "instance": {
+      "foo": true,
+      "bar": 2,
+      "baz": "qux"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -2651,16 +6311,32 @@
     "description": "additionalProperties_10",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalProperties": { "type": "number" }
+      "additionalProperties": {
+        "type": "number"
+      }
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          "LoopPropertiesTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type number"
@@ -2668,14 +6344,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/bar" ],
-        [ true, "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -2695,10 +6404,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define additional properties"
@@ -2706,10 +6426,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was not expected to define additional properties"
@@ -2720,20 +6451,55 @@
     "description": "additionalProperties_12",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false },
+    "instance": {
+      "foo": true,
+      "bar": false
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LoopPropertiesTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesTypeStrict", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2742,18 +6508,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2768,18 +6589,43 @@
     "description": "additionalProperties_13",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false, "baz": 1 },
+    "instance": {
+      "foo": true,
+      "bar": false,
+      "baz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines the property \"baz\""
@@ -2787,10 +6633,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines the property \"baz\""
@@ -2802,18 +6659,42 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false },
+    "instance": {
+      "foo": true,
+      "bar": false
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type boolean"
@@ -2821,20 +6702,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2850,25 +6797,84 @@
     "description": "additionalProperties_15",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "patternProperties": { "^@": true },
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "patternProperties": {
+        "^@": true
+      },
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false },
+    "instance": {
+      "foo": true,
+      "bar": false
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAll", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAll", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define properties \"bar\", and \"foo\"",
@@ -2879,18 +6885,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAll", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAll", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesAll",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define properties \"bar\", and \"foo\"",
@@ -2907,19 +6968,45 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "items": {
         "type": "object",
-        "required": [ "foo", "bar" ],
+        "required": [
+          "foo",
+          "bar"
+        ],
         "additionalProperties": false,
-        "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+        "properties": {
+          "foo": {
+            "type": "boolean"
+          },
+          "bar": {
+            "type": "boolean"
+          }
+        }
       }
     },
-    "instance": [ { "foo": true, "bar": false } ],
+    "instance": [
+      {
+        "foo": true,
+        "bar": false
+      }
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be an object whose required properties were of type boolean"
@@ -2927,22 +7014,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ true, "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ true, "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ true, "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2961,19 +7125,40 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "items": {
         "type": "object",
-        "required": [ "foo", "bar" ],
+        "required": [
+          "foo",
+          "bar"
+        ],
         "additionalProperties": false,
-        "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+        "properties": {
+          "foo": {
+            "type": "boolean"
+          },
+          "bar": {
+            "type": "boolean"
+          }
+        }
       }
     },
     "instance": [],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be an object whose required properties were of type boolean"
@@ -2981,10 +7166,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema"
@@ -2996,23 +7192,67 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo" ],
-      "properties": { "foo": { "type": "boolean" } },
-      "patternProperties": { "^[@$_#]": {} },
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^[@$_#]": {}
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": false, "@bar": "baz" },
+    "instance": {
+      "foo": false,
+      "@bar": "baz"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -3022,18 +7262,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -3050,9 +7345,19 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "items": {
         "type": "object",
-        "required": [ "foo", "bar" ],
+        "required": [
+          "foo",
+          "bar"
+        ],
         "additionalProperties": false,
-        "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } }
+        "properties": {
+          "foo": {
+            "type": "integer"
+          },
+          "bar": {
+            "type": "integer"
+          }
+        }
       }
     },
     "instance": [
@@ -3064,10 +7369,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsPropertiesExactlyTypeStrictHash", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsPropertiesExactlyTypeStrictHash",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be an object whose required properties were of type integer"
@@ -3075,22 +7391,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ true, "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ true, "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ true, "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -3109,12 +7502,22 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "items": {
         "type": "object",
-        "required": [ "foo", "bar", "baz" ],
+        "required": [
+          "foo",
+          "bar",
+          "baz"
+        ],
         "additionalProperties": false,
         "properties": {
-          "foo": { "type": "integer" },
-          "bar": { "type": "integer" },
-          "baz": { "type": "integer" }
+          "foo": {
+            "type": "integer"
+          },
+          "bar": {
+            "type": "integer"
+          },
+          "baz": {
+            "type": "integer"
+          }
         }
       }
     },
@@ -3128,10 +7531,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsPropertiesExactlyTypeStrictHash3", "/items", "#/items", "" ]
+        [
+          "LoopItemsPropertiesExactlyTypeStrictHash3",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsPropertiesExactlyTypeStrictHash3", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsPropertiesExactlyTypeStrictHash3",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be an object whose required properties were of type integer"
@@ -3139,24 +7553,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ "AssertionTypeStrict", "/items/properties/baz/type", "#/items/properties/baz/type", "/0/baz" ],
-        [ "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/baz/type",
+          "#/items/properties/baz/type",
+          "/0/baz"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/items/required", "#/items/required", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/properties/bar/type", "#/items/properties/bar/type", "/0/bar" ],
-        [ true, "AssertionTypeStrict", "/items/properties/baz/type", "#/items/properties/baz/type", "/0/baz" ],
-        [ true, "AssertionTypeStrict", "/items/properties/foo/type", "#/items/properties/foo/type", "/0/foo" ],
-        [ true, "LogicalWhenType", "/items/properties", "#/items/properties", "/0" ],
-        [ true, "LoopPropertiesExcept", "/items/additionalProperties", "#/items/additionalProperties", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/items/required",
+          "#/items/required",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/bar/type",
+          "#/items/properties/bar/type",
+          "/0/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/baz/type",
+          "#/items/properties/baz/type",
+          "/0/baz"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/properties/foo/type",
+          "#/items/properties/foo/type",
+          "/0/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/items/properties",
+          "#/items/properties",
+          "/0"
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/items/additionalProperties",
+          "#/items/additionalProperties",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", \"baz\", and \"foo\"",
@@ -3174,9 +7676,19 @@
     "description": "additionalProperties_23",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {
       "foo": 12345678910111213141516171819202122232425262728293031,
@@ -3185,12 +7697,34 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LoopPropertiesTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesTypeStrict", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -3199,18 +7733,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -3225,16 +7814,34 @@
     "description": "additionalProperties_25",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalProperties": { "type": [ "integer", "string" ] }
+      "additionalProperties": {
+        "type": [
+          "integer",
+          "string"
+        ]
+      }
     },
-    "instance": { "foo": 12345678910111213141516171819202122232425262728293031 },
+    "instance": {
+      "foo": 12345678910111213141516171819202122232425262728293031
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          "LoopPropertiesTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type integer, or string"
@@ -3242,12 +7849,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ]
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/additionalProperties/type", "#/additionalProperties/type", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/additionalProperties/type",
+          "#/additionalProperties/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer",
@@ -3260,9 +7889,19 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {
       "foo": 12345678910111213141516171819202122232425262728293031,
@@ -3271,10 +7910,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type integer"
@@ -3282,20 +7932,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -3312,11 +8028,18 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" ],
+      "required": [
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+      ],
       "additionalProperties": false,
       "properties": {
-        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": { "type": "integer" },
-        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy": { "type": "integer" }
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": {
+          "type": "integer"
+        },
+        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy": {
+          "type": "integer"
+        }
       }
     },
     "instance": {
@@ -3326,10 +8049,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrict", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrict",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type integer"
@@ -3337,20 +8071,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type", "#/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type", "/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ],
-        [ "AssertionTypeStrict", "/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type", "#/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type", "/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type",
+          "#/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type",
+          "/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type",
+          "#/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type",
+          "/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type", "#/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type", "/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ],
-        [ true, "AssertionTypeStrict", "/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type", "#/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type", "/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type",
+          "#/properties/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/type",
+          "/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type",
+          "#/properties/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/type",
+          "/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\", and \"yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\"",
@@ -3366,18 +8166,42 @@
     "description": "not_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "not": { "type": "string" }
+      "not": {
+        "type": "string"
+      }
     },
     "instance": 5,
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionTypeStrict", "/not/type", "#/not/type", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/not/type", "#/not/type", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -3386,12 +8210,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionTypeStrict", "/not/type", "#/not/type", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/not/type", "#/not/type", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -3403,18 +8249,42 @@
     "description": "not_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "not": { "type": "string" }
+      "not": {
+        "type": "string"
+      }
     },
     "instance": "foo",
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionTypeStrict", "/not/type", "#/not/type", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/not/type", "#/not/type", "" ],
-        [ false, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3423,12 +8293,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionTypeStrict", "/not/type", "#/not/type", "" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/not/type", "#/not/type", "" ],
-        [ false, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/not/type",
+          "#/not/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3441,24 +8333,77 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "not": {
-        "properties": { "foo": { "type": "boolean" } },
-        "additionalProperties": { "type": "integer" }
+        "properties": {
+          "foo": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "integer"
+        }
       }
     },
-    "instance": { "foo": true, "bar": false },
+    "instance": {
+      "foo": true,
+      "bar": false
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "AssertionPropertyTypeStrict", "/not/properties/foo/type", "#/not/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/not/additionalProperties", "#/not/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/not/additionalProperties/type", "#/not/additionalProperties/type", "/bar" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/not/properties/foo/type",
+          "#/not/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/not/additionalProperties",
+          "#/not/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/additionalProperties/type",
+          "#/not/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/not/properties/foo/type", "#/not/properties/foo/type", "/foo" ],
-        [ false, "AssertionTypeStrict", "/not/additionalProperties/type", "#/not/additionalProperties/type", "/bar" ],
-        [ false, "LoopPropertiesExcept", "/not/additionalProperties", "#/not/additionalProperties", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/not/properties/foo/type",
+          "#/not/properties/foo/type",
+          "/foo"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/not/additionalProperties/type",
+          "#/not/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/not/additionalProperties",
+          "#/not/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -3469,18 +8414,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalNot", "/not", "#/not", "" ],
-        [ "LogicalWhenType", "/not/properties", "#/not/properties", "" ],
-        [ "AssertionTypeStrict", "/not/properties/foo/type", "#/not/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/not/additionalProperties", "#/not/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/not/additionalProperties/type", "#/not/additionalProperties/type", "/bar" ]
+        [
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/not/properties",
+          "#/not/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/properties/foo/type",
+          "#/not/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/not/additionalProperties",
+          "#/not/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/not/additionalProperties/type",
+          "#/not/additionalProperties/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/not/properties/foo/type", "#/not/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/not/properties", "#/not/properties", "" ],
-        [ false, "AssertionTypeStrict", "/not/additionalProperties/type", "#/not/additionalProperties/type", "/bar" ],
-        [ false, "LoopPropertiesExcept", "/not/additionalProperties", "#/not/additionalProperties", "" ],
-        [ true, "LogicalNot", "/not", "#/not", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/not/properties/foo/type",
+          "#/not/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/not/properties",
+          "#/not/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/not/additionalProperties/type",
+          "#/not/additionalProperties/type",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/not/additionalProperties",
+          "#/not/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/not",
+          "#/not",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -3495,7 +8495,9 @@
     "description": "items_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "instance": 5,
     "valid": true,
@@ -3506,16 +8508,33 @@
     "description": "items_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type string"
@@ -3523,16 +8542,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3546,16 +8609,33 @@
     "description": "items_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", 5, "baz" ],
+    "instance": [
+      "foo",
+      5,
+      "baz"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type string"
@@ -3563,14 +8643,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3583,7 +8696,11 @@
     "description": "items_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": [ { "type": "string" } ]
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -3594,16 +8711,34 @@
     "description": "items_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": [ { "type": "integer" }, { "type": "boolean" } ]
+      "items": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "instance": [],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The first 2 items of the array value were expected to validate against the corresponding subschemas"
@@ -3611,10 +8746,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The first 2 items of the array value were expected to validate against the corresponding subschemas"
@@ -3625,18 +8771,49 @@
     "description": "items_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": [ { "type": "integer" }, { "type": "boolean" } ]
+      "items": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5 ],
+    "instance": [
+      5
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3645,12 +8822,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3662,20 +8861,64 @@
     "description": "items_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": [ { "type": "integer" }, { "type": "boolean" } ]
+      "items": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5, true, "extra" ],
+    "instance": [
+      5,
+      true,
+      "extra"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3685,14 +8928,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3705,20 +8981,64 @@
     "description": "items_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": [ { "type": "integer" }, { "type": "boolean" } ]
+      "items": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
-    "instance": [ 5, 1, "extra" ],
+    "instance": [
+      5,
+      1,
+      "extra"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ false, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3728,14 +9048,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ false, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3748,19 +9101,54 @@
     "description": "items_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "foo": { "properties": { "bar": { "items": { "type": "string" } } } } }
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
-    "instance": { "foo": {}, "bar": [] },
+    "instance": {
+      "foo": {},
+      "bar": []
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema",
@@ -3778,24 +9166,60 @@
             "properties": {
               "geometry": {
                 "type": "object",
-                "required": [ "geometries" ],
-                "properties": { "geometries": { "items": { "type": "string" } } }
+                "required": [
+                  "geometries"
+                ],
+                "properties": {
+                  "geometries": {
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }
         }
       }
     },
-    "instance": { "features": [ { "geometry": null } ] },
+    "instance": {
+      "features": [
+        {
+          "geometry": null
+        }
+      ]
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItems", "/properties/features/items", "#/properties/features/items", "/features" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/features/items/properties/geometry/properties", "#/properties/features/items/properties/geometry/properties", "/features/0/geometry" ]
+        [
+          "LoopItems",
+          "/properties/features/items",
+          "#/properties/features/items",
+          "/features"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/features/items/properties/geometry/properties",
+          "#/properties/features/items/properties/geometry/properties",
+          "/features/0/geometry"
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties/features/items/properties/geometry/properties", "#/properties/features/items/properties/geometry/properties", "/features/0/geometry" ],
-        [ false, "LoopItems", "/properties/features/items", "#/properties/features/items", "/features" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/features/items/properties/geometry/properties",
+          "#/properties/features/items/properties/geometry/properties",
+          "/features/0/geometry"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/properties/features/items",
+          "#/properties/features/items",
+          "/features"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -3804,16 +9228,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItems", "/properties/features/items", "#/properties/features/items", "/features" ],
-        [ "LogicalWhenType", "/properties/features/items/properties", "#/properties/features/items/properties", "/features/0" ],
-        [ "AssertionDefinesStrict", "/properties/features/items/properties/geometry/required", "#/properties/features/items/properties/geometry/required", "/features/0/geometry" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItems",
+          "/properties/features/items",
+          "#/properties/features/items",
+          "/features"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/features/items/properties",
+          "#/properties/features/items/properties",
+          "/features/0"
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/features/items/properties/geometry/required",
+          "#/properties/features/items/properties/geometry/required",
+          "/features/0/geometry"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/properties/features/items/properties/geometry/required", "#/properties/features/items/properties/geometry/required", "/features/0/geometry" ],
-        [ false, "LogicalWhenType", "/properties/features/items/properties", "#/properties/features/items/properties", "/features/0" ],
-        [ false, "LoopItems", "/properties/features/items", "#/properties/features/items", "/features" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/properties/features/items/properties/geometry/required",
+          "#/properties/features/items/properties/geometry/required",
+          "/features/0/geometry"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/features/items/properties",
+          "#/properties/features/items/properties",
+          "/features/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/properties/features/items",
+          "#/properties/features/items",
+          "/features"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"geometries\"",
@@ -3838,16 +9306,31 @@
     "description": "items_12",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "integer" }
+      "items": {
+        "type": "integer"
+      }
     },
-    "instance": [ 12345678910111213141516171819202122232425262728293031 ],
+    "instance": [
+      12345678910111213141516171819202122232425262728293031
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type integer"
@@ -3855,12 +9338,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3872,16 +9377,34 @@
     "description": "items_14",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": [ "integer", "string" ] }
+      "items": {
+        "type": [
+          "integer",
+          "string"
+        ]
+      }
     },
-    "instance": [ 12345678910111213141516171819202122232425262728293031 ],
+    "instance": [
+      12345678910111213141516171819202122232425262728293031
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrictAny", "/items", "#/items", "" ]
+        [
+          "LoopItemsTypeStrictAny",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsTypeStrictAny", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsTypeStrictAny",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type integer, or string"
@@ -3889,12 +9412,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer",
@@ -3906,9 +9451,15 @@
     "description": "additionalItems_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalItems": { "type": "string" }
+      "additionalItems": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -3917,17 +9468,36 @@
     "description": "additionalItems_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalItems": { "type": "integer" },
-      "items": { "type": "string" }
+      "additionalItems": {
+        "type": "integer"
+      },
+      "items": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsTypeStrict", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsTypeStrict",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type string"
@@ -3935,16 +9505,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3958,21 +9572,66 @@
     "description": "additionalItems_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalItems": { "type": "string" },
-      "items": [ { "type": "boolean" }, { "type": "integer" } ]
+      "additionalItems": {
+        "type": "string"
+      },
+      "items": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5 ],
+    "instance": [
+      true,
+      5
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -3982,14 +9641,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -4002,27 +9694,107 @@
     "description": "additionalItems_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalItems": { "type": "string" },
-      "items": [ { "type": "boolean" }, { "type": "integer" } ]
+      "additionalItems": {
+        "type": "string"
+      },
+      "items": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5, "foo", "bar" ],
+    "instance": [
+      true,
+      5,
+      "foo",
+      "bar"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/3" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/3"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ true, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/3" ],
-        [ true, "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -4035,20 +9807,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/3" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/3"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ true, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/3" ],
-        [ true, "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/3"
+        ],
+        [
+          true,
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -4064,25 +9902,94 @@
     "description": "additionalItems_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "additionalItems": { "type": "string" },
-      "items": [ { "type": "boolean" }, { "type": "integer" } ]
+      "additionalItems": {
+        "type": "string"
+      },
+      "items": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
-    "instance": [ true, 5, 6, "bar" ],
+    "instance": [
+      true,
+      5,
+      6,
+      "bar"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ false, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ false, "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -4094,18 +10001,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ],
-        [ "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ]
+        [
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/items/0/type", "#/items/0/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/1/type", "#/items/1/type", "/1" ],
-        [ true, "AssertionArrayPrefix", "/items", "#/items", "" ],
-        [ false, "AssertionTypeStrict", "/additionalItems/type", "#/additionalItems/type", "/2" ],
-        [ false, "LoopItemsFrom", "/additionalItems", "#/additionalItems", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/0/type",
+          "#/items/0/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/1/type",
+          "#/items/1/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionArrayPrefix",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/additionalItems/type",
+          "#/additionalItems/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopItemsFrom",
+          "/additionalItems",
+          "#/additionalItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type boolean",
@@ -4120,16 +10082,37 @@
     "description": "anyOf_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "anyOf": [ { "type": "string" }, { "type": "integer" }, { "type": "number" } ]
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ]
     },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, or string and it was of type number"
@@ -4137,16 +10120,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/anyOf/2/type", "#/anyOf/2/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionTypeStrict", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/anyOf/2/type", "#/anyOf/2/type", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -4160,16 +10187,37 @@
     "description": "anyOf_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "anyOf": [ { "type": "string" }, { "type": "integer" }, { "type": "number" } ]
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        }
+      ]
     },
     "instance": true,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number, or string but it was of type boolean"
@@ -4177,16 +10225,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/anyOf/2/type", "#/anyOf/2/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ false, "AssertionTypeStrictAny", "/anyOf/2/type", "#/anyOf/2/type", "" ],
-        [ false, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -4203,46 +10295,162 @@
       "anyOf": [
         {
           "properties": {
-            "version": { "enum": [ 1 ] },
-            "one": { "items": { "type": "integer" } },
-            "two": { "items": { "type": "boolean" } },
-            "three": { "items": { "type": "object" } },
-            "four": { "items": { "type": "integer" } },
-            "five": { "items": { "type": "boolean" } },
-            "six": { "items": { "type": "object" } },
-            "seven": { "items": { "type": "object" } },
-            "eight": { "items": { "type": "object" } },
-            "nine": { "items": { "type": "object" } },
-            "then": { "items": { "type": "object" } }
+            "version": {
+              "enum": [
+                1
+              ]
+            },
+            "one": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "two": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "three": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "four": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "five": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "six": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "seven": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "eight": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "nine": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "then": {
+              "items": {
+                "type": "object"
+              }
+            }
           }
         },
         {
-          "properties": { "version": { "enum": [ 2 ] }, "one": { "type": "string" } }
+          "properties": {
+            "version": {
+              "enum": [
+                2
+              ]
+            },
+            "one": {
+              "type": "string"
+            }
+          }
         },
         {
           "properties": {
-            "version": { "enum": [ 3 ] },
-            "one": { "items": { "type": "integer" } },
-            "two": { "items": { "type": "boolean" } },
-            "three": { "items": { "type": "object" } }
+            "version": {
+              "enum": [
+                3
+              ]
+            },
+            "one": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "two": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "three": {
+              "items": {
+                "type": "object"
+              }
+            }
           }
         }
       ]
     },
-    "instance": { "version": 2, "one": "two" },
+    "instance": {
+      "version": 2,
+      "one": "two"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionEqual", "/anyOf/0/properties/version/enum", "#/anyOf/0/properties/version/enum", "/version" ],
-        [ "AssertionEqual", "/anyOf/1/properties/version/enum", "#/anyOf/1/properties/version/enum", "/version" ],
-        [ "AssertionPropertyTypeStrict", "/anyOf/1/properties/one/type", "#/anyOf/1/properties/one/type", "/one" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/anyOf/0/properties/version/enum",
+          "#/anyOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionEqual",
+          "/anyOf/1/properties/version/enum",
+          "#/anyOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/anyOf/1/properties/one/type",
+          "#/anyOf/1/properties/one/type",
+          "/one"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/anyOf/0/properties/version/enum", "#/anyOf/0/properties/version/enum", "/version" ],
-        [ true, "AssertionEqual", "/anyOf/1/properties/version/enum", "#/anyOf/1/properties/version/enum", "/version" ],
-        [ true, "AssertionPropertyTypeStrict", "/anyOf/1/properties/one/type", "#/anyOf/1/properties/one/type", "/one" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/anyOf/0/properties/version/enum",
+          "#/anyOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/anyOf/1/properties/version/enum",
+          "#/anyOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/anyOf/1/properties/one/type",
+          "#/anyOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -4253,24 +10461,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ "AssertionEqual", "/anyOf/0/properties/version/enum", "#/anyOf/0/properties/version/enum", "/version" ],
-        [ "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ "AssertionEqual", "/anyOf/1/properties/version/enum", "#/anyOf/1/properties/version/enum", "/version" ],
-        [ "AssertionTypeStrict", "/anyOf/1/properties/one/type", "#/anyOf/1/properties/one/type", "/one" ],
-        [ "LogicalWhenType", "/anyOf/2/properties", "#/anyOf/2/properties", "" ],
-        [ "AssertionEqual", "/anyOf/2/properties/version/enum", "#/anyOf/2/properties/version/enum", "/version" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/anyOf/0/properties/version/enum",
+          "#/anyOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/anyOf/1/properties/version/enum",
+          "#/anyOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/1/properties/one/type",
+          "#/anyOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          "LogicalWhenType",
+          "/anyOf/2/properties",
+          "#/anyOf/2/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/anyOf/2/properties/version/enum",
+          "#/anyOf/2/properties/version/enum",
+          "/version"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/anyOf/0/properties/version/enum", "#/anyOf/0/properties/version/enum", "/version" ],
-        [ false, "LogicalWhenType", "/anyOf/0/properties", "#/anyOf/0/properties", "" ],
-        [ true, "AssertionEqual", "/anyOf/1/properties/version/enum", "#/anyOf/1/properties/version/enum", "/version" ],
-        [ true, "AssertionTypeStrict", "/anyOf/1/properties/one/type", "#/anyOf/1/properties/one/type", "/one" ],
-        [ true, "LogicalWhenType", "/anyOf/1/properties", "#/anyOf/1/properties", "" ],
-        [ false, "AssertionEqual", "/anyOf/2/properties/version/enum", "#/anyOf/2/properties/version/enum", "/version" ],
-        [ false, "LogicalWhenType", "/anyOf/2/properties", "#/anyOf/2/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/anyOf/0/properties/version/enum",
+          "#/anyOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/anyOf/0/properties",
+          "#/anyOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/anyOf/1/properties/version/enum",
+          "#/anyOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/1/properties/one/type",
+          "#/anyOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/anyOf/1/properties",
+          "#/anyOf/1/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/anyOf/2/properties/version/enum",
+          "#/anyOf/2/properties/version/enum",
+          "/version"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/anyOf/2/properties",
+          "#/anyOf/2/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -4288,37 +10584,109 @@
     "description": "anyOf_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "anyOf": [ { "$ref": "#/definitions/test" }, true ],
+      "anyOf": [
+        {
+          "$ref": "#/definitions/test"
+        },
+        true
+      ],
       "definitions": {
         "test": {
           "properties": {
-            "a": { "type": "string" },
-            "b": { "type": "string", "pattern": "^b" },
-            "c": { "type": "string", "pattern": "^c" },
-            "d": { "type": "string", "pattern": "^d" },
-            "e": { "type": "string", "pattern": "^e" },
-            "f": { "type": "string", "pattern": "^f" },
-            "g": { "type": "string", "pattern": "^g" },
-            "h": { "type": "string", "pattern": "^h" },
-            "i": { "type": "string", "pattern": "^i" },
-            "j": { "type": "string", "pattern": "^j" },
-            "k": { "type": "string", "pattern": "^k" }
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "type": "string",
+              "pattern": "^b"
+            },
+            "c": {
+              "type": "string",
+              "pattern": "^c"
+            },
+            "d": {
+              "type": "string",
+              "pattern": "^d"
+            },
+            "e": {
+              "type": "string",
+              "pattern": "^e"
+            },
+            "f": {
+              "type": "string",
+              "pattern": "^f"
+            },
+            "g": {
+              "type": "string",
+              "pattern": "^g"
+            },
+            "h": {
+              "type": "string",
+              "pattern": "^h"
+            },
+            "i": {
+              "type": "string",
+              "pattern": "^i"
+            },
+            "j": {
+              "type": "string",
+              "pattern": "^j"
+            },
+            "k": {
+              "type": "string",
+              "pattern": "^k"
+            }
           }
         }
       }
     },
-    "instance": { "a": "foo" },
+    "instance": {
+      "a": "foo"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "LoopPropertiesMatch", "/anyOf/0/$ref/properties", "#/definitions/test/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/anyOf/0/$ref/properties/a/type", "#/definitions/test/properties/a/type", "/a" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/anyOf/0/$ref/properties",
+          "#/definitions/test/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/anyOf/0/$ref/properties/a/type",
+          "#/definitions/test/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/anyOf/0/$ref/properties/a/type", "#/definitions/test/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/anyOf/0/$ref/properties", "#/definitions/test/properties", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/anyOf/0/$ref/properties/a/type",
+          "#/definitions/test/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/anyOf/0/$ref/properties",
+          "#/definitions/test/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4328,16 +10696,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "ControlJump", "/anyOf/0/$ref", "#/anyOf/0/$ref", "" ],
-        [ "LoopPropertiesMatch", "/anyOf/0/$ref/properties", "#/definitions/test/properties", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/$ref/properties/a/type", "#/definitions/test/properties/a/type", "/a" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/anyOf/0/$ref",
+          "#/anyOf/0/$ref",
+          ""
+        ],
+        [
+          "LoopPropertiesMatch",
+          "/anyOf/0/$ref/properties",
+          "#/definitions/test/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/$ref/properties/a/type",
+          "#/definitions/test/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/anyOf/0/$ref/properties/a/type", "#/definitions/test/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/anyOf/0/$ref/properties", "#/definitions/test/properties", "" ],
-        [ true, "ControlJump", "/anyOf/0/$ref", "#/anyOf/0/$ref", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/anyOf/0/$ref/properties/a/type",
+          "#/definitions/test/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/anyOf/0/$ref/properties",
+          "#/definitions/test/properties",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/anyOf/0/$ref",
+          "#/anyOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4352,28 +10764,91 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "oneOf": [
-        { "type": "string" },
-        { "type": "integer" },
-        { "type": "number" },
-        { "type": "boolean" }
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
       ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ false, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4385,18 +10860,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ false, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4412,28 +10942,91 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "oneOf": [
-        { "type": "string" },
-        { "type": "integer" },
-        { "type": "number" },
-        { "type": "boolean" }
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
       ]
     },
     "instance": 3.14,
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type number",
@@ -4445,18 +11038,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type number",
@@ -4472,26 +11120,78 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "oneOf": [
-        { "type": "string" },
-        { "type": "integer" },
-        { "type": "number" },
-        { "type": "boolean" }
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
       ]
     },
     "instance": 5,
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ true, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -4502,18 +11202,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ true, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/oneOf/2/type", "#/oneOf/2/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/3/type", "#/oneOf/3/type", "" ],
-        [ false, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/2/type",
+          "#/oneOf/2/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/3/type",
+          "#/oneOf/3/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -4528,18 +11283,44 @@
     "description": "oneOf_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "oneOf": [ { "type": "number" } ]
+      "oneOf": [
+        {
+          "type": "number"
+        }
+      ]
     },
     "instance": 3.14,
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/0/type", "#/oneOf/0/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -4548,12 +11329,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrictAny", "/oneOf/0/type", "#/oneOf/0/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -4568,48 +11371,175 @@
       "oneOf": [
         {
           "properties": {
-            "version": { "enum": [ 1 ] },
-            "one": { "items": { "type": "integer" } },
-            "two": { "items": { "type": "boolean" } },
-            "three": { "items": { "type": "object" } },
-            "four": { "items": { "type": "integer" } },
-            "five": { "items": { "type": "boolean" } },
-            "six": { "items": { "type": "object" } },
-            "seven": { "items": { "type": "object" } },
-            "eight": { "items": { "type": "object" } },
-            "nine": { "items": { "type": "object" } },
-            "then": { "items": { "type": "object" } }
+            "version": {
+              "enum": [
+                1
+              ]
+            },
+            "one": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "two": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "three": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "four": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "five": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "six": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "seven": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "eight": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "nine": {
+              "items": {
+                "type": "object"
+              }
+            },
+            "then": {
+              "items": {
+                "type": "object"
+              }
+            }
           }
         },
         {
-          "properties": { "version": { "enum": [ 2 ] }, "one": { "type": "string" } }
+          "properties": {
+            "version": {
+              "enum": [
+                2
+              ]
+            },
+            "one": {
+              "type": "string"
+            }
+          }
         },
         {
           "properties": {
-            "version": { "enum": [ 3 ] },
-            "one": { "items": { "type": "integer" } },
-            "two": { "items": { "type": "boolean" } },
-            "three": { "items": { "type": "object" } }
+            "version": {
+              "enum": [
+                3
+              ]
+            },
+            "one": {
+              "items": {
+                "type": "integer"
+              }
+            },
+            "two": {
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "three": {
+              "items": {
+                "type": "object"
+              }
+            }
           }
         }
       ]
     },
-    "instance": { "version": 2, "one": "two" },
+    "instance": {
+      "version": 2,
+      "one": "two"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionEqual", "/oneOf/0/properties/version/enum", "#/oneOf/0/properties/version/enum", "/version" ],
-        [ "AssertionEqual", "/oneOf/1/properties/version/enum", "#/oneOf/1/properties/version/enum", "/version" ],
-        [ "AssertionPropertyTypeStrict", "/oneOf/1/properties/one/type", "#/oneOf/1/properties/one/type", "/one" ],
-        [ "AssertionEqual", "/oneOf/2/properties/version/enum", "#/oneOf/2/properties/version/enum", "/version" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/0/properties/version/enum",
+          "#/oneOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/1/properties/version/enum",
+          "#/oneOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/oneOf/1/properties/one/type",
+          "#/oneOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/2/properties/version/enum",
+          "#/oneOf/2/properties/version/enum",
+          "/version"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/oneOf/0/properties/version/enum", "#/oneOf/0/properties/version/enum", "/version" ],
-        [ true, "AssertionEqual", "/oneOf/1/properties/version/enum", "#/oneOf/1/properties/version/enum", "/version" ],
-        [ true, "AssertionPropertyTypeStrict", "/oneOf/1/properties/one/type", "#/oneOf/1/properties/one/type", "/one" ],
-        [ false, "AssertionEqual", "/oneOf/2/properties/version/enum", "#/oneOf/2/properties/version/enum", "/version" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/oneOf/0/properties/version/enum",
+          "#/oneOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/oneOf/1/properties/version/enum",
+          "#/oneOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/oneOf/1/properties/one/type",
+          "#/oneOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/oneOf/2/properties/version/enum",
+          "#/oneOf/2/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -4621,24 +11551,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "LogicalWhenType", "/oneOf/0/properties", "#/oneOf/0/properties", "" ],
-        [ "AssertionEqual", "/oneOf/0/properties/version/enum", "#/oneOf/0/properties/version/enum", "/version" ],
-        [ "LogicalWhenType", "/oneOf/1/properties", "#/oneOf/1/properties", "" ],
-        [ "AssertionEqual", "/oneOf/1/properties/version/enum", "#/oneOf/1/properties/version/enum", "/version" ],
-        [ "AssertionTypeStrict", "/oneOf/1/properties/one/type", "#/oneOf/1/properties/one/type", "/one" ],
-        [ "LogicalWhenType", "/oneOf/2/properties", "#/oneOf/2/properties", "" ],
-        [ "AssertionEqual", "/oneOf/2/properties/version/enum", "#/oneOf/2/properties/version/enum", "/version" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/oneOf/0/properties",
+          "#/oneOf/0/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/0/properties/version/enum",
+          "#/oneOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          "LogicalWhenType",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/1/properties/version/enum",
+          "#/oneOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/properties/one/type",
+          "#/oneOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          "LogicalWhenType",
+          "/oneOf/2/properties",
+          "#/oneOf/2/properties",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/oneOf/2/properties/version/enum",
+          "#/oneOf/2/properties/version/enum",
+          "/version"
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/oneOf/0/properties/version/enum", "#/oneOf/0/properties/version/enum", "/version" ],
-        [ false, "LogicalWhenType", "/oneOf/0/properties", "#/oneOf/0/properties", "" ],
-        [ true, "AssertionEqual", "/oneOf/1/properties/version/enum", "#/oneOf/1/properties/version/enum", "/version" ],
-        [ true, "AssertionTypeStrict", "/oneOf/1/properties/one/type", "#/oneOf/1/properties/one/type", "/one" ],
-        [ true, "LogicalWhenType", "/oneOf/1/properties", "#/oneOf/1/properties", "" ],
-        [ false, "AssertionEqual", "/oneOf/2/properties/version/enum", "#/oneOf/2/properties/version/enum", "/version" ],
-        [ false, "LogicalWhenType", "/oneOf/2/properties", "#/oneOf/2/properties", "" ],
-        [ true, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/oneOf/0/properties/version/enum",
+          "#/oneOf/0/properties/version/enum",
+          "/version"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/oneOf/0/properties",
+          "#/oneOf/0/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionEqual",
+          "/oneOf/1/properties/version/enum",
+          "#/oneOf/1/properties/version/enum",
+          "/version"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/oneOf/1/properties/one/type",
+          "#/oneOf/1/properties/one/type",
+          "/one"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/oneOf/1/properties",
+          "#/oneOf/1/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionEqual",
+          "/oneOf/2/properties/version/enum",
+          "#/oneOf/2/properties/version/enum",
+          "/version"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/oneOf/2/properties",
+          "#/oneOf/2/properties",
+          ""
+        ],
+        [
+          true,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to equal the integer constant 1",
@@ -4667,20 +11685,60 @@
     "description": "oneOf_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "oneOf": [ { "type": "string" }, { "type": "integer" } ]
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
     "instance": true,
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ false, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -4690,14 +11748,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalXor", "/oneOf", "#/oneOf", "" ],
-        [ "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ]
+        [
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/oneOf/0/type", "#/oneOf/0/type", "" ],
-        [ false, "AssertionTypeStrict", "/oneOf/1/type", "#/oneOf/1/type", "" ],
-        [ false, "LogicalXor", "/oneOf", "#/oneOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/0/type",
+          "#/oneOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/oneOf/1/type",
+          "#/oneOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/oneOf",
+          "#/oneOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type boolean",
@@ -4710,7 +11801,17 @@
     "description": "dependencies_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
     "instance": 5,
     "valid": true,
@@ -4721,16 +11822,41 @@
     "description": "dependencies_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "foo": 1, "bar": 2, "baz": 3 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "baz": 3
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "Because the object value defined the property \"foo\", it was also expected to define the properties \"bar\", and \"baz\""
@@ -4738,10 +11864,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "Because the object value defined the property \"foo\", it was also expected to define the properties \"bar\", and \"baz\""
@@ -4752,16 +11889,40 @@
     "description": "dependencies_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "foo": 1, "baz": 3 },
+    "instance": {
+      "foo": 1,
+      "baz": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "Because the object value defined the property \"foo\", it was also expected to define the property \"bar\""
@@ -4769,10 +11930,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "Because the object value defined the property \"foo\", it was also expected to define the property \"bar\""
@@ -4783,20 +11955,66 @@
     "description": "dependencies_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "qux": 1, "extra": 2 },
+    "instance": {
+      "qux": 1,
+      "extra": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ true, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4806,14 +12024,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ true, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4826,18 +12077,52 @@
     "description": "dependencies_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "qux": 1 },
+    "instance": {
+      "qux": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4846,12 +12131,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4863,16 +12170,39 @@
     "description": "dependencies_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "none": 1 },
+    "instance": {
+      "none": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\""
@@ -4880,10 +12210,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\""
@@ -4894,16 +12235,34 @@
     "description": "dependencies_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ] }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ]
+      }
     },
-    "instance": { "none": 1 },
+    "instance": {
+      "none": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\""
@@ -4911,10 +12270,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyDependencies", "/dependencies", "#/dependencies", "" ]
+        [
+          true,
+          "AssertionPropertyDependencies",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value did not define the property \"foo\""
@@ -4925,18 +12295,53 @@
     "description": "dependencies_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "dependencies": { "foo": [ "bar", "baz" ], "qux": { "required": [ "extra" ] } }
+      "dependencies": {
+        "foo": [
+          "bar",
+          "baz"
+        ],
+        "qux": {
+          "required": [
+            "extra"
+          ]
+        }
+      }
     },
-    "instance": { "foo": 1, "qux": 2 },
+    "instance": {
+      "foo": 1,
+      "qux": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4945,12 +12350,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ],
-        [ "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ]
+        [
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefines", "/dependencies/qux/required", "#/dependencies/qux/required", "" ],
-        [ false, "LogicalWhenDefines", "/dependencies", "#/dependencies", "" ]
+        [
+          false,
+          "AssertionDefines",
+          "/dependencies/qux/required",
+          "#/dependencies/qux/required",
+          ""
+        ],
+        [
+          false,
+          "LogicalWhenDefines",
+          "/dependencies",
+          "#/dependencies",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"extra\"",
@@ -4973,16 +12400,31 @@
     "description": "enum_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "enum": [ 1, {}, "foo" ]
+      "enum": [
+        1,
+        {},
+        "foo"
+      ]
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal one of the 3 declared values"
@@ -4990,10 +12432,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal one of the 3 declared values"
@@ -5004,16 +12457,33 @@
     "description": "enum_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "enum": [ 1, {}, "foo" ]
+      "enum": [
+        1,
+        {},
+        "foo"
+      ]
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal one of the following values: 1, \"foo\", and {}"
@@ -5021,10 +12491,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal one of the following values: 1, \"foo\", and {}"
@@ -5033,15 +12514,31 @@
   },
   {
     "description": "enum_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "enum": [ 1 ] },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "enum": [
+        1
+      ]
+    },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -5049,10 +12546,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -5064,16 +12572,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "string",
-      "enum": [ "foo" ]
+      "enum": [
+        "foo"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\""
@@ -5081,12 +12602,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -5099,16 +12642,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "boolean",
-      "enum": [ true ]
+      "enum": [
+        true
+      ]
     },
     "instance": true,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true"
@@ -5116,12 +12672,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true",
@@ -5134,16 +12712,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "number",
-      "enum": [ 3.14 ]
+      "enum": [
+        3.14
+      ]
     },
     "instance": 3.14,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14"
@@ -5151,12 +12742,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14",
@@ -5169,16 +12782,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "number",
-      "enum": [ 3 ]
+      "enum": [
+        3
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3"
@@ -5186,12 +12812,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3",
@@ -5204,16 +12852,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "integer",
-      "enum": [ 3 ]
+      "enum": [
+        3
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3"
@@ -5221,12 +12882,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3",
@@ -5239,16 +12922,31 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "string",
-      "enum": [ "foo", "bar", "baz" ]
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the given declared values"
@@ -5256,12 +12954,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 3 declared values",
@@ -5274,18 +12994,43 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "string",
-      "enum": [ "foo", 1 ]
+      "enum": [
+        "foo",
+        1
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 2 declared values",
@@ -5294,12 +13039,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 2 declared values",
@@ -5312,16 +13079,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
-      "enum": [ [ 1 ] ]
+      "enum": [
+        [
+          1
+        ]
+      ]
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]"
@@ -5329,12 +13113,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -5347,16 +13153,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "enum": [ {} ]
+      "enum": [
+        {}
+      ]
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}"
@@ -5364,12 +13183,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}",
@@ -5382,16 +13223,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "null",
-      "enum": [ null ]
+      "enum": [
+        null
+      ]
     },
     "instance": null,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null"
@@ -5399,12 +13253,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null",
@@ -5418,18 +13294,42 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "string",
       "minLength": 1,
-      "enum": [ "foo" ]
+      "enum": [
+        "foo"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -5438,14 +13338,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -5460,18 +13393,46 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
       "minItems": 1,
-      "enum": [ [ 1 ] ]
+      "enum": [
+        [
+          1
+        ]
+      ]
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -5480,14 +13441,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -5502,18 +13496,46 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "minProperties": 1,
-      "enum": [ { "foo": 1 } ]
+      "enum": [
+        {
+          "foo": 1
+        }
+      ]
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -5522,14 +13544,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -5543,16 +13598,31 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "string",
-      "enum": [ "foo", "bar", "baz" ]
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
+      ]
     },
     "instance": "xxxx",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxxx\" was expected to equal one of the given declared values"
@@ -5560,10 +13630,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqualsAny", "/enum", "#/enum", "" ]
+        [
+          false,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxxx\" was expected to equal one of the following values: \"bar\", \"baz\", and \"foo\""
@@ -5577,19 +13658,40 @@
       "properties": {
         "foo": {
           "type": "object",
-          "required": [ "bar" ],
-          "properties": { "bar": { "enum": [ "baz" ] } }
+          "required": [
+            "bar"
+          ],
+          "properties": {
+            "bar": {
+              "enum": [
+                "baz"
+              ]
+            }
+          }
         }
       }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -5597,12 +13699,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesStrict", "/properties/foo/required", "#/properties/foo/required", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/foo/required",
+          "#/properties/foo/required",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/properties/foo/required", "#/properties/foo/required", "/foo" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/properties/foo/required",
+          "#/properties/foo/required",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"bar\"",
@@ -5617,19 +13741,41 @@
       "properties": {
         "foo": {
           "type": "object",
-          "required": [ "bar", "baz" ],
-          "properties": { "bar": { "enum": [ "qux" ] } }
+          "required": [
+            "bar",
+            "baz"
+          ],
+          "properties": {
+            "bar": {
+              "enum": [
+                "qux"
+              ]
+            }
+          }
         }
       }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties/foo/properties", "#/properties/foo/properties", "/foo" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/foo/properties",
+          "#/properties/foo/properties",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -5637,12 +13783,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionDefinesAllStrict", "/properties/foo/required", "#/properties/foo/required", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionDefinesAllStrict",
+          "/properties/foo/required",
+          "#/properties/foo/required",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/properties/foo/required", "#/properties/foo/required", "/foo" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/properties/foo/required",
+          "#/properties/foo/required",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"bar\", and \"baz\"",
@@ -5671,10 +13839,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          true,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to not contain duplicate items"
@@ -5682,10 +13861,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          true,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to not contain duplicate items"
@@ -5709,14 +13899,29 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "uniqueItems": true
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          true,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to not contain duplicate items"
@@ -5724,10 +13929,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          true,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to not contain duplicate items"
@@ -5740,14 +13956,29 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "uniqueItems": true
     },
-    "instance": [ 2, 1, 2 ],
+    "instance": [
+      2,
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate item: 2"
@@ -5755,10 +13986,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate item: 2"
@@ -5771,7 +14013,11 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "uniqueItems": false
     },
-    "instance": [ 2, 1, 2 ],
+    "instance": [
+      2,
+      1,
+      2
+    ],
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -5782,14 +14028,33 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "uniqueItems": true
     },
-    "instance": [ 2, 1, 2, 3, 2, 2, 2 ],
+    "instance": [
+      2,
+      1,
+      2,
+      3,
+      2,
+      2,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate item: 2"
@@ -5797,10 +14062,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate item: 2"
@@ -5813,14 +14089,34 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "uniqueItems": true
     },
-    "instance": [ 2, 1, 2, 3, 2, 2, 1, 2 ],
+    "instance": [
+      2,
+      1,
+      2,
+      3,
+      2,
+      2,
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate items: 1, and 2"
@@ -5828,10 +14124,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionUnique", "/uniqueItems", "#/uniqueItems", "" ]
+        [
+          false,
+          "AssertionUnique",
+          "/uniqueItems",
+          "#/uniqueItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value contained the following duplicate items: 1, and 2"
@@ -5840,7 +14147,10 @@
   },
   {
     "description": "minLength_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minLength": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -5848,15 +14158,29 @@
   },
   {
     "description": "minLength_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minLength": 2
+    },
     "instance": "xx",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at least 2 characters and it consisted of 2 characters"
@@ -5864,10 +14188,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at least 2 characters and it consisted of 2 characters"
@@ -5876,15 +14211,29 @@
   },
   {
     "description": "minLength_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minLength": 2
+    },
     "instance": "x",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at least 2 characters but it consisted of 1 character"
@@ -5892,10 +14241,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at least 2 characters but it consisted of 1 character"
@@ -5913,10 +14273,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 1 character"
@@ -5924,12 +14295,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at least 1 character and it consisted of 2 characters",
@@ -5948,10 +14341,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5959,10 +14363,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5971,7 +14386,10 @@
   },
   {
     "description": "minLength_6",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minLength": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minLength": 0
+    },
     "instance": "x",
     "valid": true,
     "fast": {},
@@ -5979,7 +14397,10 @@
   },
   {
     "description": "minLength_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minLength": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minLength": 0
+    },
     "instance": "",
     "valid": true,
     "fast": {},
@@ -5998,7 +14419,10 @@
   },
   {
     "description": "maxLength_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxLength": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -6006,15 +14430,29 @@
   },
   {
     "description": "maxLength_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxLength": 2
+    },
     "instance": "xx",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters"
@@ -6022,10 +14460,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters"
@@ -6034,15 +14483,29 @@
   },
   {
     "description": "maxLength_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxLength": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxLength": 2
+    },
     "instance": "xxx",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to consist of at most 2 characters but it consisted of 3 characters"
@@ -6050,10 +14513,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to consist of at most 2 characters but it consisted of 3 characters"
@@ -6071,10 +14545,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -6082,12 +14567,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -6106,10 +14613,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -6117,10 +14635,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to consist of at most 2 characters but it consisted of 3 characters"
@@ -6139,10 +14668,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of 1 to 2 characters"
@@ -6150,14 +14690,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -6168,15 +14741,29 @@
   },
   {
     "description": "maxLength_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxLength": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxLength": 0
+    },
     "instance": "x",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at most 0 characters but it consisted of 1 character"
@@ -6184,10 +14771,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"x\" was expected to consist of at most 0 characters but it consisted of 1 character"
@@ -6196,15 +14794,29 @@
   },
   {
     "description": "maxLength_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxLength": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxLength": 0
+    },
     "instance": "",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"\" was expected to consist of at most 0 characters and it consisted of 0 characters"
@@ -6212,10 +14824,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"\" was expected to consist of at most 0 characters and it consisted of 0 characters"
@@ -6235,7 +14858,10 @@
   },
   {
     "description": "minItems_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minItems": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minItems": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -6243,15 +14869,32 @@
   },
   {
     "description": "minItems_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minItems": 2 },
-    "instance": [ 1, 2 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minItems": 2
+    },
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 2 items"
@@ -6259,10 +14902,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 2 items"
@@ -6271,15 +14925,31 @@
   },
   {
     "description": "minItems_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minItems": 2 },
-    "instance": [ 1 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minItems": 2
+    },
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items but it contained 1 item"
@@ -6287,10 +14957,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items but it contained 1 item"
@@ -6308,10 +14989,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6319,10 +15011,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6336,14 +15039,29 @@
       "type": "array",
       "minItems": 2
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -6351,12 +15069,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 3 items",
@@ -6371,14 +15111,29 @@
       "type": "array",
       "minItems": 0
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array"
@@ -6386,10 +15141,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array"
@@ -6398,15 +15164,23 @@
   },
   {
     "description": "minItems_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minItems": 0 },
-    "instance": [ 1 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minItems": 0
+    },
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {},
     "exhaustive": {}
   },
   {
     "description": "minItems_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minItems": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minItems": 0
+    },
     "instance": [],
     "valid": true,
     "fast": {},
@@ -6418,18 +15192,44 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
       "minItems": 0,
-      "items": { "type": "number" }
+      "items": {
+        "type": "number"
+      }
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsTypeStrictAny", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsTypeStrictAny",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsTypeStrictAny", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsTypeStrictAny",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type number",
@@ -6438,14 +15238,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number",
@@ -6467,7 +15300,10 @@
   },
   {
     "description": "maxItems_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxItems": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxItems": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -6475,15 +15311,32 @@
   },
   {
     "description": "maxItems_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxItems": 2 },
-    "instance": [ 1, 2 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxItems": 2
+    },
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items"
@@ -6491,10 +15344,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items"
@@ -6503,15 +15367,33 @@
   },
   {
     "description": "maxItems_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxItems": 2 },
-    "instance": [ 1, 2, 3 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxItems": 2
+    },
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -6519,10 +15401,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -6540,10 +15433,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6551,10 +15455,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6568,14 +15483,28 @@
       "type": "array",
       "maxItems": 2
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -6583,12 +15512,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -6603,14 +15554,29 @@
       "type": "array",
       "maxItems": 2
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -6618,10 +15584,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -6636,14 +15613,28 @@
       "minItems": 1,
       "maxItems": 2
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of 1 to 2 items"
@@ -6651,14 +15642,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -6669,15 +15693,31 @@
   },
   {
     "description": "maxItems_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxItems": 0 },
-    "instance": [ 1 ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxItems": 0
+    },
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 0 items but it contained 1 item"
@@ -6685,10 +15725,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 0 items but it contained 1 item"
@@ -6697,15 +15748,29 @@
   },
   {
     "description": "maxItems_9",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxItems": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxItems": 0
+    },
     "instance": [],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 0 items and it contained 0 items"
@@ -6713,10 +15778,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 0 items and it contained 0 items"
@@ -6736,7 +15812,10 @@
   },
   {
     "description": "minProperties_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minProperties": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minProperties": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -6744,15 +15823,32 @@
   },
   {
     "description": "minProperties_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minProperties": 2 },
-    "instance": { "bar": 2, "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minProperties": 2
+    },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties and it contained 2 properties: \"bar\", and \"foo\""
@@ -6760,10 +15856,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties and it contained 2 properties: \"bar\", and \"foo\""
@@ -6772,15 +15879,31 @@
   },
   {
     "description": "minProperties_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minProperties": 2 },
-    "instance": { "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minProperties": 2
+    },
+    "instance": {
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties but it contained 1 property: \"foo\""
@@ -6788,10 +15911,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties but it contained 1 property: \"foo\""
@@ -6805,14 +15939,27 @@
       "type": "object",
       "minProperties": 1
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 1 property"
@@ -6820,12 +15967,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 1 property and it contained 1 property: \"foo\"",
@@ -6840,14 +16009,27 @@
       "type": "object",
       "minProperties": 0
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6855,10 +16037,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -6867,15 +16060,23 @@
   },
   {
     "description": "minProperties_6",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minProperties": 0 },
-    "instance": { "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minProperties": 0
+    },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
   },
   {
     "description": "minProperties_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minProperties": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minProperties": 0
+    },
     "instance": {},
     "valid": true,
     "fast": {},
@@ -6894,7 +16095,10 @@
   },
   {
     "description": "maxProperties_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxProperties": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxProperties": 2
+    },
     "instance": 5,
     "valid": true,
     "fast": {},
@@ -6902,15 +16106,32 @@
   },
   {
     "description": "maxProperties_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxProperties": 2 },
-    "instance": { "bar": 2, "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxProperties": 2
+    },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\""
@@ -6918,10 +16139,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\""
@@ -6930,15 +16162,33 @@
   },
   {
     "description": "maxProperties_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxProperties": 2 },
-    "instance": { "bar": 2, "baz": 3, "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxProperties": 2
+    },
+    "instance": {
+      "bar": 2,
+      "baz": 3,
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"bar\", \"baz\", and \"foo\""
@@ -6946,10 +16196,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"bar\", \"baz\", and \"foo\""
@@ -6963,14 +16224,28 @@
       "type": "object",
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -6978,12 +16253,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\"",
@@ -6998,14 +16295,29 @@
       "type": "object",
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1, "baz": 3 },
+    "instance": {
+      "bar": 2,
+      "foo": 1,
+      "baz": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -7013,10 +16325,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"bar\", \"baz\", and \"foo\""
@@ -7031,14 +16354,28 @@
       "minProperties": 1,
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of 1 to 2 properties"
@@ -7046,14 +16383,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\"",
@@ -7064,15 +16434,31 @@
   },
   {
     "description": "maxProperties_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxProperties": 0 },
-    "instance": { "foo": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxProperties": 0
+    },
+    "instance": {
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 0 properties but it contained 1 property: \"foo\""
@@ -7080,10 +16466,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 0 properties but it contained 1 property: \"foo\""
@@ -7092,15 +16489,29 @@
   },
   {
     "description": "maxProperties_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maxProperties": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maxProperties": 0
+    },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 0 properties and it contained 0 properties"
@@ -7108,10 +16519,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 0 properties and it contained 0 properties"
@@ -7131,7 +16553,10 @@
   },
   {
     "description": "minimum_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 2
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -7139,15 +16564,29 @@
   },
   {
     "description": "minimum_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 2
+    },
     "instance": 2.1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than or equal to the integer 2"
@@ -7155,10 +16594,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than or equal to the integer 2"
@@ -7167,15 +16617,29 @@
   },
   {
     "description": "minimum_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 2
+    },
     "instance": 2,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than or equal to the integer 2"
@@ -7183,10 +16647,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than or equal to the integer 2"
@@ -7195,15 +16670,29 @@
   },
   {
     "description": "minimum_4",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 2
+    },
     "instance": 1.8,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.8 was expected to be greater than or equal to the integer 2"
@@ -7211,10 +16700,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.8 was expected to be greater than or equal to the integer 2"
@@ -7223,15 +16723,29 @@
   },
   {
     "description": "minimum_5",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 0
+    },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than or equal to the integer 0"
@@ -7239,10 +16753,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than or equal to the integer 0"
@@ -7251,15 +16776,29 @@
   },
   {
     "description": "minimum_6",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 0
+    },
     "instance": 0,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 0"
@@ -7267,10 +16806,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 0"
@@ -7290,7 +16840,10 @@
   },
   {
     "description": "maximum_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 2
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -7298,15 +16851,29 @@
   },
   {
     "description": "maximum_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 2
+    },
     "instance": 1.9,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than or equal to the integer 2"
@@ -7314,10 +16881,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than or equal to the integer 2"
@@ -7326,15 +16904,29 @@
   },
   {
     "description": "maximum_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 2
+    },
     "instance": 2,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than or equal to the integer 2"
@@ -7342,10 +16934,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than or equal to the integer 2"
@@ -7354,15 +16957,29 @@
   },
   {
     "description": "maximum_4",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 2
+    },
     "instance": 2.1,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be less than or equal to the integer 2"
@@ -7370,10 +16987,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be less than or equal to the integer 2"
@@ -7382,15 +17010,29 @@
   },
   {
     "description": "maximum_5",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 0 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 0
+    },
     "instance": 0,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 0"
@@ -7398,10 +17040,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 0"
@@ -7421,15 +17074,29 @@
   },
   {
     "description": "minimum_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 10,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7437,10 +17104,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7449,15 +17127,29 @@
   },
   {
     "description": "minimum_9",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 3,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7465,10 +17157,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7477,15 +17180,29 @@
   },
   {
     "description": "minimum_10",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 10,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7493,10 +17210,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7505,15 +17233,29 @@
   },
   {
     "description": "minimum_11",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 3,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7521,10 +17263,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7533,15 +17286,29 @@
   },
   {
     "description": "minimum_14",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 10,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7549,10 +17316,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than or equal to the integer 5"
@@ -7561,15 +17339,29 @@
   },
   {
     "description": "minimum_15",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 3,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7577,10 +17369,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be greater than or equal to the integer 5"
@@ -7589,15 +17392,29 @@
   },
   {
     "description": "minimum_20",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 0.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 0.5
+    },
     "instance": 0.7,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be greater than or equal to the number 0.5"
@@ -7605,10 +17422,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be greater than or equal to the number 0.5"
@@ -7617,15 +17445,29 @@
   },
   {
     "description": "minimum_21",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 0.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 0.5
+    },
     "instance": 0.3,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be greater than or equal to the number 0.5"
@@ -7633,10 +17475,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be greater than or equal to the number 0.5"
@@ -7645,15 +17498,29 @@
   },
   {
     "description": "minimum_23",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 5
+    },
     "instance": 5,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 5"
@@ -7661,10 +17528,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 5"
@@ -7673,15 +17551,29 @@
   },
   {
     "description": "minimum_24",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "minimum": 2.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "minimum": 2.5
+    },
     "instance": 5,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the number 2.5"
@@ -7689,10 +17581,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the number 2.5"
@@ -7701,15 +17604,29 @@
   },
   {
     "description": "maximum_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7717,10 +17634,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7729,15 +17657,29 @@
   },
   {
     "description": "maximum_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7745,10 +17687,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7757,15 +17710,29 @@
   },
   {
     "description": "maximum_9",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7773,10 +17740,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7785,15 +17763,29 @@
   },
   {
     "description": "maximum_10",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7801,10 +17793,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7813,15 +17816,29 @@
   },
   {
     "description": "maximum_13",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7829,10 +17846,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the integer 5"
@@ -7841,15 +17869,29 @@
   },
   {
     "description": "maximum_14",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7857,10 +17899,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 5"
@@ -7869,15 +17922,29 @@
   },
   {
     "description": "maximum_19",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 0.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 0.5
+    },
     "instance": 0.3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be less than or equal to the number 0.5"
@@ -7885,10 +17952,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be less than or equal to the number 0.5"
@@ -7897,15 +17975,29 @@
   },
   {
     "description": "maximum_20",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 0.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 0.5
+    },
     "instance": 0.7,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be less than or equal to the number 0.5"
@@ -7913,10 +18005,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be less than or equal to the number 0.5"
@@ -7925,15 +18028,29 @@
   },
   {
     "description": "maximum_22",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5
+    },
     "instance": 5,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than or equal to the integer 5"
@@ -7941,10 +18058,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than or equal to the integer 5"
@@ -7953,15 +18081,29 @@
   },
   {
     "description": "maximum_23",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "maximum": 5.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "maximum": 5.5
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the number 5.5"
@@ -7969,10 +18111,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than or equal to the number 5.5"
@@ -7990,10 +18143,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than the integer 2"
@@ -8001,10 +18165,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than the integer 2"
@@ -8022,10 +18197,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than the integer 2, but they were equal"
@@ -8033,10 +18219,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than the integer 2, but they were equal"
@@ -8054,10 +18251,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than or equal to the integer 2"
@@ -8065,10 +18273,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than or equal to the integer 2"
@@ -8086,10 +18305,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than the integer 2"
@@ -8097,10 +18327,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than the integer 2"
@@ -8118,10 +18359,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than the integer 2, but they were equal"
@@ -8129,10 +18381,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than the integer 2, but they were equal"
@@ -8150,10 +18413,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than or equal to the integer 2"
@@ -8161,10 +18435,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than or equal to the integer 2"
@@ -8182,10 +18467,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8193,10 +18489,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8214,10 +18521,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8225,10 +18543,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8246,10 +18575,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8257,10 +18597,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8278,10 +18629,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8289,10 +18651,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8310,10 +18683,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be greater than the number 2.5, but they were equal"
@@ -8321,10 +18705,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be greater than the number 2.5, but they were equal"
@@ -8342,10 +18737,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8353,10 +18759,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be greater than the integer 5"
@@ -8374,10 +18791,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8385,10 +18813,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than the integer 5, but they were equal"
@@ -8406,10 +18845,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be greater than the number 2.5, but they were equal"
@@ -8417,10 +18867,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be greater than the number 2.5, but they were equal"
@@ -8438,10 +18899,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be greater than the number 0.5"
@@ -8449,10 +18921,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.7 was expected to be greater than the number 0.5"
@@ -8470,10 +18953,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.5 was expected to be greater than the number 0.5, but they were equal"
@@ -8481,10 +18975,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.5 was expected to be greater than the number 0.5, but they were equal"
@@ -8502,10 +19007,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8513,10 +19029,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8534,10 +19061,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8545,10 +19083,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8566,10 +19115,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8577,10 +19137,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8598,10 +19169,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8609,10 +19191,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8630,10 +19223,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be less than the number 2.5, but they were equal"
@@ -8641,10 +19245,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be less than the number 2.5, but they were equal"
@@ -8662,10 +19277,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8673,10 +19299,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be less than the integer 5"
@@ -8694,10 +19331,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8705,10 +19353,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be less than the integer 5, but they were equal"
@@ -8726,10 +19385,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be less than the number 2.5, but they were equal"
@@ -8737,10 +19407,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.5 was expected to be less than the number 2.5, but they were equal"
@@ -8758,10 +19439,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be less than the number 0.5"
@@ -8769,10 +19461,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.3 was expected to be less than the number 0.5"
@@ -8790,10 +19493,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.5 was expected to be less than the number 0.5, but they were equal"
@@ -8801,10 +19515,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.5 was expected to be less than the number 0.5, but they were equal"
@@ -8813,7 +19538,10 @@
   },
   {
     "description": "multipleOf_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -8821,15 +19549,29 @@
   },
   {
     "description": "multipleOf_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 6,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 6 was expected to be divisible by the integer 3"
@@ -8837,10 +19579,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 6 was expected to be divisible by the integer 3"
@@ -8849,15 +19602,29 @@
   },
   {
     "description": "multipleOf_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 7,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 7 was expected to be divisible by the integer 3"
@@ -8865,10 +19632,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 7 was expected to be divisible by the integer 3"
@@ -8877,15 +19655,29 @@
   },
   {
     "description": "multipleOf_4",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3.2 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3.2
+    },
     "instance": 6.4,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 6.4 was expected to be divisible by the number 3.2"
@@ -8893,10 +19685,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 6.4 was expected to be divisible by the number 3.2"
@@ -8916,15 +19719,29 @@
   },
   {
     "description": "multipleOf_7",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 9,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -8932,10 +19749,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -8944,15 +19772,29 @@
   },
   {
     "description": "multipleOf_8",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -8960,10 +19802,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -8972,15 +19825,29 @@
   },
   {
     "description": "multipleOf_9",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 9,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -8988,10 +19855,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -9000,15 +19878,29 @@
   },
   {
     "description": "multipleOf_10",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -9016,10 +19908,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -9028,15 +19931,29 @@
   },
   {
     "description": "multipleOf_13",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 9,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -9044,10 +19961,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 9 was expected to be divisible by the integer 3"
@@ -9056,15 +19984,29 @@
   },
   {
     "description": "multipleOf_14",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 3 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 3
+    },
     "instance": 10,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -9072,10 +20014,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be divisible by the integer 3"
@@ -9084,15 +20037,29 @@
   },
   {
     "description": "multipleOf_20",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 0.1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 0.1
+    },
     "instance": 0.35,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.35 was expected to be divisible by the number 0.1"
@@ -9100,10 +20067,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 0.35 was expected to be divisible by the number 0.1"
@@ -9112,15 +20090,29 @@
   },
   {
     "description": "multipleOf_22",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 1.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 1.5
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be divisible by the number 1.5"
@@ -9128,10 +20120,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to be divisible by the number 1.5"
@@ -9140,15 +20143,29 @@
   },
   {
     "description": "multipleOf_23",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 0.01 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 0.01
+    },
     "instance": 1280.32,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1280.32 was expected to be divisible by the number 0.01"
@@ -9156,10 +20173,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1280.32 was expected to be divisible by the number 0.01"
@@ -9181,7 +20209,10 @@
   },
   {
     "description": "unknown_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "fooBar": "baz" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "fooBar": "baz"
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -9189,7 +20220,10 @@
   },
   {
     "description": "unknown_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "x-test": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "x-test": 1
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -9197,7 +20231,10 @@
   },
   {
     "description": "format_uri_1",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "format": "uri" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "format": "uri"
+    },
     "instance": 6,
     "valid": true,
     "fast": {},
@@ -9205,7 +20242,10 @@
   },
   {
     "description": "format_uri_2",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "format": "uri" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "format": "uri"
+    },
     "instance": "https://www.example.com",
     "valid": true,
     "fast": {},
@@ -9213,7 +20253,10 @@
   },
   {
     "description": "format_uri_3",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "format": "uri" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "format": "uri"
+    },
     "instance": "!!!x::://",
     "valid": true,
     "fast": {},
@@ -9224,17 +20267,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema",
       "id": "common",
-      "allOf": [ { "$ref": "#reference" } ],
-      "definitions": { "reference": { "id": "#reference", "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#reference"
+        }
+      ],
+      "definitions": {
+        "reference": {
+          "id": "#reference",
+          "type": "string"
+        }
+      }
     },
     "instance": "test",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "common#/definitions/reference/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "common#/definitions/reference/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "common#/definitions/reference/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "common#/definitions/reference/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -9242,14 +20305,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "common#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "common#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "common#/definitions/reference/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "common#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "common#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "common#/definitions/reference/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "common#/definitions/reference/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "common#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "common#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "common#/definitions/reference/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "common#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "common#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -9262,16 +20358,35 @@
     "description": "items_integer_bounded_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 50, 99 ],
+    "instance": [
+      10,
+      50,
+      99
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -9279,28 +20394,138 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -9320,16 +20545,35 @@
     "description": "items_integer_bounded_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 200, 50 ],
+    "instance": [
+      10,
+      200,
+      50
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -9337,18 +20581,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -9363,16 +20662,33 @@
     "description": "items_integer_bounded_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ "foo" ],
+    "instance": [
+      "foo"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -9380,12 +20696,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string",
@@ -9397,7 +20735,11 @@
     "description": "items_integer_bounded_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": "not an array",
     "valid": true,
@@ -9408,17 +20750,32 @@
     "description": "items_integer_bounded_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": [],
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema"
@@ -9429,16 +20786,34 @@
     "description": "items_integer_bounded_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10.5, 99.9 ],
+    "instance": [
+      10.5,
+      99.9
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -9446,22 +20821,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 10.5 was expected to be less than or equal to the integer 100",
@@ -9478,28 +20930,112 @@
     "description": "items_integer_bounded_7_real_bounds",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0.5, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0.5,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 50 ],
+    "instance": [
+      1,
+      50
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -9513,22 +21049,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -9545,16 +21158,34 @@
     "description": "items_integer_bounded_8_boundary_values",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 0, 100 ],
+    "instance": [
+      0,
+      100
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -9562,22 +21193,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -9594,42 +21302,108 @@
     "description": "items_integer_bounded_9_type_integer_no_optimization",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "integer", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 3.5 ],
+    "instance": [
+      3.5
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "/items",
+          "#/items",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBoundedStrict",
+          "/items",
+          "#/items",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
-        "The number value 3.5 was expected to be less than or equal to the integer 100",
-        "The number value 3.5 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer but it was of type number",
+        "The value was expected to be an integer within the given range",
         "Every item in the array value was expected to validate against the given subschema"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ false, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.5 was expected to be less than or equal to the integer 100",
@@ -9643,42 +21417,108 @@
     "description": "items_integer_bounded_10_type_integer_valid",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "items": { "type": "integer", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 50 ],
+    "instance": [
+      50
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "/items",
+          "#/items",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "/items",
+          "#/items",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 50 was expected to be less than or equal to the integer 100",
-        "The integer value 50 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer",
+        "The value was expected to be an integer within the given range",
         "Every item in the array value was expected to validate against the given subschema"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrict", "/items/type", "#/items/type", "/0" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -9700,31 +21540,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 50 was expected to be less than or equal to the integer 100",
-        "The integer value 50 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -9745,21 +21623,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 200 was expected to be less than or equal to the integer 100"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 200 was expected to be less than or equal to the integer 100"
@@ -9778,31 +21678,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 0 was expected to be less than or equal to the integer 100",
-        "The integer value 0 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -9823,31 +21761,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 100 was expected to be less than or equal to the integer 100",
-        "The integer value 100 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 100 was expected to be less than or equal to the integer 100",
@@ -9867,26 +21843,56 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 5 was expected to be greater than or equal to the integer 1",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 1",
@@ -9905,21 +21911,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 0 was expected to be greater than or equal to the integer 1"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 1"
@@ -9931,19 +21959,48 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 },
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      },
       "minItems": 1
     },
-    "instance": [ 10, 50 ],
+    "instance": [
+      10,
+      50
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -9952,26 +22009,125 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -9991,17 +22147,32 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 },
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      },
       "minItems": 1
     },
     "instance": [],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 1 item"
@@ -10009,12 +22180,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema",
@@ -10027,17 +22220,35 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 },
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      },
       "minItems": 1
     },
-    "instance": [ 10, 200 ],
+    "instance": [
+      10,
+      200
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -10045,18 +22256,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -10071,16 +22337,35 @@
     "description": "prop_type_integer_bounded_strict_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 50 },
+    "instance": {
+      "x": 50
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10088,16 +22373,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -10111,16 +22440,35 @@
     "description": "prop_type_integer_bounded_strict_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 200 },
+    "instance": {
+      "x": 200
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10128,12 +22476,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 200 was expected to be less than or equal to the integer 100",
@@ -10145,16 +22515,35 @@
     "description": "prop_type_integer_bounded_strict_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": -1 },
+    "instance": {
+      "x": -1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10162,14 +22551,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value -1 was expected to be less than or equal to the integer 100",
@@ -10182,16 +22604,35 @@
     "description": "prop_type_integer_bounded_strict_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10199,16 +22640,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -10222,16 +22707,35 @@
     "description": "prop_type_integer_bounded_strict_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 100 },
+    "instance": {
+      "x": 100
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10239,16 +22743,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 100 was expected to be less than or equal to the integer 100",
@@ -10262,16 +22810,35 @@
     "description": "prop_type_integer_bounded_strict_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": "hello" },
+    "instance": {
+      "x": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBoundedStrict", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBoundedStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -10279,12 +22846,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type string",
@@ -10296,17 +22885,34 @@
     "description": "prop_type_integer_bounded_strict_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -10317,16 +22923,34 @@
     "description": "prop_type_integer_lower_bound_strict_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5 },
+    "instance": {
+      "x": 5
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -10334,14 +22958,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 1",
@@ -10354,16 +23011,34 @@
     "description": "prop_type_integer_lower_bound_strict_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -10371,12 +23046,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 1",
@@ -10388,16 +23085,34 @@
     "description": "prop_type_integer_lower_bound_strict_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 1 },
+    "instance": {
+      "x": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -10405,14 +23120,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than or equal to the integer 1",
@@ -10425,16 +23173,34 @@
     "description": "prop_type_integer_lower_bound_strict_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5.5 },
+    "instance": {
+      "x": 5.5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBoundStrict", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBoundStrict",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -10442,14 +23208,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 5.5 was expected to be greater than or equal to the integer 1",
@@ -10462,17 +23261,33 @@
     "description": "prop_type_integer_lower_bound_strict_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -10486,19 +23301,36 @@
       "properties": {
         "scores": {
           "type": "array",
-          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
           "minItems": 1
         }
       }
     },
-    "instance": { "scores": "hello" },
+    "instance": {
+      "scores": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          false,
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -10506,12 +23338,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type string",
@@ -10526,19 +23380,36 @@
       "properties": {
         "scores": {
           "type": "array",
-          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
           "minItems": 1
         }
       }
     },
-    "instance": { "scores": [] },
+    "instance": {
+      "scores": []
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          false,
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -10546,14 +23417,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ false, "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema",
@@ -10569,19 +23473,39 @@
       "properties": {
         "scores": {
           "type": "array",
-          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
           "minItems": 1
         }
       }
     },
-    "instance": { "scores": [ 50, 75 ] },
+    "instance": {
+      "scores": [
+        50,
+        75
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          true,
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -10589,28 +23513,138 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
-        [ "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ true, "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
-        [ true, "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -10636,10 +23670,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than or equal to the integer 99999999999999999999999999999999999"
@@ -10647,10 +23692,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than or equal to the integer 99999999999999999999999999999999999"
@@ -10667,10 +23723,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be greater than or equal to the integer 99999999999999999999999999999999999"
@@ -10678,10 +23745,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be greater than or equal to the integer 99999999999999999999999999999999999"
@@ -10698,10 +23776,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than or equal to the integer 99999999999999999999999999999999999"
@@ -10709,10 +23798,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than or equal to the integer 99999999999999999999999999999999999"
@@ -10729,10 +23829,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be less than or equal to the integer 99999999999999999999999999999999999"
@@ -10740,10 +23851,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be less than or equal to the integer 99999999999999999999999999999999999"
@@ -10761,10 +23883,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than the integer 99999999999999999999999999999999999"
@@ -10772,10 +23905,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than the integer 99999999999999999999999999999999999"
@@ -10793,10 +23937,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be greater than the integer 99999999999999999999999999999999999, but they were equal"
@@ -10804,10 +23959,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be greater than the integer 99999999999999999999999999999999999, but they were equal"
@@ -10825,10 +23991,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than the integer 99999999999999999999999999999999999"
@@ -10836,10 +24013,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than the integer 99999999999999999999999999999999999"
@@ -10857,10 +24045,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be less than the integer 99999999999999999999999999999999999, but they were equal"
@@ -10868,10 +24067,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be less than the integer 99999999999999999999999999999999999, but they were equal"
@@ -10888,10 +24098,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 299999999999999999999999999999999997 was expected to be divisible by the integer 99999999999999999999999999999999999"
@@ -10899,10 +24120,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 299999999999999999999999999999999997 was expected to be divisible by the integer 99999999999999999999999999999999999"
@@ -10919,10 +24151,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 299999999999999999999999999999999998 was expected to be divisible by the integer 99999999999999999999999999999999999"
@@ -10930,10 +24173,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          false,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 299999999999999999999999999999999998 was expected to be divisible by the integer 99999999999999999999999999999999999"
@@ -10942,15 +24196,29 @@
   },
   {
     "description": "multipleOf_21",
-    "schema": { "$schema": "http://json-schema.org/draft-04/schema#", "multipleOf": 0.5 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "multipleOf": 0.5
+    },
     "instance": 99999999999999999999999999999999999,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be divisible by the number 0.5"
@@ -10958,10 +24226,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDivisible", "/multipleOf", "#/multipleOf", "" ]
+        [
+          true,
+          "AssertionDivisible",
+          "/multipleOf",
+          "#/multipleOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be divisible by the number 0.5"
@@ -10973,17 +24252,41 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": 42 },
+    "instance": {
+      "a": "hello",
+      "b": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -10991,18 +24294,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -11018,17 +24376,40 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11036,10 +24417,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -11051,17 +24443,41 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": 123, "b": 42 },
+    "instance": {
+      "a": 123,
+      "b": 42
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11069,14 +24485,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -11090,16 +24539,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "x": "hello", "y": 42 },
+    "instance": {
+      "x": "hello",
+      "y": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11107,16 +24577,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionTypeStrict", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionTypeStrict", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11131,16 +24645,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11148,12 +24680,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined properties subschemas",
@@ -11166,16 +24720,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": "not an object",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11183,10 +24755,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type string"
@@ -11198,16 +24781,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "extra": 999 },
+    "instance": {
+      "a": "hello",
+      "extra": 999
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11215,14 +24816,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11236,17 +24870,39 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11254,16 +24910,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -11280,14 +24980,27 @@
       "type": "object",
       "properties": {}
     },
-    "instance": { "anything": true },
+    "instance": {
+      "anything": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -11295,10 +25008,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -11310,17 +25034,38 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": "anything" },
+    "instance": {
+      "a": "hello",
+      "b": "anything"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11328,16 +25073,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -11352,17 +25141,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11370,10 +25179,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -11386,17 +25206,39 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": "hello" } },
+    "instance": {
+      "inner": {
+        "x": "hello"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11404,18 +25246,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ true, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ true, "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11432,17 +25329,39 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": 123 } },
+    "instance": {
+      "inner": {
+        "x": 123
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11450,14 +25369,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ false, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -11471,21 +25423,64 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "patternProperties": { "^b": { "type": "integer" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -11495,16 +25490,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -11519,21 +25558,60 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11543,16 +25621,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11567,23 +25689,79 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "anyOf": [ { "required": [ "a" ] } ]
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "a"
+          ]
+        }
+      ]
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -11594,18 +25772,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -11621,19 +25854,47 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "minProperties": 1
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -11642,16 +25903,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 1 property and it contained 1 property: \"a\"",
@@ -11667,16 +25972,33 @@
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
       "$dynamicRef": "#foo",
-      "properties": { "a": { "type": "string" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -11684,14 +26006,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11711,10 +26066,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11722,10 +26088,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11743,10 +26120,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11754,10 +26142,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11769,17 +26168,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.example.com",
-      "allOf": [ { "$ref": "#/definitions/test" } ],
-      "definitions": { "test": { "id": "", "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/test"
+        }
+      ],
+      "definitions": {
+        "test": {
+          "id": "",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11787,14 +26206,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11808,17 +26260,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.example.com",
-      "allOf": [ { "$ref": "#/definitions/test" } ],
-      "definitions": { "test": { "id": "#", "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/test"
+        }
+      ],
+      "definitions": {
+        "test": {
+          "id": "#",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -11826,14 +26298,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -11846,18 +26351,44 @@
     "description": "additionalProperties_30",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false, "qux": 1, "baz": 2 },
+    "instance": {
+      "foo": true,
+      "bar": false,
+      "qux": 1,
+      "baz": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines properties \"baz\", and \"qux\""
@@ -11865,10 +26396,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines properties \"baz\", and \"qux\""
@@ -11880,18 +26422,39 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": {}, "bar": {} }
+      "properties": {
+        "foo": {},
+        "bar": {}
+      }
     },
-    "instance": { "foo": 1, "bar": 2, "baz": 3 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "baz": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines properties \"bar\", and \"foo\", but it also defines the property \"baz\""
@@ -11899,10 +26462,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines the property \"baz\""
@@ -11914,18 +26488,40 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": {}, "bar": {} }
+      "properties": {
+        "foo": {},
+        "bar": {}
+      }
     },
-    "instance": { "foo": 1, "bar": 2, "baz": 3, "qux": 4 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "baz": 3,
+      "qux": 4
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines properties \"bar\", and \"foo\", but it also defines properties \"baz\", and \"qux\""
@@ -11933,10 +26529,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\", but it also defines properties \"baz\", and \"qux\""
@@ -11948,18 +26555,42 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar", "qux" ],
+      "required": [
+        "foo",
+        "bar",
+        "qux"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": {}, "bar": {}, "qux": {} }
+      "properties": {
+        "foo": {},
+        "bar": {},
+        "qux": {}
+      }
     },
-    "instance": { "foo": 1, "bar": 2, "qux": 3, "baz": 4 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "qux": 3,
+      "baz": 4
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties, but it also defines the property \"baz\""
@@ -11967,10 +26598,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", \"foo\", and \"qux\", but it also defines the property \"baz\""
@@ -11982,18 +26624,43 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "foo", "bar", "qux" ],
+      "required": [
+        "foo",
+        "bar",
+        "qux"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": {}, "bar": {}, "qux": {} }
+      "properties": {
+        "foo": {},
+        "bar": {},
+        "qux": {}
+      }
     },
-    "instance": { "foo": 1, "bar": 2, "qux": 3, "baz": 4, "zap": 5 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "qux": 3,
+      "baz": 4,
+      "zap": 5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties, but it also defines properties \"baz\", and \"zap\""
@@ -12001,10 +26668,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesExactly", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", \"foo\", and \"qux\", but it also defines properties \"baz\", and \"zap\""
@@ -12015,21 +26693,51 @@
     "description": "properties_closed_object_fast_path",
     "schema": {
       "type": "object",
-      "required": [ "foo" ],
+      "required": [
+        "foo"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "string" } },
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
       "$schema": "http://json-schema.org/draft-04/schema#"
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -12038,18 +26746,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -12072,10 +26835,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -12083,10 +26857,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
@@ -12101,14 +26886,28 @@
       "minItems": 3,
       "maxItems": 1
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -12116,10 +26915,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 1 item but it contained 2 items"
@@ -12134,14 +26944,28 @@
       "minProperties": 3,
       "maxProperties": 1
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -12149,10 +26973,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
@@ -12166,14 +27001,29 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2, "c": 3 },
+    "instance": {
+      "a": 1,
+      "b": 2,
+      "c": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -12181,10 +27031,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
@@ -12198,14 +27059,28 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -12213,12 +27088,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -12233,14 +27130,27 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -12248,10 +27158,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
@@ -12265,14 +27186,28 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -12280,12 +27215,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -12300,14 +27257,29 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -12315,10 +27287,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -12332,14 +27315,28 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -12347,12 +27344,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -12367,14 +27386,27 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -12382,10 +27414,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items but it contained 1 item"
@@ -12399,14 +27442,28 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -12414,12 +27471,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 2 items",
@@ -12438,10 +27517,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -12449,10 +27539,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
@@ -12470,10 +27571,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -12481,12 +27593,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -12505,10 +27639,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -12516,10 +27661,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
@@ -12537,10 +27693,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -12548,12 +27715,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
@@ -12565,7 +27754,10 @@
     "description": "type_array_unknown_names",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "type": [ "foo", "bar" ]
+      "type": [
+        "foo",
+        "bar"
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -12585,26 +27777,64 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": 5, "b": { "x": "s" } },
+    "instance": {
+      "a": 5,
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12613,14 +27843,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12634,28 +27897,77 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": { "x": "s" } },
+    "instance": {
+      "a": {},
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12665,24 +27977,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12701,28 +28101,75 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": {} },
+    "instance": {
+      "a": {},
+      "b": {}
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12732,16 +28179,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -12756,17 +28247,36 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -12774,16 +28284,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -12798,17 +28352,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
     "instance": {},
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -12816,10 +28387,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\""
@@ -12833,20 +28415,41 @@
       "properties": {
         "scores": {
           "type": "array",
-          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
           "minItems": 1,
           "maxItems": 2
         }
       }
     },
-    "instance": { "scores": [ 1, 2, 3 ] },
+    "instance": {
+      "scores": [
+        1,
+        2,
+        3
+      ]
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          false,
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -12854,32 +28457,164 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/2" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/2" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/2" ],
-        [ "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/2"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/2"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/2"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/properties/scores/maxItems",
+          "#/properties/scores/maxItems",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/2" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/2" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/2" ],
-        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ false, "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/2"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/properties/scores/maxItems",
+          "#/properties/scores/maxItems",
+          "/scores"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -12904,20 +28639,40 @@
       "properties": {
         "scores": {
           "type": "array",
-          "items": { "type": "number", "minimum": 0, "maximum": 100 },
+          "items": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
           "minItems": 1,
           "maxItems": 2
         }
       }
     },
-    "instance": { "scores": [ 1, 2 ] },
+    "instance": {
+      "scores": [
+        1,
+        2
+      ]
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBoundedSized", "/properties", "#/properties", "/scores" ]
+        [
+          true,
+          "LoopItemsIntegerBoundedSized",
+          "/properties",
+          "#/properties",
+          "/scores"
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -12925,30 +28680,151 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
-        [ "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
-        [ "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/properties/scores/maxItems",
+          "#/properties/scores/maxItems",
+          "/scores"
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/0" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/0" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/0" ],
-        [ true, "AssertionLessEqual", "/properties/scores/items/maximum", "#/properties/scores/items/maximum", "/scores/1" ],
-        [ true, "AssertionGreaterEqual", "/properties/scores/items/minimum", "#/properties/scores/items/minimum", "/scores/1" ],
-        [ true, "AssertionTypeStrictAny", "/properties/scores/items/type", "#/properties/scores/items/type", "/scores/1" ],
-        [ true, "LoopItems", "/properties/scores/items", "#/properties/scores/items", "/scores" ],
-        [ true, "AssertionArraySizeLess", "/properties/scores/maxItems", "#/properties/scores/maxItems", "/scores" ],
-        [ true, "AssertionArraySizeGreater", "/properties/scores/minItems", "#/properties/scores/minItems", "/scores" ],
-        [ true, "AssertionTypeStrict", "/properties/scores/type", "#/properties/scores/type", "/scores" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/scores/items/maximum",
+          "#/properties/scores/items/maximum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/scores/items/minimum",
+          "#/properties/scores/items/minimum",
+          "/scores/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/properties/scores/items/type",
+          "#/properties/scores/items/type",
+          "/scores/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/properties/scores/items",
+          "#/properties/scores/items",
+          "/scores"
+        ],
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/properties/scores/maxItems",
+          "#/properties/scores/maxItems",
+          "/scores"
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/properties/scores/minItems",
+          "#/properties/scores/minItems",
+          "/scores"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/scores/type",
+          "#/properties/scores/type",
+          "/scores"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -12970,18 +28846,42 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-      "required": [ "a", "b" ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
       "additionalProperties": false
     },
-    "instance": { "b": "x", "a": 1 },
+    "instance": {
+      "b": "x",
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -12989,14 +28889,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a\", and \"b\"",

--- a/test/evaluator/evaluator_draft6.json
+++ b/test/evaluator/evaluator_draft6.json
@@ -1,7 +1,10 @@
 [
   {
     "description": "unknown_keyword",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "foobar": "baz" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "foobar": "baz"
+    },
     "instance": "foo bar",
     "valid": true,
     "fast": {},
@@ -9,15 +12,29 @@
   },
   {
     "description": "const_1",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "const": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "const": 1
+    },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -25,10 +42,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -37,15 +65,29 @@
   },
   {
     "description": "const_1_hyperschema",
-    "schema": { "$schema": "http://json-schema.org/draft-06/hyper-schema#", "const": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/hyper-schema#",
+      "const": 1
+    },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -53,10 +95,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to equal the integer constant 1"
@@ -65,15 +118,29 @@
   },
   {
     "description": "const_2",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "const": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "const": 1
+    },
     "instance": "foo",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the integer constant 1"
@@ -81,10 +148,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          false,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the integer constant 1"
@@ -102,10 +180,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\""
@@ -113,12 +202,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -137,10 +248,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null"
@@ -148,12 +270,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null",
@@ -172,10 +316,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true"
@@ -183,12 +338,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true",
@@ -207,10 +384,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14"
@@ -218,12 +406,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14",
@@ -242,10 +452,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3"
@@ -253,12 +474,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3",
@@ -277,10 +520,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [] was expected to equal the array constant []"
@@ -288,12 +542,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [] was expected to equal the array constant []",
@@ -312,10 +588,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}"
@@ -323,12 +610,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}",
@@ -342,18 +651,44 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "minProperties": 1,
-      "const": { "foo": 1 }
+      "const": {
+        "foo": 1
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -362,14 +697,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -384,18 +752,44 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
       "minItems": 1,
-      "const": [ 1 ]
+      "const": [
+        1
+      ]
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -404,14 +798,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -432,12 +859,34 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -446,14 +895,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/const", "#/const", "" ],
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/const", "#/const", "" ],
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/const",
+          "#/const",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -472,10 +954,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than the integer 2"
@@ -483,10 +976,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 2.1 was expected to be greater than the integer 2"
@@ -503,10 +1007,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than the integer 2, but they were equal"
@@ -514,10 +1029,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be greater than the integer 2, but they were equal"
@@ -534,10 +1060,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than the integer 0"
@@ -545,10 +1082,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than the integer 0"
@@ -576,10 +1124,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than the integer 2"
@@ -587,10 +1146,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 1.9 was expected to be less than the integer 2"
@@ -607,10 +1177,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than the integer 2, but they were equal"
@@ -618,10 +1199,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than the integer 2, but they were equal"
@@ -638,10 +1230,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than the integer 0, but they were equal"
@@ -649,10 +1252,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than the integer 0, but they were equal"
@@ -674,7 +1288,9 @@
     "description": "contains_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
     "instance": 2,
     "valid": true,
@@ -685,20 +1301,59 @@
     "description": "contains_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ 1, "bar", 3 ],
+    "instance": [
+      1,
+      "bar",
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -708,14 +1363,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -728,22 +1416,72 @@
     "description": "contains_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -754,16 +1492,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/1" ],
-        [ false, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/2" ],
-        [ false, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/1"
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/2"
+        ],
+        [
+          false,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -777,18 +1559,46 @@
     "description": "contains_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "contains": { "type": "string" }
+      "contains": {
+        "type": "string"
+      }
     },
-    "instance": [ "foo", "bar", "baz" ],
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -797,12 +1607,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopContains", "/contains", "#/contains", "" ],
-        [ "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ]
+        [
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/contains/type", "#/contains/type", "/0" ],
-        [ true, "LoopContains", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/contains/type",
+          "#/contains/type",
+          "/0"
+        ],
+        [
+          true,
+          "LoopContains",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -812,15 +1644,33 @@
   },
   {
     "description": "contains_5",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "contains": true },
-    "instance": [ "foo", "bar", "baz" ],
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "contains": true
+    },
+    "instance": [
+      "foo",
+      "bar",
+      "baz"
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 1 item and it contained 3 items"
@@ -828,10 +1678,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/contains", "#/contains", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/contains",
+          "#/contains",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 1 item and it contained 3 items"
@@ -842,7 +1703,9 @@
     "description": "propertyNames_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "minLength": 5 }
+      "propertyNames": {
+        "minLength": 5
+      }
     },
     "instance": 2,
     "valid": true,
@@ -853,9 +1716,15 @@
     "description": "propertyNames_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "foo": { "propertyNames": {} } }
+      "properties": {
+        "foo": {
+          "propertyNames": {}
+        }
+      }
     },
-    "instance": { "foo": {} },
+    "instance": {
+      "foo": {}
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -864,18 +1733,44 @@
     "description": "propertyNames_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "pattern": "^f" }
+      "propertyNames": {
+        "pattern": "^f"
+      }
     },
-    "instance": { "bar": 2 },
+    "instance": {
+      "bar": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionRegex", "/propertyNames/pattern", "#/propertyNames/pattern", "/bar" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/propertyNames/pattern",
+          "#/propertyNames/pattern",
+          "/bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/propertyNames/pattern", "#/propertyNames/pattern", "/bar" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/propertyNames/pattern",
+          "#/propertyNames/pattern",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"bar\" was expected to match the regular expression \"^f\"",
@@ -884,12 +1779,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionRegex", "/propertyNames/pattern", "#/propertyNames/pattern", "/bar" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/propertyNames/pattern",
+          "#/propertyNames/pattern",
+          "/bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/propertyNames/pattern", "#/propertyNames/pattern", "/bar" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/propertyNames/pattern",
+          "#/propertyNames/pattern",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"bar\" was expected to match the regular expression \"^f\"",
@@ -901,19 +1818,49 @@
     "description": "propertyNames_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "$ref": "#/definitions/test" },
-      "definitions": { "test": { "pattern": "^f" } }
+      "propertyNames": {
+        "$ref": "#/definitions/test"
+      },
+      "definitions": {
+        "test": {
+          "pattern": "^f"
+        }
+      }
     },
-    "instance": { "bar": 2 },
+    "instance": {
+      "bar": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionRegex", "/propertyNames/$ref/pattern", "#/definitions/test/pattern", "/bar" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionRegex",
+          "/propertyNames/$ref/pattern",
+          "#/definitions/test/pattern",
+          "/bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/propertyNames/$ref/pattern", "#/definitions/test/pattern", "/bar" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/propertyNames/$ref/pattern",
+          "#/definitions/test/pattern",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"bar\" was expected to match the regular expression \"^f\"",
@@ -922,14 +1869,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/bar" ],
-        [ "AssertionRegex", "/propertyNames/$ref/pattern", "#/definitions/test/pattern", "/bar" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/bar"
+        ],
+        [
+          "AssertionRegex",
+          "/propertyNames/$ref/pattern",
+          "#/definitions/test/pattern",
+          "/bar"
+        ]
       ],
       "post": [
-        [ false, "AssertionRegex", "/propertyNames/$ref/pattern", "#/definitions/test/pattern", "/bar" ],
-        [ false, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/bar" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionRegex",
+          "/propertyNames/$ref/pattern",
+          "#/definitions/test/pattern",
+          "/bar"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/bar"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"bar\" was expected to match the regular expression \"^f\"",
@@ -942,9 +1922,13 @@
     "description": "propertyNames_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "string" }
+      "propertyNames": {
+        "type": "string"
+      }
     },
-    "instance": { "bar": 2 },
+    "instance": {
+      "bar": 2
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -953,18 +1937,46 @@
     "description": "propertyNames_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "enum": [ "foo" ] }
+      "propertyNames": {
+        "enum": [
+          "foo"
+        ]
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqual", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal the string constant \"foo\"",
@@ -973,12 +1985,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqual", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqual",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal the string constant \"foo\"",
@@ -990,18 +2024,48 @@
     "description": "propertyNames_10",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "enum": [ "foo", "bar", "baz" ] }
+      "propertyNames": {
+        "enum": [
+          "foo",
+          "bar",
+          "baz"
+        ]
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqualsAnyStringHash", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqualsAnyStringHash",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAnyStringHash", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAnyStringHash",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the given declared values",
@@ -1010,12 +2074,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the 3 declared values",
@@ -1027,18 +2113,48 @@
     "description": "propertyNames_11",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "enum": [ "foo", "bar", true ] }
+      "propertyNames": {
+        "enum": [
+          "foo",
+          "bar",
+          true
+        ]
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the 3 declared values",
@@ -1047,12 +2163,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/propertyNames/enum", "#/propertyNames/enum", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/propertyNames/enum",
+          "#/propertyNames/enum",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the 3 declared values",
@@ -1064,20 +2202,68 @@
     "description": "propertyNames_12",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "oneOf": [ { "enum": [ "foo", "bar", "baz" ] }, { "type": "string" } ] }
+      "propertyNames": {
+        "oneOf": [
+          {
+            "enum": [
+              "foo",
+              "bar",
+              "baz"
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalXor", "/propertyNames/oneOf", "#/propertyNames/oneOf", "/foo" ],
-        [ "AssertionEqualsAnyStringHash", "/propertyNames/oneOf/0/enum", "#/propertyNames/oneOf/0/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalXor",
+          "/propertyNames/oneOf",
+          "#/propertyNames/oneOf",
+          "/foo"
+        ],
+        [
+          "AssertionEqualsAnyStringHash",
+          "/propertyNames/oneOf/0/enum",
+          "#/propertyNames/oneOf/0/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAnyStringHash", "/propertyNames/oneOf/0/enum", "#/propertyNames/oneOf/0/enum", "/foo" ],
-        [ false, "LogicalXor", "/propertyNames/oneOf", "#/propertyNames/oneOf", "/foo" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAnyStringHash",
+          "/propertyNames/oneOf/0/enum",
+          "#/propertyNames/oneOf/0/enum",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/propertyNames/oneOf",
+          "#/propertyNames/oneOf",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the given declared values",
@@ -1087,14 +2273,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalXor", "/propertyNames/oneOf", "#/propertyNames/oneOf", "/foo" ],
-        [ "AssertionEqualsAny", "/propertyNames/oneOf/0/enum", "#/propertyNames/oneOf/0/enum", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalXor",
+          "/propertyNames/oneOf",
+          "#/propertyNames/oneOf",
+          "/foo"
+        ],
+        [
+          "AssertionEqualsAny",
+          "/propertyNames/oneOf/0/enum",
+          "#/propertyNames/oneOf/0/enum",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/propertyNames/oneOf/0/enum", "#/propertyNames/oneOf/0/enum", "/foo" ],
-        [ false, "LogicalXor", "/propertyNames/oneOf", "#/propertyNames/oneOf", "/foo" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/propertyNames/oneOf/0/enum",
+          "#/propertyNames/oneOf/0/enum",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalXor",
+          "/propertyNames/oneOf",
+          "#/propertyNames/oneOf",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The property name \"foo\" was expected to equal one of the 3 declared values",
@@ -1107,20 +2326,50 @@
     "description": "propertyNames_13",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "$ref": "#/definitions/test" },
-      "definitions": { "test": { "type": "string" } }
+      "propertyNames": {
+        "$ref": "#/definitions/test"
+      },
+      "definitions": {
+        "test": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1132,18 +2381,39 @@
     "description": "propertyNames_14",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "definitions": { "stringType": { "type": "string" } },
-      "propertyNames": { "$ref": "#/definitions/stringType" },
-      "additionalProperties": { "$ref": "#/definitions/stringType" }
+      "definitions": {
+        "stringType": {
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "$ref": "#/definitions/stringType"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/stringType"
+      }
     },
-    "instance": { "foo": 123 },
+    "instance": {
+      "foo": 123
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          false,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type string"
@@ -1151,18 +2421,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ false, "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ],
-        [ false, "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ false, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1177,18 +2502,39 @@
     "description": "propertyNames_15",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "definitions": { "stringType": { "type": "string" } },
-      "additionalProperties": { "$ref": "#/definitions/stringType" },
-      "propertyNames": { "$ref": "#/definitions/stringType" }
+      "definitions": {
+        "stringType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/stringType"
+      },
+      "propertyNames": {
+        "$ref": "#/definitions/stringType"
+      }
     },
-    "instance": { "foo": 123 },
+    "instance": {
+      "foo": 123
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          false,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type string"
@@ -1196,18 +2542,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ false, "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ],
-        [ false, "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ false, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ],
+        [
+          false,
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          false,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1222,18 +2623,39 @@
     "description": "propertyNames_16",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "definitions": { "stringType": { "type": "string" } },
-      "propertyNames": { "$ref": "#/definitions/stringType" },
-      "additionalProperties": { "$ref": "#/definitions/stringType" }
+      "definitions": {
+        "stringType": {
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "$ref": "#/definitions/stringType"
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/stringType"
+      }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "" ]
+        [
+          true,
+          "LoopPropertiesTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties were expected to be of type string"
@@ -1241,18 +2663,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ true, "AssertionTypeStrict", "/additionalProperties/$ref/type", "#/definitions/stringType/type", "/foo" ],
-        [ true, "ControlJump", "/additionalProperties/$ref", "#/additionalProperties/$ref", "/foo" ],
-        [ true, "LoopProperties", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/additionalProperties/$ref/type",
+          "#/definitions/stringType/type",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/additionalProperties/$ref",
+          "#/additionalProperties/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopProperties",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1267,22 +2744,64 @@
     "description": "propertyNames_17",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "$ref": "#/definitions/foo" },
-      "definitions": { "foo": { "$ref": "#/definitions/bar" }, "bar": {} }
+      "propertyNames": {
+        "$ref": "#/definitions/foo"
+      },
+      "definitions": {
+        "foo": {
+          "$ref": "#/definitions/bar"
+        },
+        "bar": {}
+      }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ "ControlJump", "/propertyNames/$ref/$ref", "#/definitions/foo/$ref", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/$ref/$ref", "#/definitions/foo/$ref", "/foo" ],
-        [ true, "ControlJump", "/propertyNames/$ref", "#/propertyNames/$ref", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/$ref",
+          "#/propertyNames/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1295,24 +2814,81 @@
     "description": "propertyNames_18",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "allOf": [ { "$ref": "#/definitions/foo" } ] },
-      "definitions": { "foo": { "$ref": "#/definitions/bar" }, "bar": {} }
+      "propertyNames": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/foo"
+          }
+        ]
+      },
+      "definitions": {
+        "foo": {
+          "$ref": "#/definitions/bar"
+        },
+        "bar": {}
+      }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalAnd", "/propertyNames/allOf", "#/propertyNames/allOf", "/foo" ],
-        [ "ControlJump", "/propertyNames/allOf/0/$ref", "#/propertyNames/allOf/0/$ref", "/foo" ],
-        [ "ControlJump", "/propertyNames/allOf/0/$ref/$ref", "#/definitions/foo/$ref", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/propertyNames/allOf",
+          "#/propertyNames/allOf",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/allOf/0/$ref",
+          "#/propertyNames/allOf/0/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/allOf/0/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/allOf/0/$ref/$ref", "#/definitions/foo/$ref", "/foo" ],
-        [ true, "ControlJump", "/propertyNames/allOf/0/$ref", "#/propertyNames/allOf/0/$ref", "/foo" ],
-        [ true, "LogicalAnd", "/propertyNames/allOf", "#/propertyNames/allOf", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/allOf/0/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/allOf/0/$ref",
+          "#/propertyNames/allOf/0/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/propertyNames/allOf",
+          "#/propertyNames/allOf",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1327,20 +2903,61 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "propertyNames": {
-        "allOf": [ { "anyOf": [ { "allOf": [ { "$ref": "#/definitions/foo" } ] } ] } ]
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/foo"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "definitions": { "foo": { "$ref": "#/definitions/bar" }, "bar": {} }
+      "definitions": {
+        "foo": {
+          "$ref": "#/definitions/bar"
+        },
+        "bar": {}
+      }
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalOr", "/propertyNames/allOf/0/anyOf", "#/propertyNames/allOf/0/anyOf", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalOr",
+          "/propertyNames/allOf/0/anyOf",
+          "#/propertyNames/allOf/0/anyOf",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "LogicalOr", "/propertyNames/allOf/0/anyOf", "#/propertyNames/allOf/0/anyOf", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LogicalOr",
+          "/propertyNames/allOf/0/anyOf",
+          "#/propertyNames/allOf/0/anyOf",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the given subschema",
@@ -1349,20 +2966,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalAnd", "/propertyNames/allOf", "#/propertyNames/allOf", "/foo" ],
-        [ "LogicalOr", "/propertyNames/allOf/0/anyOf", "#/propertyNames/allOf/0/anyOf", "/foo" ],
-        [ "LogicalAnd", "/propertyNames/allOf/0/anyOf/0/allOf", "#/propertyNames/allOf/0/anyOf/0/allOf", "/foo" ],
-        [ "ControlJump", "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref", "#/propertyNames/allOf/0/anyOf/0/allOf/0/$ref", "/foo" ],
-        [ "ControlJump", "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref/$ref", "#/definitions/foo/$ref", "/foo" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/propertyNames/allOf",
+          "#/propertyNames/allOf",
+          "/foo"
+        ],
+        [
+          "LogicalOr",
+          "/propertyNames/allOf/0/anyOf",
+          "#/propertyNames/allOf/0/anyOf",
+          "/foo"
+        ],
+        [
+          "LogicalAnd",
+          "/propertyNames/allOf/0/anyOf/0/allOf",
+          "#/propertyNames/allOf/0/anyOf/0/allOf",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref",
+          "#/propertyNames/allOf/0/anyOf/0/allOf/0/$ref",
+          "/foo"
+        ],
+        [
+          "ControlJump",
+          "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "ControlJump", "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref/$ref", "#/definitions/foo/$ref", "/foo" ],
-        [ true, "ControlJump", "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref", "#/propertyNames/allOf/0/anyOf/0/allOf/0/$ref", "/foo" ],
-        [ true, "LogicalAnd", "/propertyNames/allOf/0/anyOf/0/allOf", "#/propertyNames/allOf/0/anyOf/0/allOf", "/foo" ],
-        [ true, "LogicalOr", "/propertyNames/allOf/0/anyOf", "#/propertyNames/allOf/0/anyOf", "/foo" ],
-        [ true, "LogicalAnd", "/propertyNames/allOf", "#/propertyNames/allOf", "/foo" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref/$ref",
+          "#/definitions/foo/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "ControlJump",
+          "/propertyNames/allOf/0/anyOf/0/allOf/0/$ref",
+          "#/propertyNames/allOf/0/anyOf/0/allOf/0/$ref",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/propertyNames/allOf/0/anyOf/0/allOf",
+          "#/propertyNames/allOf/0/anyOf/0/allOf",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/propertyNames/allOf/0/anyOf",
+          "#/propertyNames/allOf/0/anyOf",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/propertyNames/allOf",
+          "#/propertyNames/allOf",
+          "/foo"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value was expected to validate against the referenced schema",
@@ -1378,17 +3061,38 @@
     "description": "propertyNames_20",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "definitions": { "test": { "type": "string" } } },
-      "allOf": [ { "$ref": "#/propertyNames/definitions/test" } ]
+      "propertyNames": {
+        "definitions": {
+          "test": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/propertyNames/definitions/test"
+        }
+      ]
     },
     "instance": 1,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/propertyNames/definitions/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/propertyNames/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/propertyNames/definitions/test/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/propertyNames/definitions/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -1396,14 +3100,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "#/propertyNames/definitions/test/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/propertyNames/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/type", "#/propertyNames/definitions/test/type", "" ],
-        [ false, "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "#/propertyNames/definitions/test/type",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -1416,18 +3153,43 @@
     "description": "propertyNames_21",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "definitions": { "inner": { "$ref": "#/definitions/outer" } } },
-      "allOf": [ { "$ref": "#/propertyNames/definitions/inner" } ],
-      "definitions": { "outer": { "type": "string" } }
+      "propertyNames": {
+        "definitions": {
+          "inner": {
+            "$ref": "#/definitions/outer"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/propertyNames/definitions/inner"
+        }
+      ],
+      "definitions": {
+        "outer": {
+          "type": "string"
+        }
+      }
     },
     "instance": 1,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/$ref/type", "#/definitions/outer/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/$ref/type",
+          "#/definitions/outer/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/$ref/type", "#/definitions/outer/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/$ref/type",
+          "#/definitions/outer/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -1435,16 +3197,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ "ControlJump", "/allOf/0/$ref/$ref", "#/propertyNames/definitions/inner/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/$ref/type", "#/definitions/outer/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref/$ref",
+          "#/propertyNames/definitions/inner/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/$ref/type",
+          "#/definitions/outer/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/$ref/$ref/type", "#/definitions/outer/type", "" ],
-        [ false, "ControlJump", "/allOf/0/$ref/$ref", "#/propertyNames/definitions/inner/$ref", "" ],
-        [ false, "ControlJump", "/allOf/0/$ref", "#/allOf/0/$ref", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/$ref/type",
+          "#/definitions/outer/type",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/allOf/0/$ref/$ref",
+          "#/propertyNames/definitions/inner/$ref",
+          ""
+        ],
+        [
+          false,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "#/allOf/0/$ref",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -1461,7 +3267,11 @@
       "title": "My title",
       "description": "My description",
       "default": 1,
-      "examples": [ 1, 2, 3 ]
+      "examples": [
+        1,
+        2,
+        3
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -1470,7 +3280,10 @@
   },
   {
     "description": "unknown_1",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "fooBar": "baz" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "fooBar": "baz"
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -1478,7 +3291,10 @@
   },
   {
     "description": "unknown_2",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "x-test": 1 },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "x-test": 1
+    },
     "instance": "foo",
     "valid": true,
     "fast": {},
@@ -1495,10 +3311,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 1 character"
@@ -1506,12 +3333,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at least 1 character and it consisted of 2 characters",
@@ -1530,10 +3379,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -1541,12 +3401,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -1565,10 +3447,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -1576,10 +3469,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xxx\" was expected to consist of at most 2 characters but it consisted of 3 characters"
@@ -1598,10 +3502,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of 1 to 2 characters"
@@ -1609,14 +3524,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"xx\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -1632,14 +3580,29 @@
       "type": "array",
       "minItems": 2
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -1647,12 +3610,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 3 items",
@@ -1667,14 +3652,28 @@
       "type": "array",
       "maxItems": 2
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -1682,12 +3681,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -1702,14 +3723,29 @@
       "type": "array",
       "maxItems": 2
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -1717,10 +3753,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -1735,14 +3782,28 @@
       "minItems": 1,
       "maxItems": 2
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of 1 to 2 items"
@@ -1750,14 +3811,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -1773,14 +3867,27 @@
       "type": "object",
       "minProperties": 1
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 1 property"
@@ -1788,12 +3895,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 1 property and it contained 1 property: \"foo\"",
@@ -1808,14 +3937,28 @@
       "type": "object",
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -1823,12 +3966,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\"",
@@ -1843,14 +4008,29 @@
       "type": "object",
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1, "baz": 3 },
+    "instance": {
+      "bar": 2,
+      "foo": 1,
+      "baz": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -1858,10 +4038,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"bar\", \"baz\", and \"foo\""
@@ -1876,14 +4067,28 @@
       "minProperties": 1,
       "maxProperties": 2
     },
-    "instance": { "bar": 2, "foo": 1 },
+    "instance": {
+      "bar": 2,
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of 1 to 2 properties"
@@ -1891,14 +4096,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"bar\", and \"foo\"",
@@ -1912,16 +4150,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "string",
-      "enum": [ "foo" ]
+      "enum": [
+        "foo"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\""
@@ -1929,12 +4180,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -1947,16 +4220,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "boolean",
-      "enum": [ true ]
+      "enum": [
+        true
+      ]
     },
     "instance": true,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true"
@@ -1964,12 +4250,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The boolean value true was expected to equal the boolean constant true",
@@ -1982,16 +4290,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "number",
-      "enum": [ 3.14 ]
+      "enum": [
+        3.14
+      ]
     },
     "instance": 3.14,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14"
@@ -1999,12 +4320,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.14 was expected to equal the number constant 3.14",
@@ -2017,16 +4360,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "number",
-      "enum": [ 3 ]
+      "enum": [
+        3
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3"
@@ -2034,12 +4390,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrictAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3",
@@ -2052,16 +4430,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "integer",
-      "enum": [ 3 ]
+      "enum": [
+        3
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3"
@@ -2069,12 +4460,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 3 was expected to equal the integer constant 3",
@@ -2087,16 +4500,31 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "string",
-      "enum": [ "foo", "bar", "baz" ]
+      "enum": [
+        "foo",
+        "bar",
+        "baz"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAnyStringHash", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqualsAnyStringHash",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the given declared values"
@@ -2104,12 +4532,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 3 declared values",
@@ -2122,18 +4572,43 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "string",
-      "enum": [ "foo", 1 ]
+      "enum": [
+        "foo",
+        1
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 2 declared values",
@@ -2142,12 +4617,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqualsAny", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqualsAny",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal one of the 2 declared values",
@@ -2160,16 +4657,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "enum": [ [ 1 ] ]
+      "enum": [
+        [
+          1
+        ]
+      ]
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]"
@@ -2177,12 +4691,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -2195,16 +4731,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "enum": [ {} ]
+      "enum": [
+        {}
+      ]
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}"
@@ -2212,12 +4761,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {} was expected to equal the object constant {}",
@@ -2230,16 +4801,29 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "null",
-      "enum": [ null ]
+      "enum": [
+        null
+      ]
     },
     "instance": null,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null"
@@ -2247,12 +4831,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The null value null was expected to equal the null constant null",
@@ -2266,18 +4872,42 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "string",
       "minLength": 1,
-      "enum": [ "foo" ]
+      "enum": [
+        "foo"
+      ]
     },
     "instance": "foo",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -2286,14 +4916,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"foo\" was expected to equal the string constant \"foo\"",
@@ -2308,18 +4971,46 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
       "minItems": 1,
-      "enum": [ [ 1 ] ]
+      "enum": [
+        [
+          1
+        ]
+      ]
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -2328,14 +5019,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value [1] was expected to equal the array constant [1]",
@@ -2350,18 +5074,46 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "minProperties": 1,
-      "enum": [ { "foo": 1 } ]
+      "enum": [
+        {
+          "foo": 1
+        }
+      ]
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -2370,14 +5122,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionEqual", "/enum", "#/enum", "" ],
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionEqual", "/enum", "#/enum", "" ],
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionEqual",
+          "/enum",
+          "#/enum",
+          ""
+        ],
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value {\"foo\":1} was expected to equal the object constant {\"foo\":1}",
@@ -2391,18 +5176,42 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "boolean" }, "bar": { "type": "boolean" } }
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      }
     },
-    "instance": { "foo": true, "bar": false },
+    "instance": {
+      "foo": true,
+      "bar": false
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type boolean"
@@ -2410,20 +5219,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2440,20 +5315,55 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "foo", "bar" ],
+      "required": [
+        "foo",
+        "bar"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactlyStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactlyStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines properties \"bar\", and \"foo\"",
@@ -2462,20 +5372,86 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2492,24 +5468,60 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "foo", "bar", "baz" ],
+      "required": [
+        "foo",
+        "bar",
+        "baz"
+      ],
       "additionalProperties": false,
       "properties": {
-        "foo": { "type": "integer" },
-        "bar": { "type": "integer" },
-        "baz": { "type": "integer" }
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        },
+        "baz": {
+          "type": "integer"
+        }
       }
     },
-    "instance": { "foo": 1, "bar": 2, "baz": 3 },
+    "instance": {
+      "foo": 1,
+      "bar": 2,
+      "baz": 3
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ],
-        [ "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactlyStrictHash3", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactlyStrictHash3",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that only defines the 3 given properties",
@@ -2518,22 +5530,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionType", "/properties/baz/type", "#/properties/baz/type", "/baz" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionType",
+          "/properties/baz/type",
+          "#/properties/baz/type",
+          "/baz"
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionType", "/properties/baz/type", "#/properties/baz/type", "/baz" ],
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/baz/type",
+          "#/properties/baz/type",
+          "/baz"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", \"baz\", and \"foo\"",
@@ -2550,16 +5639,37 @@
     "description": "anyOf_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "anyOf": [ { "type": "string" }, { "type": "number" }, { "type": "null" } ]
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "instance": 1,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrictAny", "/anyOf", "#/anyOf", "" ]
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type null, number, or string and it was of type number"
@@ -2567,16 +5677,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ "AssertionTypeStrictAny", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ "AssertionTypeStrict", "/anyOf/2/type", "#/anyOf/2/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/anyOf/0/type", "#/anyOf/0/type", "" ],
-        [ true, "AssertionTypeStrictAny", "/anyOf/1/type", "#/anyOf/1/type", "" ],
-        [ false, "AssertionTypeStrict", "/anyOf/2/type", "#/anyOf/2/type", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/0/type",
+          "#/anyOf/0/type",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/anyOf/1/type",
+          "#/anyOf/1/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/anyOf/2/type",
+          "#/anyOf/2/type",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -2588,15 +5742,29 @@
   },
   {
     "description": "type_1",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "type": "integer" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "integer"
+    },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2604,10 +5772,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2616,15 +5795,29 @@
   },
   {
     "description": "type_2",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "type": "integer" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "integer"
+    },
     "instance": 3.0,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2632,10 +5825,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2644,15 +5848,29 @@
   },
   {
     "description": "type_3",
-    "schema": { "$schema": "http://json-schema.org/draft-06/schema#", "type": "integer" },
+    "schema": {
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "type": "integer"
+    },
     "instance": 3.2,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number"
@@ -2660,10 +5878,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number"
@@ -2674,16 +5903,30 @@
     "description": "type_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "type": [ "integer", "string" ]
+      "type": [
+        "integer",
+        "string"
+      ]
     },
     "instance": 3,
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer"
@@ -2691,10 +5934,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string and it was of type integer"
@@ -2705,16 +5959,30 @@
     "description": "type_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "type": [ "integer", "string" ]
+      "type": [
+        "integer",
+        "string"
+      ]
     },
     "instance": 3.1,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string but it was of type number"
@@ -2722,10 +5990,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeAny", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeAny",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer, or string but it was of type number"
@@ -2736,16 +6015,33 @@
     "description": "properties_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "foo": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 1 },
+    "instance": {
+      "foo": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2753,12 +6049,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2770,16 +6088,33 @@
     "description": "properties_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "foo": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 1.0 },
+    "instance": {
+      "foo": 1.0
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          true,
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer"
@@ -2787,12 +6122,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -2804,16 +6161,33 @@
     "description": "properties_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "foo": { "type": "integer" } }
+      "properties": {
+        "foo": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "foo": 1.1 },
+    "instance": {
+      "foo": 1.1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionPropertyType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          false,
+          "AssertionPropertyType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number"
@@ -2821,12 +6195,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number",
@@ -2838,20 +6234,55 @@
     "description": "properties_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": 1, "bar": 2 },
+    "instance": {
+      "foo": 1,
+      "bar": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2860,18 +6291,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2886,20 +6372,55 @@
     "description": "properties_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": 1.0, "bar": 2.0 },
+    "instance": {
+      "foo": 1.0,
+      "bar": 2.0
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2908,18 +6429,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ true, "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ true, "AssertionType", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2934,20 +6510,55 @@
     "description": "properties_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "required": [ "foo", "bar" ],
-      "properties": { "foo": { "type": "integer" }, "bar": { "type": "integer" } },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "properties": {
+        "foo": {
+          "type": "integer"
+        },
+        "bar": {
+          "type": "integer"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "foo": 1.1, "bar": 2.1 },
+    "instance": {
+      "foo": 1.1,
+      "bar": 2.1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ false, "LoopPropertiesType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "LoopPropertiesType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2956,14 +6567,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ false, "AssertionType", "/properties/bar/type", "#/properties/bar/type", "/bar" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/properties/bar/type",
+          "#/properties/bar/type",
+          "/bar"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"bar\", and \"foo\"",
@@ -2976,16 +6620,33 @@
     "description": "items_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "integer" }
+      "items": {
+        "type": "integer"
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsType", "/items", "#/items", "" ]
+        [
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsType", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type integer"
@@ -2993,16 +6654,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionType", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionType", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3016,16 +6721,33 @@
     "description": "items_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "integer" }
+      "items": {
+        "type": "integer"
+      }
     },
-    "instance": [ 1.0, 2.0, 3.0 ],
+    "instance": [
+      1.0,
+      2.0,
+      3.0
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsType", "/items", "#/items", "" ]
+        [
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsType", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type integer"
@@ -3033,16 +6755,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionType", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionType", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionType", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer",
@@ -3056,16 +6822,33 @@
     "description": "items_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "integer" }
+      "items": {
+        "type": "integer"
+      }
     },
-    "instance": [ 1.1, 2.1, 3.1 ],
+    "instance": [
+      1.1,
+      2.1,
+      3.1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsType", "/items", "#/items", "" ]
+        [
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsType", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsType",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The array items were expected to be of type integer"
@@ -3073,12 +6856,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionType", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionType",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type number",
@@ -3090,18 +6895,45 @@
     "description": "allOf_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "allOf": [ { "type": "string" }, false ]
+      "allOf": [
+        {
+          "type": "string"
+        },
+        false
+      ]
     },
     "instance": "foo",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionFail", "/allOf/1", "#/allOf/1", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/allOf/1",
+          "#/allOf/1",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "AssertionFail", "/allOf/1", "#/allOf/1", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/allOf/1",
+          "#/allOf/1",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3110,14 +6942,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ "AssertionFail", "/allOf/1", "#/allOf/1", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/allOf/1",
+          "#/allOf/1",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "AssertionFail", "/allOf/1", "#/allOf/1", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/allOf/1",
+          "#/allOf/1",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -3130,16 +6995,32 @@
     "description": "allOf_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "allOf": [ { "type": "string" }, false ]
+      "allOf": [
+        {
+          "type": "string"
+        },
+        false
+      ]
     },
     "instance": 5,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer"
@@ -3147,12 +7028,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "#/allOf", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/allOf/0/type", "#/allOf/0/type", "" ],
-        [ false, "LogicalAnd", "/allOf", "#/allOf", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/allOf/0/type",
+          "#/allOf/0/type",
+          ""
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/allOf",
+          "#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -3164,16 +7067,35 @@
     "description": "items_integer_bounded_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 50, 99 ],
+    "instance": [
+      10,
+      50,
+      99
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -3181,28 +7103,138 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -3222,16 +7254,35 @@
     "description": "items_integer_bounded_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10, 200, 50 ],
+    "instance": [
+      10,
+      200,
+      50
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -3239,18 +7290,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 10 was expected to be less than or equal to the integer 100",
@@ -3265,16 +7371,33 @@
     "description": "items_integer_bounded_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ "foo" ],
+    "instance": [
+      "foo"
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -3282,12 +7405,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type number but it was of type string",
@@ -3299,7 +7444,11 @@
     "description": "items_integer_bounded_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": "not an array",
     "valid": true,
@@ -3310,17 +7459,32 @@
     "description": "items_integer_bounded_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": [],
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema"
@@ -3331,16 +7495,34 @@
     "description": "items_integer_bounded_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 10.5, 99.9 ],
+    "instance": [
+      10.5,
+      99.9
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -3348,22 +7530,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 10.5 was expected to be less than or equal to the integer 100",
@@ -3380,28 +7639,112 @@
     "description": "items_integer_bounded_7_real_bounds",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0.5, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0.5,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 50 ],
+    "instance": [
+      1,
+      50
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -3415,22 +7758,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -3447,16 +7867,34 @@
     "description": "items_integer_bounded_8_boundary_values",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 0, 100 ],
+    "instance": [
+      0,
+      100
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -3464,22 +7902,99 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -3504,31 +8019,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 50 was expected to be less than or equal to the integer 100",
-        "The integer value 50 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -3549,21 +8102,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 200 was expected to be less than or equal to the integer 100"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/maximum", "#/maximum", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 200 was expected to be less than or equal to the integer 100"
@@ -3582,31 +8157,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 0 was expected to be less than or equal to the integer 100",
-        "The integer value 0 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -3627,31 +8240,69 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 100 was expected to be less than or equal to the integer 100",
-        "The integer value 100 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 100 was expected to be less than or equal to the integer 100",
@@ -3672,31 +8323,69 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The number value 3.5 was expected to be less than or equal to the integer 100",
-        "The number value 3.5 was expected to be greater than or equal to the integer 0",
-        "The value was expected to be of type integer but it was of type number"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/maximum", "#/maximum", "" ],
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/maximum",
+          "#/maximum",
+          ""
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.5 was expected to be less than or equal to the integer 100",
@@ -3717,21 +8406,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The value was expected to be of type integer but it was of type string"
+        "The value was expected to be an integer within the given range"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type string"
@@ -3749,26 +8460,56 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 5 was expected to be greater than or equal to the integer 1",
-        "The value was expected to be of type integer"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ true, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          true,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 1",
@@ -3787,21 +8528,43 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The integer value 0 was expected to be greater than or equal to the integer 1"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 1"
@@ -3819,26 +8582,56 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#",
+          ""
+        ]
       ],
       "descriptions": [
-        "The number value 5.5 was expected to be greater than or equal to the integer 1",
-        "The value was expected to be of type integer but it was of type number"
+        "The value was expected to be an integer above the given minimum"
       ]
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ "AssertionType", "/type", "#/type", "" ]
+        [
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/minimum", "#/minimum", "" ],
-        [ false, "AssertionType", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/minimum",
+          "#/minimum",
+          ""
+        ],
+        [
+          false,
+          "AssertionType",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 5.5 was expected to be greater than or equal to the integer 1",
@@ -3850,16 +8643,35 @@
     "description": "prop_type_integer_bounded_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 50 },
+    "instance": {
+      "x": 50
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -3867,16 +8679,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 50 was expected to be less than or equal to the integer 100",
@@ -3890,16 +8746,35 @@
     "description": "prop_type_integer_bounded_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 200 },
+    "instance": {
+      "x": 200
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -3907,12 +8782,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 200 was expected to be less than or equal to the integer 100",
@@ -3924,16 +8821,35 @@
     "description": "prop_type_integer_bounded_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": -1 },
+    "instance": {
+      "x": -1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -3941,14 +8857,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value -1 was expected to be less than or equal to the integer 100",
@@ -3961,16 +8910,35 @@
     "description": "prop_type_integer_bounded_4",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -3978,16 +8946,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be less than or equal to the integer 100",
@@ -4001,16 +9013,35 @@
     "description": "prop_type_integer_bounded_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 100 },
+    "instance": {
+      "x": 100
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -4018,16 +9049,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 100 was expected to be less than or equal to the integer 100",
@@ -4041,16 +9116,35 @@
     "description": "prop_type_integer_bounded_7",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": 3.5 },
+    "instance": {
+      "x": 3.5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -4058,16 +9152,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/properties/x/maximum", "#/properties/x/maximum", "/x" ],
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/properties/x/maximum",
+          "#/properties/x/maximum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 3.5 was expected to be less than or equal to the integer 100",
@@ -4081,16 +9219,35 @@
     "description": "prop_type_integer_bounded_8",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
-    "instance": { "x": "hello" },
+    "instance": {
+      "x": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerBounded", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerBounded",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer within the given range"
@@ -4098,12 +9255,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type integer but it was of type string",
@@ -4115,17 +9294,34 @@
     "description": "prop_type_integer_bounded_9",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 0, "maximum": 100 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -4136,16 +9332,34 @@
     "description": "prop_type_integer_lower_bound_1",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5 },
+    "instance": {
+      "x": 5
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -4153,14 +9367,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 5 was expected to be greater than or equal to the integer 1",
@@ -4173,16 +9420,34 @@
     "description": "prop_type_integer_lower_bound_2",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 0 },
+    "instance": {
+      "x": 0
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -4190,12 +9455,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 0 was expected to be greater than or equal to the integer 1",
@@ -4207,16 +9494,34 @@
     "description": "prop_type_integer_lower_bound_3",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 1 },
+    "instance": {
+      "x": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          true,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -4224,14 +9529,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ true, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be greater than or equal to the integer 1",
@@ -4244,16 +9582,34 @@
     "description": "prop_type_integer_lower_bound_5",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
-    "instance": { "x": 5.5 },
+    "instance": {
+      "x": 5.5
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeIntegerLowerBound", "", "#/properties", "/x" ]
+        [
+          false,
+          "AssertionTypeIntegerLowerBound",
+          "",
+          "#/properties",
+          "/x"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an integer above the given minimum"
@@ -4261,14 +9617,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ]
       ],
       "post": [
-        [ true, "AssertionGreaterEqual", "/properties/x/minimum", "#/properties/x/minimum", "/x" ],
-        [ false, "AssertionType", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/properties/x/minimum",
+          "#/properties/x/minimum",
+          "/x"
+        ],
+        [
+          false,
+          "AssertionType",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The number value 5.5 was expected to be greater than or equal to the integer 1",
@@ -4281,17 +9670,33 @@
     "description": "prop_type_integer_lower_bound_6",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "x": { "type": "integer", "minimum": 1 } }
+      "properties": {
+        "x": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {},
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the single defined property subschema"
@@ -4308,10 +9713,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than the integer 99999999999999999999999999999999999"
@@ -4319,10 +9735,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          true,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 199999999999999999999999999999999998 was expected to be greater than the integer 99999999999999999999999999999999999"
@@ -4339,10 +9766,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be greater than the integer 99999999999999999999999999999999999, but they were equal"
@@ -4350,10 +9788,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionGreater", "/exclusiveMinimum", "#/exclusiveMinimum", "" ]
+        [
+          false,
+          "AssertionGreater",
+          "/exclusiveMinimum",
+          "#/exclusiveMinimum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be greater than the integer 99999999999999999999999999999999999, but they were equal"
@@ -4370,10 +9819,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than the integer 99999999999999999999999999999999999"
@@ -4381,10 +9841,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          true,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999998 was expected to be less than the integer 99999999999999999999999999999999999"
@@ -4401,10 +9872,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be less than the integer 99999999999999999999999999999999999, but they were equal"
@@ -4412,10 +9894,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionLess", "/exclusiveMaximum", "#/exclusiveMaximum", "" ]
+        [
+          false,
+          "AssertionLess",
+          "/exclusiveMaximum",
+          "#/exclusiveMaximum",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99999999999999999999999999999999999 was expected to be less than the integer 99999999999999999999999999999999999, but they were equal"
@@ -4427,17 +9920,41 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": 42 },
+    "instance": {
+      "a": "hello",
+      "b": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4445,18 +9962,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionType", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionType",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionType", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -4472,17 +10044,40 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4490,10 +10085,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -4505,17 +10111,41 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": 123, "b": 42 },
+    "instance": {
+      "a": 123,
+      "b": 42
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4523,14 +10153,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -4544,16 +10207,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "x": "hello", "y": 42 },
+    "instance": {
+      "x": "hello",
+      "y": 42
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4561,16 +10245,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ "AssertionType", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          "AssertionType",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/x/type", "#/properties/x/type", "/x" ],
-        [ true, "AssertionType", "/properties/y/type", "#/properties/y/type", "/y" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/x/type",
+          "#/properties/x/type",
+          "/x"
+        ],
+        [
+          true,
+          "AssertionType",
+          "/properties/y/type",
+          "#/properties/y/type",
+          "/y"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4585,16 +10313,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4602,12 +10348,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined properties subschemas",
@@ -4620,16 +10388,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "x": { "type": "string" }, "y": { "type": "integer" } }
+      "properties": {
+        "x": {
+          "type": "string"
+        },
+        "y": {
+          "type": "integer"
+        }
+      }
     },
     "instance": "not an object",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4637,10 +10423,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object but it was of type string"
@@ -4652,16 +10449,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "extra": 999 },
+    "instance": {
+      "a": "hello",
+      "extra": 999
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4669,14 +10484,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4690,17 +10538,39 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" }, "b": { "type": "integer" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4708,16 +10578,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -4734,14 +10648,27 @@
       "type": "object",
       "properties": {}
     },
-    "instance": { "anything": true },
+    "instance": {
+      "anything": true
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -4749,10 +10676,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type object"
@@ -4764,17 +10702,38 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello", "b": "anything" },
+    "instance": {
+      "a": "hello",
+      "b": "anything"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4782,16 +10741,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -4806,17 +10809,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a",
+        "b"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4824,10 +10847,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesAllStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\""
@@ -4840,17 +10874,39 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": "hello" } },
+    "instance": {
+      "inner": {
+        "x": "hello"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4858,18 +10914,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ true, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ true, "AssertionTypeStrict", "/properties/inner/type", "#/properties/inner/type", "/inner" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/inner/type",
+          "#/properties/inner/type",
+          "/inner"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4886,17 +10997,39 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
-        "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+        "inner": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
-    "instance": { "inner": { "x": 123 } },
+    "instance": {
+      "inner": {
+        "x": 123
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -4904,14 +11037,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ]
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/properties/inner/properties/x/type", "#/properties/inner/properties/x/type", "/inner/x" ],
-        [ false, "LogicalWhenType", "/properties/inner/properties", "#/properties/inner/properties", "/inner" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/inner/properties/x/type",
+          "#/properties/inner/properties/x/type",
+          "/inner/x"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties/inner/properties",
+          "#/properties/inner/properties",
+          "/inner"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -4925,21 +11091,64 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "patternProperties": { "^b": { "type": "integer" } }
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^b": {
+          "type": "integer"
+        }
+      }
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -4949,16 +11158,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesStartsWith", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopPropertiesStartsWith",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that start with the string \"b\" were expected to validate against the defined pattern property subschema",
@@ -4973,21 +11226,60 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "additionalProperties": false
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatchClosed", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatchClosed",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -4997,16 +11289,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -5021,23 +11357,79 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
-      "anyOf": [ { "required": [ "a" ] } ]
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "a"
+          ]
+        }
+      ]
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -5048,18 +11440,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefines", "/anyOf/0/required", "#/anyOf/0/required", "" ],
-        [ true, "LogicalOr", "/anyOf", "#/anyOf", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefines",
+          "/anyOf/0/required",
+          "#/anyOf/0/required",
+          ""
+        ],
+        [
+          true,
+          "LogicalOr",
+          "/anyOf",
+          "#/anyOf",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to define the property \"a\"",
@@ -5075,19 +11522,47 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" } },
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
       "minProperties": 1
     },
-    "instance": { "a": "hello" },
+    "instance": {
+      "a": "hello"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas",
@@ -5096,16 +11571,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 1 property and it contained 1 property: \"a\"",
@@ -5126,10 +11645,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5137,10 +11667,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5158,10 +11699,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5169,10 +11721,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5184,17 +11747,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.example.com",
-      "allOf": [ { "$ref": "#/definitions/test" } ],
-      "definitions": { "test": { "$id": "", "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/test"
+        }
+      ],
+      "definitions": {
+        "test": {
+          "$id": "",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5202,14 +11785,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -5223,17 +11839,37 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.example.com",
-      "allOf": [ { "$ref": "#/definitions/test" } ],
-      "definitions": { "test": { "$id": "#", "type": "string" } }
+      "allOf": [
+        {
+          "$ref": "#/definitions/test"
+        }
+      ],
+      "definitions": {
+        "test": {
+          "$id": "#",
+          "type": "string"
+        }
+      }
     },
     "instance": "foo bar",
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string"
@@ -5241,14 +11877,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ],
-        [ "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ]
+        [
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ],
+        [
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/allOf/0/$ref/type", "https://www.example.com#/definitions/test/type", "" ],
-        [ true, "ControlJump", "/allOf/0/$ref", "https://www.example.com#/allOf/0/$ref", "" ],
-        [ true, "LogicalAnd", "/allOf", "https://www.example.com#/allOf", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/allOf/0/$ref/type",
+          "https://www.example.com#/definitions/test/type",
+          ""
+        ],
+        [
+          true,
+          "ControlJump",
+          "/allOf/0/$ref",
+          "https://www.example.com#/allOf/0/$ref",
+          ""
+        ],
+        [
+          true,
+          "LogicalAnd",
+          "/allOf",
+          "https://www.example.com#/allOf",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -5261,21 +11930,51 @@
     "description": "properties_closed_object_fast_path",
     "schema": {
       "type": "object",
-      "required": [ "foo" ],
+      "required": [
+        "foo"
+      ],
       "additionalProperties": false,
-      "properties": { "foo": { "type": "string" } },
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
       "$schema": "http://json-schema.org/draft-06/schema#"
     },
-    "instance": { "foo": "bar" },
+    "instance": {
+      "foo": "bar"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -5284,18 +11983,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/foo/type", "#/properties/foo/type", "/foo" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/foo/type",
+          "#/properties/foo/type",
+          "/foo"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"foo\"",
@@ -5318,10 +12072,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5329,10 +12094,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 1 character but it consisted of 4 characters"
@@ -5347,14 +12123,28 @@
       "minItems": 3,
       "maxItems": 1
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5362,10 +12152,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 1 item but it contained 2 items"
@@ -5380,14 +12181,28 @@
       "minProperties": 3,
       "maxProperties": 1
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionFail", "/type", "#/type", "" ]
+        [
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema"
@@ -5395,10 +12210,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 1 property but it contained 2 properties: \"a\", and \"b\""
@@ -5412,14 +12238,29 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2, "c": 3 },
+    "instance": {
+      "a": 1,
+      "b": 2,
+      "c": 3
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -5427,10 +12268,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties but it contained 3 properties: \"a\", \"b\", and \"c\""
@@ -5444,14 +12296,28 @@
       "type": "object",
       "maxProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at most 2 properties"
@@ -5459,12 +12325,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeLess", "/maxProperties", "#/maxProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeLess",
+          "/maxProperties",
+          "#/maxProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at most 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -5479,14 +12367,27 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -5494,10 +12395,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ]
+        [
+          false,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties but it contained 1 property: \"a\""
@@ -5511,14 +12423,28 @@
       "type": "object",
       "minProperties": 2.0
     },
-    "instance": { "a": 1, "b": 2 },
+    "instance": {
+      "a": 1,
+      "b": 2
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeObjectBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeObjectBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an object of at least 2 properties"
@@ -5526,12 +12452,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectSizeGreater", "/minProperties", "#/minProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionObjectSizeGreater",
+          "/minProperties",
+          "#/minProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to contain at least 2 properties and it contained 2 properties: \"a\", and \"b\"",
@@ -5546,14 +12494,29 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -5561,10 +12524,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items but it contained 3 items"
@@ -5578,14 +12552,28 @@
       "type": "array",
       "maxItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at most 2 items"
@@ -5593,12 +12581,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at most 2 items and it contained 2 items",
@@ -5613,14 +12623,27 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1 ],
+    "instance": [
+      1
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -5628,10 +12651,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items but it contained 1 item"
@@ -5645,14 +12679,28 @@
       "type": "array",
       "minItems": 2.0
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of at least 2 items"
@@ -5660,12 +12708,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The array value was expected to contain at least 2 items and it contained 2 items",
@@ -5684,10 +12754,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -5695,10 +12776,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"abcd\" was expected to consist of at most 2 characters but it consisted of 4 characters"
@@ -5716,10 +12808,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringUpper", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringUpper",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at most 2 characters"
@@ -5727,12 +12830,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/maxLength", "#/maxLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/maxLength",
+          "#/maxLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at most 2 characters and it consisted of 2 characters",
@@ -5751,10 +12876,21 @@
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -5762,10 +12898,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"a\" was expected to consist of at least 2 characters but it consisted of 1 character"
@@ -5783,10 +12930,21 @@
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStringBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStringBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of a string of at least 2 characters"
@@ -5794,12 +12952,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeGreater", "/minLength", "#/minLength", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionStringSizeGreater",
+          "/minLength",
+          "#/minLength",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The string value \"ab\" was expected to consist of at least 2 characters and it consisted of 2 characters",
@@ -5811,18 +12991,44 @@
     "description": "property_names_type_null",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "null" }
+      "propertyNames": {
+        "type": "null"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5831,12 +13037,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5848,16 +13076,29 @@
     "description": "property_names_type_null_empty_object",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "null" }
+      "propertyNames": {
+        "type": "null"
+      }
     },
     "instance": {},
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object is empty and no properties were expected to validate against the given subschema"
@@ -5865,10 +13106,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object is empty and no properties were expected to validate against the given subschema"
@@ -5879,9 +13131,13 @@
     "description": "property_names_type_string",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "string" }
+      "propertyNames": {
+        "type": "string"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5898,9 +13154,16 @@
     "description": "property_names_type_string_or_boolean",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": [ "string", "boolean" ] }
+      "propertyNames": {
+        "type": [
+          "string",
+          "boolean"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5917,18 +13180,47 @@
     "description": "property_names_type_number_or_boolean",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": [ "number", "boolean" ] }
+      "propertyNames": {
+        "type": [
+          "number",
+          "boolean"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5937,12 +13229,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/type", "#/propertyNames/type", "/a" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/type",
+          "#/propertyNames/type",
+          "/a"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5954,9 +13268,16 @@
     "description": "property_names_type_string_or_null",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": [ "string", "null" ] }
+      "propertyNames": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [],
@@ -5973,20 +13294,59 @@
     "description": "property_names_not_type_null",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "not": { "type": "null" } }
+      "propertyNames": {
+        "not": {
+          "type": "null"
+        }
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
-        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -5996,14 +13356,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ false, "AssertionFail", "/propertyNames/not/type", "#/propertyNames/not/type", "/a" ],
-        [ true, "LogicalNot", "/propertyNames/not", "#/propertyNames/not", "/a" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionFail",
+          "/propertyNames/not/type",
+          "#/propertyNames/not/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalNot",
+          "/propertyNames/not",
+          "#/propertyNames/not",
+          "/a"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "No instance is expected to succeed against the false schema",
@@ -6016,18 +13409,45 @@
     "description": "property_names_type_string_max_length",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "string", "maxLength": 3 }
+      "propertyNames": {
+        "type": "string",
+        "maxLength": 3
+      }
     },
-    "instance": { "abcdefgh": 1 },
+    "instance": {
+      "abcdefgh": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
@@ -6036,12 +13456,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/abcdefgh" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/abcdefgh"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"abcdefgh\" was expected to consist of at most 3 characters but it consisted of 8 characters",
@@ -6053,18 +13495,45 @@
     "description": "property_names_type_string_max_length_within",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "string", "maxLength": 3 }
+      "propertyNames": {
+        "type": "string",
+        "maxLength": 3
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
@@ -6073,12 +13542,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ true, "AssertionStringSizeLess", "/propertyNames/maxLength", "#/propertyNames/maxLength", "/ab" ],
-        [ true, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          true,
+          "AssertionStringSizeLess",
+          "/propertyNames/maxLength",
+          "#/propertyNames/maxLength",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at most 3 characters and it consisted of 2 characters",
@@ -6090,18 +13581,45 @@
     "description": "property_names_type_string_min_length",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "string", "minLength": 4 }
+      "propertyNames": {
+        "type": "string",
+        "minLength": 4
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
@@ -6110,12 +13628,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopKeys", "/propertyNames", "#/propertyNames", "" ],
-        [ "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ]
+        [
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ],
+        [
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionStringSizeGreater", "/propertyNames/minLength", "#/propertyNames/minLength", "/ab" ],
-        [ false, "LoopKeys", "/propertyNames", "#/propertyNames", "" ]
+        [
+          false,
+          "AssertionStringSizeGreater",
+          "/propertyNames/minLength",
+          "#/propertyNames/minLength",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopKeys",
+          "/propertyNames",
+          "#/propertyNames",
+          ""
+        ]
       ],
       "descriptions": [
         "The object property name \"ab\" was expected to consist of at least 4 characters but it consisted of 2 characters",
@@ -6128,16 +13668,31 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
     "instance": "hello",
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type string"
@@ -6145,10 +13700,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type string"
@@ -6160,16 +13726,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type object"
@@ -6177,10 +13760,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type object"
@@ -6192,16 +13786,31 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
     "instance": null,
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type null"
@@ -6209,10 +13818,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type array but it was of type null"
@@ -6224,18 +13844,47 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": [ 2, 3 ],
+    "instance": [
+      2,
+      3
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -6244,24 +13893,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 2 was expected to be less than or equal to the integer 5",
@@ -6280,16 +14017,33 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "array",
-      "items": { "type": "number", "minimum": 1, "maximum": 5 }
+      "items": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 5
+      }
     },
-    "instance": [ 99 ],
+    "instance": [
+      99
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -6297,12 +14051,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ]
       ],
       "post": [
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 99 was expected to be less than or equal to the integer 5",
@@ -6314,7 +14090,10 @@
     "description": "type_array_unknown_names",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "type": [ "foo", "bar" ]
+      "type": [
+        "foo",
+        "bar"
+      ]
     },
     "instance": 5,
     "valid": true,
@@ -6333,9 +14112,15 @@
     "description": "property_names_type_unknown_names",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": [ "foo" ] }
+      "propertyNames": {
+        "type": [
+          "foo"
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -6344,9 +14129,13 @@
     "description": "property_names_type_unknown_name_scalar",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "propertyNames": { "type": "foo" }
+      "propertyNames": {
+        "type": "foo"
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {},
     "exhaustive": {}
@@ -6357,27 +14146,80 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "integer" },
-        "c": { "type": "boolean" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        },
+        "c": {
+          "type": "boolean"
+        }
       },
       "patternProperties": {},
       "additionalProperties": false
     },
-    "instance": { "a": "x", "zzz": 1 },
+    "instance": {
+      "a": "x",
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6388,16 +14230,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties", "#/additionalProperties", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties",
+          "#/additionalProperties",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6413,27 +14299,79 @@
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
       "properties": {
-        "a": { "type": "string" },
-        "b": { "type": "integer" },
-        "c": { "type": "boolean" }
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "integer"
+        },
+        "c": {
+          "type": "boolean"
+        }
       },
       "patternProperties": {},
       "additionalProperties": false
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6444,16 +14382,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6467,21 +14449,64 @@
     "description": "pattern_properties_nonboolean_additional",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "allOf": [ false ] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "allOf": [
+          false
+        ]
+      }
     },
-    "instance": { "zzz": 1 },
+    "instance": {
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
@@ -6491,16 +14516,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
-        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/additionalProperties/allOf",
+          "#/additionalProperties/allOf",
+          "/zzz"
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
-        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/additionalProperties/allOf",
+          "#/additionalProperties/allOf",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object properties that match the regular expression \"^a.$\" were expected to validate against the defined pattern property subschema",
@@ -6514,21 +14583,64 @@
     "description": "pattern_properties_nonboolean_additional_matching",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "allOf": [ false ] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "allOf": [
+          false
+        ]
+      }
     },
-    "instance": { "ab": "x" },
+    "instance": {
+      "ab": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6538,14 +14650,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ true, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          true,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string",
@@ -6558,19 +14703,51 @@
     "description": "pattern_properties_nonboolean_additional_bad_type",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "patternProperties": { "^a.$": { "type": "string" } },
-      "additionalProperties": { "allOf": [ false ] }
+      "patternProperties": {
+        "^a.$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "allOf": [
+          false
+        ]
+      }
     },
-    "instance": { "ab": 1 },
+    "instance": {
+      "ab": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -6579,12 +14756,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ],
-        [ "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ]
+        [
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeStrict", "/patternProperties/^a.$/type", "#/patternProperties/%5Ea.$/type", "/ab" ],
-        [ false, "LoopPropertiesRegex", "/patternProperties", "#/patternProperties", "" ]
+        [
+          false,
+          "AssertionTypeStrict",
+          "/patternProperties/^a.$/type",
+          "#/patternProperties/%5Ea.$/type",
+          "/ab"
+        ],
+        [
+          false,
+          "LoopPropertiesRegex",
+          "/patternProperties",
+          "#/patternProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be of type string but it was of type integer",
@@ -6596,21 +14795,67 @@
     "description": "closed_properties_nonboolean_additional",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
-      "additionalProperties": { "allOf": [ false ] }
+      "properties": {
+        "a": {},
+        "b": {},
+        "c": {},
+        "d": {},
+        "e": {},
+        "f": {}
+      },
+      "additionalProperties": {
+        "allOf": [
+          false
+        ]
+      }
     },
-    "instance": { "zzz": 1 },
+    "instance": {
+      "zzz": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6620,16 +14865,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ],
-        [ "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
-        [ "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ],
+        [
+          "LogicalAnd",
+          "/additionalProperties/allOf",
+          "#/additionalProperties/allOf",
+          "/zzz"
+        ],
+        [
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ false, "AssertionFail", "/additionalProperties/allOf/0", "#/additionalProperties/allOf/0", "/zzz" ],
-        [ false, "LogicalAnd", "/additionalProperties/allOf", "#/additionalProperties/allOf", "/zzz" ],
-        [ false, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          false,
+          "AssertionFail",
+          "/additionalProperties/allOf/0",
+          "#/additionalProperties/allOf/0",
+          "/zzz"
+        ],
+        [
+          false,
+          "LogicalAnd",
+          "/additionalProperties/allOf",
+          "#/additionalProperties/allOf",
+          "/zzz"
+        ],
+        [
+          false,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6643,19 +14932,54 @@
     "description": "closed_properties_nonboolean_additional_known",
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
-      "properties": { "a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {} },
-      "additionalProperties": { "allOf": [ false ] }
+      "properties": {
+        "a": {},
+        "b": {},
+        "c": {},
+        "d": {},
+        "e": {},
+        "f": {}
+      },
+      "additionalProperties": {
+        "allOf": [
+          false
+        ]
+      }
     },
-    "instance": { "a": 1 },
+    "instance": {
+      "a": 1
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6664,12 +14988,34 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopPropertiesMatch", "/properties", "#/properties", "" ],
-        [ true, "LoopPropertiesExcept", "/additionalProperties", "#/additionalProperties", "" ]
+        [
+          true,
+          "LoopPropertiesMatch",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "LoopPropertiesExcept",
+          "/additionalProperties",
+          "#/additionalProperties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the 6 defined properties subschemas",
@@ -6682,26 +15028,64 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": 5, "b": { "x": "s" } },
+    "instance": {
+      "a": 5,
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6710,14 +15094,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6731,28 +15148,77 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": { "x": "s" } },
+    "instance": {
+      "a": {},
+      "b": {
+        "x": "s"
+      }
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6762,24 +15228,112 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/properties/x/type", "#/properties/b/properties/x/type", "/b/x" ],
-        [ true, "LogicalWhenType", "/properties/b/properties", "#/properties/b/properties", "/b" ],
-        [ true, "AssertionTypeStrict", "/properties/b/type", "#/properties/b/type", "/b" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/properties/x/type",
+          "#/properties/b/properties/x/type",
+          "/b/x"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/b/type",
+          "#/properties/b/type",
+          "/b"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6798,28 +15352,75 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a", "b" ],
+      "required": [
+        "a",
+        "b"
+      ],
       "properties": {
-        "a": { "type": "object" },
+        "a": {
+          "type": "object"
+        },
         "b": {
           "type": "object",
-          "properties": { "x": { "type": "string" } },
-          "required": [ "x" ]
+          "properties": {
+            "x": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "x"
+          ]
         }
       }
     },
-    "instance": { "a": {}, "b": {} },
+    "instance": {
+      "a": {},
+      "b": {}
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionPropertyTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "AssertionObjectPropertiesSimple", "/properties/b/properties", "#/properties/b/properties", "/b" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionPropertyTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties/b/properties",
+          "#/properties/b/properties",
+          "/b"
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6829,16 +15430,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ]
+        [
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesAllStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "AssertionDefinesStrict", "/properties/b/required", "#/properties/b/required", "/b" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesAllStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/properties/b/required",
+          "#/properties/b/required",
+          "/b"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines properties \"a\", and \"b\"",
@@ -6853,17 +15498,36 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
-    "instance": { "a": "x" },
+    "instance": {
+      "a": "x"
+    },
     "valid": true,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -6871,16 +15535,60 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesStrict", "/required", "#/required", "" ],
-        [ true, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ true, "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          true,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\"",
@@ -6895,17 +15603,34 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "required": [ "a" ],
-      "properties": { "a": { "type": "string" } }
+      "required": [
+        "a"
+      ],
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      }
     },
     "instance": {},
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionObjectPropertiesSimple", "/properties", "#/properties", "" ]
+        [
+          false,
+          "AssertionObjectPropertiesSimple",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to validate against the defined property subschemas"
@@ -6913,10 +15638,21 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionDefinesStrict", "/required", "#/required", "" ]
+        [
+          false,
+          "AssertionDefinesStrict",
+          "/required",
+          "#/required",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to be an object that defines the property \"a\""
@@ -6930,18 +15666,48 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 2, 3 ],
+    "instance": [
+      1,
+      2,
+      3
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -6950,30 +15716,151 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/2" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/2" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/2" ],
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ false, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/2"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/2"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          false,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -6997,16 +15884,31 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
     "instance": [],
     "valid": false,
     "fast": {
       "pre": [
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ false, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          false,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The value was expected to consist of an array of 1 to 2 items"
@@ -7014,14 +15916,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ false, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ]
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          false,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array value was expected to validate against the given subschema",
@@ -7037,18 +15972,47 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 2 ],
+    "instance": [
+      1,
+      2
+    ],
     "valid": true,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "LoopItemsIntegerBounded", "/items", "#/items", "" ],
-        [ true, "AssertionTypeArrayBounded", "/type", "#/type", "" ]
+        [
+          true,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeArrayBounded",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range",
@@ -7057,28 +16021,138 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/1" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/1" ],
-        [ true, "LoopItems", "/items", "#/items", "" ],
-        [ true, "AssertionArraySizeLess", "/maxItems", "#/maxItems", "" ],
-        [ true, "AssertionArraySizeGreater", "/minItems", "#/minItems", "" ],
-        [ true, "AssertionTypeStrict", "/type", "#/type", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/1"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/1"
+        ],
+        [
+          true,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeLess",
+          "/maxItems",
+          "#/maxItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionArraySizeGreater",
+          "/minItems",
+          "#/minItems",
+          ""
+        ],
+        [
+          true,
+          "AssertionTypeStrict",
+          "/type",
+          "#/type",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -7101,16 +16175,34 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "items": { "type": "number", "minimum": 0, "maximum": 100 }
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      }
     },
-    "instance": [ 1, 999 ],
+    "instance": [
+      1,
+      999
+    ],
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopItemsIntegerBounded", "/items", "#/items", "" ]
+        [
+          false,
+          "LoopItemsIntegerBounded",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "Every item in the array was expected to be a number within the given range"
@@ -7118,18 +16210,73 @@
     },
     "exhaustive": {
       "pre": [
-        [ "LoopItems", "/items", "#/items", "" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ]
+        [
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ]
       ],
       "post": [
-        [ true, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/0" ],
-        [ true, "AssertionGreaterEqual", "/items/minimum", "#/items/minimum", "/0" ],
-        [ true, "AssertionTypeStrictAny", "/items/type", "#/items/type", "/0" ],
-        [ false, "AssertionLessEqual", "/items/maximum", "#/items/maximum", "/1" ],
-        [ false, "LoopItems", "/items", "#/items", "" ]
+        [
+          true,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionGreaterEqual",
+          "/items/minimum",
+          "#/items/minimum",
+          "/0"
+        ],
+        [
+          true,
+          "AssertionTypeStrictAny",
+          "/items/type",
+          "#/items/type",
+          "/0"
+        ],
+        [
+          false,
+          "AssertionLessEqual",
+          "/items/maximum",
+          "#/items/maximum",
+          "/1"
+        ],
+        [
+          false,
+          "LoopItems",
+          "/items",
+          "#/items",
+          ""
+        ]
       ],
       "descriptions": [
         "The integer value 1 was expected to be less than or equal to the integer 100",
@@ -7145,18 +16292,42 @@
     "schema": {
       "$schema": "http://json-schema.org/draft-06/schema#",
       "type": "object",
-      "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
-      "required": [ "a", "b" ],
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
       "additionalProperties": false
     },
-    "instance": { "b": "x", "a": 1 },
+    "instance": {
+      "b": "x",
+      "a": 1
+    },
     "valid": false,
     "fast": {
       "pre": [
-        [ "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "post": [
-        [ false, "LoopPropertiesExactlyTypeStrictHash", "/properties", "#/properties", "" ]
+        [
+          false,
+          "LoopPropertiesExactlyTypeStrictHash",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The required object properties were expected to be of type string"
@@ -7164,14 +16335,47 @@
     },
     "exhaustive": {
       "pre": [
-        [ "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ "LogicalWhenType", "/properties", "#/properties", "" ],
-        [ "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ]
+        [
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ],
+        [
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ]
       ],
       "post": [
-        [ true, "AssertionDefinesExactly", "/required", "#/required", "" ],
-        [ false, "AssertionTypeStrict", "/properties/a/type", "#/properties/a/type", "/a" ],
-        [ false, "LogicalWhenType", "/properties", "#/properties", "" ]
+        [
+          true,
+          "AssertionDefinesExactly",
+          "/required",
+          "#/required",
+          ""
+        ],
+        [
+          false,
+          "AssertionTypeStrict",
+          "/properties/a/type",
+          "#/properties/a/type",
+          "/a"
+        ],
+        [
+          false,
+          "LogicalWhenType",
+          "/properties",
+          "#/properties",
+          ""
+        ]
       ],
       "descriptions": [
         "The object value was expected to only define properties \"a\", and \"b\"",

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -1351,27 +1351,13 @@ TEST(type_integer_bounded_5) {
   })JSON")};
 
   const sourcemeta::core::JSON instance{3.0};
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 3, "");
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1, "");
 
-  EVALUATE_TRACE_PRE(0, AssertionLessEqual, "/maximum", "#/maximum", "");
-  EVALUATE_TRACE_PRE(1, AssertionGreaterEqual, "/minimum", "#/minimum", "");
-  EVALUATE_TRACE_PRE(2, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionLessEqual, "/maximum", "#/maximum",
-                              "");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionGreaterEqual, "/minimum", "#/minimum",
-                              "");
-  EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/type", "#/type", "");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The number value 3.0 was expected to be less "
-                               "than or equal to the integer 100");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The number value 3.0 was expected to be "
-                               "greater than or equal to the integer 0");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_PRE(0, AssertionTypeIntegerBounded, "", "#", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeIntegerBounded, "", "#", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an integer within the given range");
 }
 
 TEST(type_integer_lower_bound_3) {
@@ -1382,20 +1368,13 @@ TEST(type_integer_lower_bound_3) {
   })JSON")};
 
   const sourcemeta::core::JSON instance{5.0};
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 2, "");
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(schema, instance, 1, "");
 
-  EVALUATE_TRACE_PRE(0, AssertionGreaterEqual, "/minimum", "#/minimum", "");
-  EVALUATE_TRACE_PRE(1, AssertionType, "/type", "#/type", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionGreaterEqual, "/minimum", "#/minimum",
-                              "");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/type", "#/type", "");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                               "The number value 5.0 was expected to be "
-                               "greater than or equal to the integer 1");
-
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_PRE(0, AssertionTypeIntegerLowerBound, "", "#", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeIntegerLowerBound, "", "#", "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The value was expected to be an integer above the given minimum");
 }
 
 TEST(prop_type_integer_bounded_6) {


### PR DESCRIPTION
## Summary

* Fuse `type: number | integer` with `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` into a single bounded instruction in fast mode.
* Add `AssertionTypeNumberBounded` and support optional/exclusive numeric bounds.
* Preserve the existing unfused behaviour in exhaustive mode.
* Update template serialization, evaluator descriptions, and tests across supported JSON Schema drafts.

This reduces common numeric schemas from multiple evaluator instructions to one bounded instruction.

## Validation

* `blaze.compiler` passed.
* `blaze.evaluator_trace_suite` passed.
* ClangFormat compliance passed.
* No new benchmark was added because existing benchmark schemas already cover numeric type and bound combinations.

Closes #111


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

