### PR TITLE
Upgrade the JSON Schema Test Suite to `6648e8194c69697b2e1a15fe76a06a480b183a51`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 core https://github.com/sourcemeta/core 3e1d11893f8a7144c4ec2267f5d3f54da551f083
-jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite 1acd90e53554fa24d2529b49fd7d50bab18f8b7e
+jsonschema-test-suite https://github.com/json-schema-org/JSON-Schema-Test-Suite 6648e8194c69697b2e1a15fe76a06a480b183a51
 jsonschema-2020-12 https://github.com/json-schema-org/json-schema-spec 769daad75a9553562333a8937a187741cb708c72
 jsonschema-2019-09 https://github.com/json-schema-org/json-schema-spec 41014ea723120ce70b314d72f863c6929d9f3cfd
 jsonschema-draft7 https://github.com/json-schema-org/json-schema-spec 567f768506aaa33a38e552c85bf0586029ef1b32

--- a/ports/javascript/official.test.mjs
+++ b/ports/javascript/official.test.mjs
@@ -16,26 +16,26 @@ const BLACKLISTS = {
   'draft2020-12': new Set(),
   'draft2020-12/optional': new Set(['format-assertion', 'refOfUnknownKeyword']),
   'draft2020-12/optional/format': new Set([
-    'date-time', 'date', 'duration', 'email', 'hostname', 'idn-email',
-    'idn-hostname', 'ipv4', 'ipv6', 'iri-reference', 'iri', 'json-pointer',
-    'regex', 'relative-json-pointer', 'time', 'uri-reference', 'uri-template',
-    'uri', 'uuid', 'ecmascript-regex'
+    'date-time', 'date', 'duration', 'ecmascript-regex', 'email', 'hostname',
+    'idn-email', 'idn-hostname', 'ipv4', 'ipv6', 'iri-reference', 'iri',
+    'json-pointer', 'regex', 'relative-json-pointer', 'time', 'uri-reference',
+    'uri-template', 'uri', 'uuid'
   ]),
   'draft2019-09': new Set(),
   'draft2019-09/optional': new Set(['refOfUnknownKeyword']),
   'draft2019-09/optional/format': new Set([
-    'date-time', 'date', 'duration', 'email', 'hostname', 'idn-email',
-    'idn-hostname', 'ipv4', 'ipv6', 'iri-reference', 'iri', 'json-pointer',
-    'regex', 'relative-json-pointer', 'time', 'uri-reference', 'uri-template',
-    'uri', 'uuid'
+    'date-time', 'date', 'duration', 'ecmascript-regex', 'email', 'hostname',
+    'idn-email', 'idn-hostname', 'ipv4', 'ipv6', 'iri-reference', 'iri',
+    'json-pointer', 'regex', 'relative-json-pointer', 'time', 'uri-reference',
+    'uri-template', 'uri', 'uuid'
   ]),
   'draft7': new Set(),
   'draft7/optional': new Set(['content']),
   'draft7/optional/format': new Set([
-    'date-time', 'date', 'email', 'hostname', 'idn-email', 'idn-hostname',
-    'ipv4', 'ipv6', 'iri-reference', 'iri', 'json-pointer', 'regex',
-    'relative-json-pointer', 'time', 'unknown', 'uri-reference', 'uri-template',
-    'uri'
+    'date-time', 'date', 'ecmascript-regex', 'email', 'hostname', 'idn-email',
+    'idn-hostname', 'ipv4', 'ipv6', 'iri-reference', 'iri', 'json-pointer',
+    'regex', 'relative-json-pointer', 'time', 'unknown', 'uri-reference',
+    'uri-template', 'uri'
   ]),
   'draft6': new Set(),
   'draft6/optional': new Set(),

--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -913,7 +913,7 @@ INSTRUCTION_HANDLER(AssertionStringType) {
       result = is_email(target);
       break;
     case ValueStringType::IDNEmail:
-      result = is_idn_email(target);
+      result = is_idn_email_uts46(target);
       break;
     case ValueStringType::IPv4:
       result = is_ipv4(target);

--- a/test/canonicalizer/CMakeLists.txt
+++ b/test/canonicalizer/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(sourcemeta_blaze_canonicalizer_unit
 target_compile_definitions(sourcemeta_blaze_canonicalizer_unit
   PRIVATE SCHEMAS_PATH="${PROJECT_SOURCE_DIR}/schemas")
 
-set_tests_properties(blaze.canonicalizer PROPERTIES TIMEOUT 60)
+set_tests_properties(blaze.canonicalizer PROPERTIES TIMEOUT 90)

--- a/test/evaluator/evaluator_2020_12_test.cc
+++ b/test/evaluator/evaluator_2020_12_test.cc
@@ -2303,6 +2303,114 @@ TEST(format_idn_email_invalid_with_tweak_exhaustive) {
       "internationalized email address");
 }
 
+TEST(format_idn_email_non_nfc_domain_with_tweak_fast) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "format": "idn-email"
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("user@cafe\u0301.com")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.format_assertion = true;
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringType, "/format", "#/format", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionStringType, "/format", "#/format",
+                              "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"user@cafe\xcc\x81.com\" was expected to represent a "
+      "valid internationalized email address");
+}
+
+TEST(format_idn_email_fullwidth_domain_with_tweak_fast) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "format": "idn-email"
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("user@\uff41\uff42\uff43")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.format_assertion = true;
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS_TWEAKED(schema, instance, 1, "", tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringType, "/format", "#/format", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionStringType, "/format", "#/format",
+                              "");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"user@\xef\xbd\x81\xef\xbd\x82\xef\xbd\x83\" was "
+      "expected to represent a valid internationalized email address");
+}
+
+TEST(format_idn_email_non_nfc_domain_with_tweak_exhaustive) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "format": "idn-email"
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("user@cafe\u0301.com")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.format_assertion = true;
+
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS_TWEAKED(schema, instance, 2, "",
+                                                 tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringType, "/format", "#/format", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/format", "#/format", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionStringType, "/format", "#/format",
+                              "");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/format", "#/format", "", "idn-email");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"user@cafe\xcc\x81.com\" was expected to represent a "
+      "valid internationalized email address");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The logical type of the instance was expected to be \"idn-email\"");
+}
+
+TEST(format_idn_email_fullwidth_domain_with_tweak_exhaustive) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "format": "idn-email"
+  })JSON")};
+
+  const sourcemeta::core::JSON instance{
+      sourcemeta::core::parse_json(R"JSON("user@\uff41\uff42\uff43")JSON")};
+
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.format_assertion = true;
+
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS_TWEAKED(schema, instance, 2, "",
+                                                 tweaks);
+
+  EVALUATE_TRACE_PRE(0, AssertionStringType, "/format", "#/format", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/format", "#/format", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionStringType, "/format", "#/format",
+                              "");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/format", "#/format", "", "idn-email");
+
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The string value \"user@\xef\xbd\x81\xef\xbd\x82\xef\xbd\x83\" was "
+      "expected to represent a valid internationalized email address");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 1,
+      "The logical type of the instance was expected to be \"idn-email\"");
+}
+
 TEST(format_idn_email_no_tweak_fast) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/vendor/jsonschema-test-suite/annotations/tests/core.json
+++ b/vendor/jsonschema-test-suite/annotations/tests/core.json
@@ -28,7 +28,34 @@
     },
     {
       "description": "`$dynamicRef` resolves to `$dynamicAnchor`",
-      "compatibility": "2020",
+      "compatibility": "9999",
+      "schema": {
+        "$dynamicRef": "foo",
+        "$defs": {
+          "foo": {
+            "$dynamicAnchor": "foo",
+            "title": "Foo"
+          }
+        }
+      },
+      "tests": [
+        {
+          "instance": "bar",
+          "assertions": [
+            {
+              "location": "",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/foo": "Foo"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "`$dynamicRef` resolves to `$dynamicAnchor`",
+      "compatibility": "=2020",
       "schema": {
         "$dynamicRef": "#foo",
         "$defs": {
@@ -55,7 +82,81 @@
     },
     {
       "description": "`$dynamicRef` resolves to different `$dynamicAnchor`s depending on dynamic path",
-      "compatibility": "2020",
+      "compatibility": "9999",
+      "schema": {
+        "$id": "https://test.json-schema.org/dynamic-ref-annotation/main",
+        "if": {
+          "properties": { "kindOfList": { "const": "numbers" } },
+          "required": ["kindOfList"]
+        },
+        "then": { "$ref": "numberList" },
+        "else": { "$ref": "stringList" },
+        "$defs": {
+          "genericList": {
+            "$id": "genericList",
+            "properties": {
+              "list": {
+                "items": { "$dynamicRef": "itemType" }
+              }
+            },
+            "$defs": {
+              "defaultItemType": {
+                "$dynamicAnchor": "itemType"
+              }
+            }
+          },
+          "numberList": {
+            "$id": "numberList",
+            "$defs": {
+              "itemType": {
+                "$dynamicAnchor": "itemType",
+                "title": "Number Item"
+              }
+            },
+            "$ref": "genericList"
+          },
+          "stringList": {
+            "$id": "stringList",
+            "$defs": {
+              "itemType": {
+                "$dynamicAnchor": "itemType",
+                "title": "String Item"
+              }
+            },
+            "$ref": "genericList"
+          }
+        }
+      },
+      "tests": [
+        {
+          "instance": { "kindOfList": "numbers", "list": [1] },
+          "assertions": [
+            {
+              "location": "/list/0",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/numberList/$defs/itemType": "Number Item"
+              }
+            }
+          ]
+        },
+        {
+          "instance": { "kindOfList": "strings", "list": ["foo"] },
+          "assertions": [
+            {
+              "location": "/list/0",
+              "keyword": "title",
+              "expected": {
+                "#/$defs/stringList/$defs/itemType": "String Item"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "`$dynamicRef` resolves to different `$dynamicAnchor`s depending on dynamic path",
+      "compatibility": "=2020",
       "schema": {
         "$id": "https://test.json-schema.org/dynamic-ref-annotation/main",
         "if": {
@@ -127,6 +228,5 @@
         }
       ]
     }
-
   ]
-} 
+}

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date-time.json
@@ -150,6 +150,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/date.json
@@ -357,6 +357,66 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/duration.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/duration.json
@@ -217,6 +217,56 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ecmascript-regex.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ecmascript-regex.json
@@ -1,0 +1,116 @@
+[
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "format": "regex"
+        },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/hostname.json
@@ -120,6 +120,21 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-email.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-email.json
@@ -50,6 +50,56 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -190,6 +200,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/iri.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/iri.json
@@ -80,6 +80,51 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/relative-json-pointer.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false
@@ -95,6 +100,36 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri-reference.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri-reference.json
@@ -92,6 +92,72 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri-template.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri-template.json
@@ -55,6 +55,146 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uri.json
@@ -227,6 +227,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/draft2019-09/optional/format/uuid.json
@@ -130,6 +130,21 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date-time.json
@@ -150,6 +150,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/date.json
@@ -357,6 +357,66 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/duration.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/duration.json
@@ -217,6 +217,56 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ecmascript-regex.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ecmascript-regex.json
@@ -12,5 +12,105 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "Python-specific regular expression syntax is not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "Python named group (?P<name>...) is not ECMA 262",
+        "data": "(?P<name>x)",
+        "valid": false
+      },
+      {
+        "description": "Python named backreference (?P=name) is not ECMA 262",
+        "data": "(?P<n>a)(?P=n)",
+        "valid": false
+      },
+      {
+        "description": "inline comment group (?#...) is not ECMA 262",
+        "data": "(?#comment)a",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "global inline flag groups are not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a single global inline flag (?i)",
+        "data": "(?i)abc",
+        "valid": false
+      },
+      {
+        "description": "multiple global inline flags (?ims)",
+        "data": "(?ims)abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 named groups and backreferences are valid",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an ECMA 262 named group (?<name>...)",
+        "data": "(?<name>x)",
+        "valid": true
+      },
+      {
+        "description": "an ECMA 262 named backreference \\k<name>",
+        "data": "(?<n>a)\\k<n>",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 lookbehind is valid, including variable width",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a variable-width lookbehind (ES2018)",
+        "data": "(?<=a+)b",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 character classes and escapes",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an empty character class is valid ECMA 262",
+        "data": "[]",
+        "valid": true
+      },
+      {
+        "description": "a negated empty character class is valid ECMA 262",
+        "data": "[^]",
+        "valid": true
+      },
+      {
+        "description": "a control escape \\cA is valid ECMA 262",
+        "data": "\\cA",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/hostname.json
@@ -120,6 +120,21 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-email.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-email.json
@@ -50,6 +50,56 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -190,6 +200,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/iri.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/iri.json
@@ -80,6 +80,51 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/relative-json-pointer.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false
@@ -95,6 +100,36 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri-reference.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri-reference.json
@@ -92,6 +92,72 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri-template.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri-template.json
@@ -55,6 +55,146 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uri.json
@@ -227,6 +227,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/draft2020-12/optional/format/uuid.json
@@ -130,6 +130,21 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft3/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft3/optional/format/date-time.json
@@ -37,6 +37,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft4/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft4/optional/format/date-time.json
@@ -147,6 +147,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft4/optional/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft4/optional/format/hostname.json
@@ -142,6 +142,16 @@
                 "description": "IDN label separator",
                 "data": "example\uff0ecom",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft4/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft4/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -187,6 +197,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft4/optional/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/draft4/optional/format/uri.json
@@ -224,6 +224,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/date-time.json
@@ -147,6 +147,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/hostname.json
@@ -142,6 +142,16 @@
                 "description": "IDN label separator",
                 "data": "example\uff0ecom",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -187,6 +197,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri-reference.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri-reference.json
@@ -89,6 +89,72 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri-template.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri-template.json
@@ -52,6 +52,146 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/draft6/optional/format/uri.json
@@ -224,6 +224,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/date-time.json
@@ -147,6 +147,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/date.json
@@ -354,6 +354,66 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/ecmascript-regex.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/ecmascript-regex.json
@@ -1,0 +1,98 @@
+[
+    {
+        "description": "\\a is not an ECMA 262 control escape",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "when used as a pattern",
+                "data": "\\a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Python-specific regular expression syntax is not valid ECMA 262",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "Python named group (?P<name>...) is not ECMA 262",
+                "data": "(?P<name>x)",
+                "valid": false
+            },
+            {
+                "description": "Python named backreference (?P=name) is not ECMA 262",
+                "data": "(?P<n>a)(?P=n)",
+                "valid": false
+            },
+            {
+                "description": "inline comment group (?#...) is not ECMA 262",
+                "data": "(?#comment)a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "global inline flag groups are not valid ECMA 262",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "a single global inline flag (?i)",
+                "data": "(?i)abc",
+                "valid": false
+            },
+            {
+                "description": "multiple global inline flags (?ims)",
+                "data": "(?ims)abc",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 named groups and backreferences are valid",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "an ECMA 262 named group (?<name>...)",
+                "data": "(?<name>x)",
+                "valid": true
+            },
+            {
+                "description": "an ECMA 262 named backreference \\k<name>",
+                "data": "(?<n>a)\\k<n>",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 lookbehind is valid, including variable width",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "a variable-width lookbehind (ES2018)",
+                "data": "(?<=a+)b",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ECMA 262 character classes and escapes",
+        "schema": { "format": "regex" },
+        "tests": [
+            {
+                "description": "an empty character class is valid ECMA 262",
+                "data": "[]",
+                "valid": true
+            },
+            {
+                "description": "a negated empty character class is valid ECMA 262",
+                "data": "[^]",
+                "valid": true
+            },
+            {
+                "description": "a control escape \\cA is valid ECMA 262",
+                "data": "\\cA",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/hostname.json
@@ -117,6 +117,21 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-email.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-email.json
@@ -47,6 +47,56 @@
                 "description": "a valid e-mail address",
                 "data": "joe.bloggs@example.com",
                 "valid": true
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/idn-hostname.json
@@ -389,6 +389,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/ipv4.json
@@ -145,6 +145,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -187,6 +197,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/iri.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/iri.json
@@ -77,6 +77,51 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/relative-json-pointer.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/relative-json-pointer.json
@@ -69,6 +69,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false
@@ -92,6 +97,36 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri-reference.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri-reference.json
@@ -89,6 +89,72 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri-template.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri-template.json
@@ -52,6 +52,146 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/draft7/optional/format/uri.json
@@ -224,6 +224,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/date-time.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/date-time.json
@@ -150,6 +150,26 @@
                 "description": "invalid extended year",
                 "data": "+11963-06-19T08:30:06.283185Z",
                 "valid": false
+            },
+            {
+                "description": "a numeric offset without minutes is invalid",
+                "data": "1985-04-12T23:20:50+01",
+                "valid": false
+            },
+            {
+                "description": "hour 24 is invalid even with a leap second",
+                "data": "2016-12-31T24:59:60+01:00",
+                "valid": false
+            },
+            {
+                "description": "a second fraction of fifteen nines is valid",
+                "data": "1985-04-12T00:59:59.999999999999999Z",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "1985-04-12T23:20:50Z\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/date.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/date.json
@@ -357,6 +357,66 @@
                 "description": "invalid: alphabetic characters in day field",
                 "data": "2020-01-DD",
                 "valid": false
+            },
+            {
+                "description": "invalid: colon separators",
+                "data": "2020:01:01",
+                "valid": false
+            },
+            {
+                "description": "invalid: dot separators",
+                "data": "2020.01.01",
+                "valid": false
+            },
+            {
+                "description": "invalid: space separators",
+                "data": "2020 01 01",
+                "valid": false
+            },
+            {
+                "description": "invalid: mixed slash and hyphen separators",
+                "data": "2020-01/01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated first hyphen",
+                "data": "2020--01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: duplicated second hyphen",
+                "data": "2020-01--01",
+                "valid": false
+            },
+            {
+                "description": "valid: date inside the Julian to Gregorian reform gap",
+                "data": "1582-10-10",
+                "valid": true
+            },
+            {
+                "description": "invalid: year field numerically larger than a 32-bit signed integer",
+                "data": "2147483648-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: character just above '9' as the second digit of the day",
+                "data": "2020-01-0:",
+                "valid": false
+            },
+            {
+                "description": "invalid: non-ASCII digit leaving ten UTF-8 bytes but eight characters",
+                "data": "\u09e80-01-01",
+                "valid": false
+            },
+            {
+                "description": "invalid: en dash separators instead of hyphen-minus",
+                "data": "2020\u201301\u201301",
+                "valid": false
+            },
+            {
+                "description": "invalid: NUL character after an otherwise valid full-date",
+                "data": "2020-01-01\u0000",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/duration.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/duration.json
@@ -217,6 +217,56 @@
                 "description": "minutes and seconds can appear without hour",
                 "data": "PT1M2S",
                 "valid": true
+            },
+            {
+                "description": "a leading sign is not allowed",
+                "data": "-P1D",
+                "valid": false
+            },
+            {
+                "description": "a number before the time separator has no unit",
+                "data": "P1D2T3H",
+                "valid": false
+            },
+            {
+                "description": "exponent notation is not allowed in a component",
+                "data": "P1e2D",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline is invalid",
+                "data": "P1D\n",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a time component",
+                "data": "P1WT1H",
+                "valid": false
+            },
+            {
+                "description": "weeks cannot be combined with a zero-valued component",
+                "data": "P0Y1W",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in a component is valid",
+                "data": "P01D",
+                "valid": true
+            },
+            {
+                "description": "a component with many digits is valid",
+                "data": "P999999999999999999999999999999999999999999999999999999999999999999999999999999D",
+                "valid": true
+            },
+            {
+                "description": "a comma as the decimal separator is invalid",
+                "data": "PT0,5S",
+                "valid": false
+            },
+            {
+                "description": "a sign inside a component is invalid",
+                "data": "P-1D",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/ecmascript-regex.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/ecmascript-regex.json
@@ -12,5 +12,105 @@
         "valid": false
       }
     ]
+  },
+  {
+    "description": "Python-specific regular expression syntax is not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "Python named group (?P<name>...) is not ECMA 262",
+        "data": "(?P<name>x)",
+        "valid": false
+      },
+      {
+        "description": "Python named backreference (?P=name) is not ECMA 262",
+        "data": "(?P<n>a)(?P=n)",
+        "valid": false
+      },
+      {
+        "description": "inline comment group (?#...) is not ECMA 262",
+        "data": "(?#comment)a",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "global inline flag groups are not valid ECMA 262",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a single global inline flag (?i)",
+        "data": "(?i)abc",
+        "valid": false
+      },
+      {
+        "description": "multiple global inline flags (?ims)",
+        "data": "(?ims)abc",
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 named groups and backreferences are valid",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an ECMA 262 named group (?<name>...)",
+        "data": "(?<name>x)",
+        "valid": true
+      },
+      {
+        "description": "an ECMA 262 named backreference \\k<name>",
+        "data": "(?<n>a)\\k<n>",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 lookbehind is valid, including variable width",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "a variable-width lookbehind (ES2018)",
+        "data": "(?<=a+)b",
+        "valid": true
+      }
+    ]
+  },
+  {
+    "description": "ECMA 262 character classes and escapes",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "regex"
+    },
+    "tests": [
+      {
+        "description": "an empty character class is valid ECMA 262",
+        "data": "[]",
+        "valid": true
+      },
+      {
+        "description": "a negated empty character class is valid ECMA 262",
+        "data": "[^]",
+        "valid": true
+      },
+      {
+        "description": "a control escape \\cA is valid ECMA 262",
+        "data": "\\cA",
+        "valid": true
+      }
+    ]
   }
 ]

--- a/vendor/jsonschema-test-suite/tests/v1/format/hostname.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/hostname.json
@@ -120,6 +120,21 @@
                 "description": "exceeds maximum label length (63)",
                 "data": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
                 "valid": false
+            },
+            {
+                "description": "trailing newline is invalid",
+                "data": "example.com\n",
+                "valid": false
+            },
+            {
+                "description": "invalid non-ASCII KELVIN SIGN (U+212A)",
+                "data": "\u212Aelvin.example.com",
+                "valid": false
+            },
+            {
+                "description": "consecutive hyphens inside a label",
+                "data": "a--b.com",
+                "valid": true
             }
         ]
     },

--- a/vendor/jsonschema-test-suite/tests/v1/format/idn-email.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/idn-email.json
@@ -55,6 +55,56 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "a non-ASCII local part with an ASCII domain is valid",
+                "data": "δοκιμή@example.com",
+                "valid": true
+            },
+            {
+                "description": "a non-ASCII quoted local part is valid",
+                "data": "\"δοκιμή\"@example.com",
+                "valid": true
+            },
+            {
+                "description": "a domain label that is not in Unicode NFC is valid",
+                "data": "user@cafe\u0301.com",
+                "valid": true
+            },
+            {
+                "description": "a local part that is not in Unicode NFC is valid",
+                "data": "cafe\u0301@example.com",
+                "valid": true
+            },
+            {
+                "description": "a C1 control in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-2 admits U+0085",
+                "data": "\u0085@example.com",
+                "valid": true
+            },
+            {
+                "description": "a noncharacter in the local part is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii; https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-3 admits U+FFFF",
+                "data": "\uffff@example.com",
+                "valid": true
+            },
+            {
+                "description": "a local part at the 64-octet limit is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1 every implementation must be able to receive a local part of 64 octets",
+                "data": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com",
+                "valid": true
+            },
+            {
+                "description": "a fullwidth commercial at is not a local-part separator",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2 Mailbox = Local-part \"@\" ( Domain / address-literal ) splits on U+0040, and any IDN mapping applies only to the domain that split produces, so U+FF20 cannot become the delimiter",
+                "data": "user\uff20example.com",
+                "valid": false
+            },
+            {
+                "description": "a local part with a supplementary-plane character is valid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc6531#section-3.3 atext =/ UTF8-non-ascii, and https://www.rfc-editor.org/rfc/rfc3629#section-4 UTF8-4 covers U+10000 and above",
+                "data": "\ud835\udd4f@example.com",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/idn-hostname.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/idn-hostname.json
@@ -397,6 +397,12 @@
                 "valid": false
             },
             {
+                "description": "A-label that decodes to only ASCII is invalid",
+                "comment": "https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1 a U-label must have at least one non-ASCII character",
+                "data": "xn--example-",
+                "valid": false
+            },
+            {
                 "description": "non-canonical Punycode that does not re-encode to itself is invalid",
                 "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
                 "data": "xn---9uc",

--- a/vendor/jsonschema-test-suite/tests/v1/format/ipv4.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/ipv4.json
@@ -148,6 +148,16 @@
                 "valid": true
             },
             {
+                "description": "valid IPv4 with an octet in the 200 to 249 range",
+                "data": "200.0.0.0",
+                "valid": true
+            },
+            {
+                "description": "valid IPv4 with two-digit octets",
+                "data": "10.20.30.40",
+                "valid": true
+            },
+            {
                 "description": "empty string is invalid",
                 "data": "",
                 "valid": false
@@ -190,6 +200,11 @@
             {
                 "description": "with port number is invalid",
                 "data": "192.168.0.1:80",
+                "valid": false
+            },
+            {
+                "description": "an IPv4-mapped IPv6 address is invalid",
+                "data": "::ffff:192.168.0.1",
                 "valid": false
             },
             {

--- a/vendor/jsonschema-test-suite/tests/v1/format/iri.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/iri.json
@@ -80,6 +80,51 @@
                 "description": "an invalid IRI though valid IRI reference",
                 "data": "âππ",
                 "valid": false
+            },
+            {
+                "description": "an IPv6 host whose embedded IPv4 has a leading zero is invalid",
+                "data": "http://[::ffff:192.168.0.01]",
+                "valid": false
+            },
+            {
+                "description": "a valid IRI with a compressed IPv6 host",
+                "data": "http://[2001:db8::1]",
+                "valid": true
+            },
+            {
+                "description": "a trailing newline after a valid IRI is invalid",
+                "data": "http://ƒøø.ßår/\n",
+                "valid": false
+            },
+            {
+                "description": "an IPvFuture host with an uppercase version letter is valid",
+                "data": "http://[V1.fe]",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with an IPv4 host",
+                "data": "http://192.168.0.1/p",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and a rootless path",
+                "data": "urn:example:resource",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with no authority and an absolute path",
+                "data": "file:/etc/hosts",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane character in the path",
+                "data": "http://ƒøø.ßår/𐌀",
+                "valid": true
+            },
+            {
+                "description": "a valid IRI with a supplementary-plane private-use char in query",
+                "data": "http://ƒøø.ßår/?q=󰀀",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/relative-json-pointer.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/relative-json-pointer.json
@@ -72,6 +72,11 @@
                 "valid": false
             },
             {
+                "description": "non-ASCII digit in the prefix is not allowed",
+                "data": "١/foo",
+                "valid": false
+            },
+            {
                 "description": "## is not a valid json-pointer",
                 "data": "0##",
                 "valid": false
@@ -95,6 +100,36 @@
                 "description": "multi-digit integer prefix",
                 "data": "120/foo/bar",
                 "valid": true
+            },
+            {
+                "description": "multi-digit prefix with a zero followed by another digit",
+                "data": "100",
+                "valid": true
+            },
+            {
+                "description": "tilde not followed by 0 or 1 in the json-pointer part",
+                "data": "0/~2",
+                "valid": false
+            },
+            {
+                "description": "unescaped tilde at the end of the json-pointer part",
+                "data": "0/foo/bar~",
+                "valid": false
+            },
+            {
+                "description": "octothorpe followed by a json-pointer",
+                "data": "1#/foo/bar",
+                "valid": false
+            },
+            {
+                "description": "empty reference tokens in the json-pointer part",
+                "data": "0//",
+                "valid": true
+            },
+            {
+                "description": "trailing newline after the non-negative integer",
+                "data": "1\n",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/uri-reference.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/uri-reference.json
@@ -92,6 +92,72 @@
                 "comment": "RFC 3986, Section 3.2.2: Fallback to reg-name allows digits and dots.",
                 "data": "http://999.999.999.999/",
                 "valid": true
+            },
+            {
+                "description": "an empty URI reference",
+                "comment": "RFC 3986, Section 4.2: relative-part includes path-empty, which is zero characters.",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "a query-only reference",
+                "comment": "RFC 3986, Section 4.2: relative-ref = relative-part [ \"?\" query ] [ \"#\" fragment ], so a query with an empty path is a reference.",
+                "data": "?query=1",
+                "valid": true
+            },
+            {
+                "description": "a network-path reference with an empty authority",
+                "comment": "RFC 3986, Section 3.2.2: host = IP-literal / IPv4address / reg-name, and reg-name may be empty.",
+                "data": "//",
+                "valid": true
+            },
+            {
+                "description": "an incomplete percent-encoding",
+                "comment": "RFC 3986, Section 2.1: pct-encoded = \"%\" HEXDIG HEXDIG.",
+                "data": "/%zz",
+                "valid": false
+            },
+            {
+                "description": "a double quote in a path",
+                "comment": "RFC 3986, Appendix A: pchar = unreserved / pct-encoded / sub-delims / \":\" / \"@\", and the double quote is in none of them.",
+                "data": "/a\"b",
+                "valid": false
+            },
+            {
+                "description": "square brackets outside an authority",
+                "comment": "RFC 3986, Section 3.2.2: square brackets are reserved for an IP-literal inside the authority. path-absolute is built from pchar, which excludes them.",
+                "data": "/[::1]",
+                "valid": false
+            },
+            {
+                "description": "a non-numeric port in a network-path reference",
+                "comment": "RFC 3986, Section 3.2.3: port = *DIGIT. reg-name admits no colon, so the text after the colon can only be a port.",
+                "data": "//example.com:abc/p",
+                "valid": false
+            },
+            {
+                "description": "more than one at-sign in the authority",
+                "comment": "RFC 3986, Section 3.2: authority = [ userinfo \"@\" ] host [ \":\" port ]. Neither userinfo nor host admits a literal at-sign.",
+                "data": "//a@b@example.com/",
+                "valid": false
+            },
+            {
+                "description": "a leading zero in the IPv4 part of an IPv6 literal",
+                "comment": "RFC 3986, Section 3.2.2: inside an IP-literal the dotted quad must be an IPv4address, and dec-octet has no leading-zero alternative. There is no reg-name fallback inside brackets.",
+                "data": "//[::ffff:192.168.0.01]/p",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment of a relative-path reference",
+                "comment": "RFC 3986, Section 4.2: relative-part uses path-noscheme, whose first segment is segment-nz-nc - a non-zero-length segment without any colon. A scheme must start with ALPHA, so 1:b cannot be read as a URI either.",
+                "data": "1:b",
+                "valid": false
+            },
+            {
+                "description": "a colon in the first segment preceded by a dot-segment",
+                "comment": "RFC 3986, Section 4.2: \"Such a segment must be preceded by a dot-segment (e.g., \\\"./this:that\\\") to make a relative-path reference.\"",
+                "data": "./this:that",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/uri-template.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/uri-template.json
@@ -55,6 +55,146 @@
                 "description": "a valid relative uri-template",
                 "data": "dictionary/{term:1}/{term}",
                 "valid": true
+            },
+            {
+                "description": "an empty expression is invalid",
+                "data": "{}",
+                "valid": false
+            },
+            {
+                "description": "an empty varspec inside the variable list is invalid",
+                "data": "{a,,b}",
+                "valid": false
+            },
+            {
+                "description": "a zero prefix max-length is invalid",
+                "data": "{v:0}",
+                "valid": false
+            },
+            {
+                "description": "a five-digit prefix max-length is invalid",
+                "data": "{v:10000}",
+                "valid": false
+            },
+            {
+                "description": "an empty string is a valid uri-template",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an unmatched closing brace is invalid",
+                "data": "foo}bar",
+                "valid": false
+            },
+            {
+                "description": "a percent-encoded triplet in a literal is valid",
+                "data": "a%41b",
+                "valid": true
+            },
+            {
+                "description": "a supplementary plane character in a literal is valid",
+                "data": "a\ud83d\ude00b",
+                "valid": true
+            },
+            {
+                "description": "reserved expansion operator",
+                "data": "{+var}",
+                "valid": true
+            },
+            {
+                "description": "fragment expansion operator",
+                "data": "{#var}",
+                "valid": true
+            },
+            {
+                "description": "label expansion operator",
+                "data": "{.var}",
+                "valid": true
+            },
+            {
+                "description": "path segment expansion operator",
+                "data": "{/var}",
+                "valid": true
+            },
+            {
+                "description": "path style parameter expansion operator",
+                "data": "{;var}",
+                "valid": true
+            },
+            {
+                "description": "form style query expansion operator",
+                "data": "{?var}",
+                "valid": true
+            },
+            {
+                "description": "form style query continuation operator",
+                "data": "{&var}",
+                "valid": true
+            },
+            {
+                "description": "the explode modifier is valid",
+                "data": "{var*}",
+                "valid": true
+            },
+            {
+                "description": "a variable list with more than one varspec is valid",
+                "data": "{x,y}",
+                "valid": true
+            },
+            {
+                "description": "a dotted variable name is valid",
+                "data": "{a.b}",
+                "valid": true
+            },
+            {
+                "description": "a double dot in a variable name is invalid",
+                "data": "{a..b}",
+                "valid": false
+            },
+            {
+                "description": "a variable name may start with a percent-encoded triplet",
+                "data": "{%41}",
+                "valid": true
+            },
+            {
+                "description": "a four-digit prefix max-length is valid",
+                "data": "{v:1000}",
+                "valid": true
+            },
+            {
+                "description": "a leading zero in the prefix max-length is invalid",
+                "data": "{v:01}",
+                "valid": false
+            },
+            {
+                "description": "a space in a literal is invalid",
+                "data": "a b",
+                "valid": false
+            },
+            {
+                "description": "a delete character in a literal is invalid",
+                "data": "a\u007fb",
+                "valid": false
+            },
+            {
+                "description": "a trailing comma in the variable list is invalid",
+                "data": "{a,}",
+                "valid": false
+            },
+            {
+                "description": "a default value in a varspec is invalid",
+                "data": "{var=def}",
+                "valid": false
+            },
+            {
+                "description": "an operator in place of the first varspec is invalid",
+                "data": "{,+var}",
+                "valid": false
+            },
+            {
+                "description": "an apostrophe in a literal is valid",
+                "data": "a'b",
+                "valid": true
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/uri.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/uri.json
@@ -227,6 +227,16 @@
                 "description": "non-numeric port is invalid",
                 "data": "http://example.com:abc/path",
                 "valid": false
+            },
+            {
+                "description": "leading zero in an embedded IPv4 address is invalid",
+                "data": "http://[::ffff:01.2.3.4]",
+                "valid": false
+            },
+            {
+                "description": "square brackets are not allowed in a path segment",
+                "data": "http:/[::1]",
+                "valid": false
             }
         ]
     }

--- a/vendor/jsonschema-test-suite/tests/v1/format/uuid.json
+++ b/vendor/jsonschema-test-suite/tests/v1/format/uuid.json
@@ -130,6 +130,21 @@
                 "description": "non-ASCII digit '২' (a Bengali 2) is invalid",
                 "data": "২eb8aa08-aa98-11ea-b4aa-73b441d16380",
                 "valid": false
+            },
+            {
+                "description": "an underscore in place of a hex digit is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d1_380",
+                "valid": false
+            },
+            {
+                "description": "a trailing newline after a complete UUID is invalid",
+                "data": "2eb8aa08-aa98-11ea-b4aa-73b441d16380\n",
+                "valid": false
+            },
+            {
+                "description": "a variant nibble not defined by RFC 4122 is valid",
+                "data": "2eb8aa08-aa98-11ea-f4aa-73b441d16380",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

