### PR TITLE
    Evaluate common array item assertions without indirect dispatch

### DIFF
--- a/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
+++ b/src/evaluator/include/sourcemeta/blaze/evaluator_dispatch.h
@@ -595,19 +595,23 @@ INSTRUCTION_HANDLER(AssertionTypeStringUpper) {
   EVALUATE_END(AssertionTypeStringUpper);
 }
 
+INSTRUCTION_DIRECT(AssertionTypeArrayBounded, ValueRange) {
+  const auto &[minimum, maximum, exhaustive] = value;
+  // Require early breaking
+  assert(!exhaustive);
+  SOURCEMETA_ASSUME(!exhaustive);
+  return target.type() == JSON::Type::Array && target.array_size() >= minimum &&
+         (!maximum.has_value() || target.array_size() <= maximum.value());
+}
+
 INSTRUCTION_HANDLER(AssertionTypeArrayBounded) {
   EVALUATE_BEGIN_NO_PRECONDITION(AssertionTypeArrayBounded);
   const auto &target{
       resolve_instance(instance, instruction.relative_instance_location)};
   const auto &value{assume_value<ValueRange>(instruction.value)};
-  const auto &[minimum, maximum, exhaustive] = value;
-  assert(!maximum.has_value() || maximum.value() >= minimum);
-  // Require early breaking
-  assert(!exhaustive);
-  SOURCEMETA_ASSUME(!exhaustive);
-  result = target.type() == JSON::Type::Array &&
-           target.array_size() >= minimum &&
-           (!maximum.has_value() || target.array_size() <= maximum.value());
+  assert(!std::get<1>(value).has_value() ||
+         std::get<1>(value).value() >= std::get<0>(value));
+  result = DIRECT(AssertionTypeArrayBounded, target, value);
   EVALUATE_END(AssertionTypeArrayBounded);
 }
 
@@ -2271,7 +2275,27 @@ INSTRUCTION_HANDLER(LoopItems) {
   if constexpr (!Track && !HasCallback) {
     for (const auto &new_instance : target.as_array()) {
       for (const auto &child : instruction.children) {
-        if (!EVALUATE_RECURSE(child, new_instance)) [[unlikely]] {
+        bool child_ok;
+        // Dynamic still pushes and pops a resource per instruction, which the
+        // direct path would skip, so it stays on the general dispatch
+        if constexpr (Dynamic) {
+          child_ok = EVALUATE_RECURSE(child, new_instance);
+        } else {
+          switch (child.type) {
+            case InstructionIndex::AssertionTypeArrayBounded:
+              child_ok =
+                  DIRECT(AssertionTypeArrayBounded,
+                         resolve_instance(new_instance,
+                                          child.relative_instance_location),
+                         assume_value<ValueRange>(child.value));
+              break;
+            default:
+              child_ok = EVALUATE_RECURSE(child, new_instance);
+              break;
+          }
+        }
+
+        if (!child_ok) [[unlikely]] {
           result = false;
           EVALUATE_END(LoopItems);
         }


### PR DESCRIPTION
`LoopItems` looks up every child instruction in the handler table once per array element, even though the children are identical every iteration, millions of indirect calls to the same few targets on a large array. I took the most frequently dispatched instruction (`AssertionTypeArrayBounded`) and made `LoopItems` call it directly, using the `INSTRUCTION_DIRECT` pattern already in the codebase.

**Improvement:**

| Case | Δ |
| --- | --- |
| geojson | −3.84% |
| cmake_presets | +0.22% |
| ui5_manifest | +0.02% |
| openapi, draft_04, users_array, jshintrc | 0.00% |

So: **3.84% fewer instructions on geojson**, nothing elsewhere, and a 0.22% cost on one case that doesn't benefit.

**Tests:** all pass — 17,688 official, 1,159 unit, 95 annotation, 3,326 + 3,326 trace, plus clang-format.

I ran multiple tests, this was the most improvement i noticed 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

