### PR TITLE
Let `SchemaFrame::analyse` treat the default identifier as a fallback

### DIFF
--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -40,7 +40,9 @@ auto dependencies_internal(
     std::unordered_set<std::string> &visited) -> void {
   sourcemeta::blaze::SchemaFrame frame{
       sourcemeta::blaze::SchemaFrame::Mode::References};
-  frame.analyse(schema, walker, resolver, default_dialect, default_id, paths);
+  frame.analyse(schema, walker, resolver, default_dialect, default_id,
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+                paths);
   const auto origin{sourcemeta::blaze::identify(schema, resolver,
                                                 default_dialect, default_id)};
 
@@ -289,6 +291,7 @@ auto bundle_schema(sourcemeta::core::JSON &root,
   if (depth == 0) {
     frame.analyse(
         subschema, walker, resolver, default_dialect, default_id,
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
         // We only want to frame in "wrapper" mode for the top level object
         paths);
   } else {
@@ -465,8 +468,9 @@ auto bundle(sourcemeta::core::JSON &schema, const SchemaWalker &walker,
                      sourcemeta::core::JSON::String>
       bundled;
   SchemaFrame initial_frame{SchemaFrame::Mode::Locations};
-  initial_frame.analyse(schema, walker, resolver, default_dialect, default_id,
-                        paths);
+  initial_frame.analyse(
+      schema, walker, resolver, default_dialect, default_id,
+      sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional, paths);
   initial_frame.for_each_resource_uri([&bundled](const auto &uri) -> void {
     bundled.emplace(sourcemeta::core::JSON::String{uri},
                     sourcemeta::core::JSON::String{uri});

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -572,6 +572,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                           const SchemaResolver &resolver,
                           std::string_view default_dialect,
                           std::string_view default_id,
+                          const SchemaFrame::IdentifierMode identifier_mode,
                           const SchemaFrame::Paths &paths) -> void {
   this->reset();
   assert((std::unordered_set<sourcemeta::core::WeakPointer,
@@ -653,9 +654,10 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
     // If the top-level schema has a specific identifier but the user
     // passes a different default identifier, then the schema is by
     // definition known by two names, and we should handle that accordingly
-    const bool has_explicit_different_id{root_id.has_value() &&
-                                         !default_id.empty() &&
-                                         root_id.value() != default_id};
+    const bool has_explicit_different_id{
+        identifier_mode == SchemaFrame::IdentifierMode::Additional &&
+        root_id.has_value() && !default_id.empty() &&
+        root_id.value() != default_id};
     sourcemeta::core::JSON::String default_id_canonical;
     if (has_explicit_different_id) {
       default_id_canonical = sourcemeta::core::URI::canonicalize(default_id);

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -73,6 +73,15 @@ public:
   /// intensive
   enum class Mode : std::uint8_t { Locations, References };
 
+  /// How a caller-provided default identifier relates to the one that the
+  /// schema declares, if any
+  enum class IdentifierMode : std::uint8_t {
+    /// Register the default identifier in addition to the schema's own
+    Additional,
+    /// Register the default identifier only if the schema declares none
+    Fallback
+  };
+
   SchemaFrame(const Mode mode) : mode_{mode} {}
 
   // We rely on internal caches that would be dangling otherwise
@@ -166,6 +175,7 @@ public:
                const SchemaResolver &resolver,
                std::string_view default_dialect = "",
                std::string_view default_id = "",
+               IdentifierMode identifier_mode = IdentifierMode::Additional,
                const Paths &paths = {sourcemeta::core::EMPTY_WEAK_POINTER})
       -> void;
 

--- a/test/frame/frame_2020_12_test.cc
+++ b/test/frame/frame_2020_12_test.cc
@@ -4456,7 +4456,8 @@ TEST(zero_paths) {
   sourcemeta::blaze::SchemaFrame frame{
       sourcemeta::blaze::SchemaFrame::Mode::References};
   frame.analyse(document, sourcemeta::blaze::schema_walker,
-                sourcemeta::blaze::schema_resolver, "", "", {});
+                sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional, {});
 
   EXPECT_EQ(frame.locations().size(), 0);
   EXPECT_EQ(frame.references().size(), 0);
@@ -4476,6 +4477,7 @@ TEST(single_nested_path_recursive_with_identifier) {
   const sourcemeta::core::Pointer wrapper_path{"wrapper"};
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(wrapper_path)});
 
   EXPECT_EQ(frame.locations().size(), 8);
@@ -4551,6 +4553,7 @@ TEST(single_nested_path_recursive_without_identifiers) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver,
                 "https://json-schema.org/draft/2020-12/schema", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(wrapper_path)});
 
   EXPECT_EQ(frame.locations().size(), 2);
@@ -4594,6 +4597,7 @@ TEST(single_nested_anonymous_with_nested_resource) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver,
                 "https://json-schema.org/draft/2020-12/schema", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(wrapper_path)});
 
   EXPECT_EQ(frame.locations().size(), 10);
@@ -4695,6 +4699,7 @@ TEST(multiple_nested_cross_ref) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver,
                 "https://json-schema.org/draft/2020-12/schema", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(path1),
                  sourcemeta::core::to_weak_pointer(path2),
                  sourcemeta::core::to_weak_pointer(path3)});
@@ -4839,6 +4844,7 @@ TEST(multiple_nested_cross_ref_missing_target) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver,
                 "https://json-schema.org/draft/2020-12/schema", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(path1),
                  sourcemeta::core::to_weak_pointer(path2)});
 
@@ -4908,6 +4914,7 @@ TEST(multiple_nested_no_base_dialect) {
   try {
     frame.analyse(document, sourcemeta::blaze::schema_walker,
                   sourcemeta::blaze::schema_resolver, "", "",
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                   {sourcemeta::core::to_weak_pointer(path1),
                    sourcemeta::core::to_weak_pointer(path2),
                    sourcemeta::core::to_weak_pointer(path3)});
@@ -4940,6 +4947,7 @@ TEST(multiple_nested_same_id) {
   try {
     frame.analyse(document, sourcemeta::blaze::schema_walker,
                   sourcemeta::blaze::schema_resolver, "", "",
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                   {sourcemeta::core::to_weak_pointer(path1),
                    sourcemeta::core::to_weak_pointer(path2)});
     FAIL();
@@ -4969,6 +4977,7 @@ TEST(multiple_nested_same_anonymous_anchors) {
     frame.analyse(document, sourcemeta::blaze::schema_walker,
                   sourcemeta::blaze::schema_resolver,
                   "https://json-schema.org/draft/2020-12/schema", "",
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                   {sourcemeta::core::to_weak_pointer(path1),
                    sourcemeta::core::to_weak_pointer(path2)});
     FAIL();
@@ -5008,6 +5017,7 @@ TEST(multiple_nested_with_default_id) {
                 // The default id should be getting ignored on nested schemas
                 // as it only makes sense for top-level framing
                 "https://www.example.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(path1),
                  sourcemeta::core::to_weak_pointer(path2)});
 

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -3911,3 +3911,173 @@ TEST(reuse_embedded_custom_metaschema_explicit_reset) {
   EXPECT_FALSE(root_vocabularies.contains(
       sourcemeta::blaze::Vocabularies::Known::JSON_Schema_2020_12_Validation));
 }
+
+TEST(id_with_default_id_additional_mode) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "https://other.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional);
+
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 10);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/$id", "https://example.com", "/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$id", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/$schema", "https://example.com", "/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$schema", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://json-schema.org/draft/2020-12/schema",
+      JSON_Schema_2020_12, "https://example.com", "/additionalProperties", "",
+      false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/additionalProperties/type",
+      "https://example.com", "/additionalProperties/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/additionalProperties/type",
+      "/additionalProperties", false, false);
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://other.com", "https://example.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://other.com#/$id", "https://example.com", "/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$id", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://other.com#/$schema", "https://example.com", "/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$schema", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://other.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://json-schema.org/draft/2020-12/schema",
+      JSON_Schema_2020_12, "https://example.com", "/additionalProperties", "",
+      false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://other.com#/additionalProperties/type",
+      "https://example.com", "/additionalProperties/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/additionalProperties/type",
+      "/additionalProperties", false, false);
+
+  EXPECT_EQ(frame.references().size(), 1);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt,
+      "https://json-schema.org/draft/2020-12/schema");
+}
+
+TEST(id_with_default_id_fallback_mode) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "https://other.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
+
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 5);
+
+  EXPECT_FALSE(frame.traverse("https://other.com").has_value());
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/$id", "https://example.com", "/$id",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$id", "", false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/$schema", "https://example.com", "/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/$schema", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://json-schema.org/draft/2020-12/schema",
+      JSON_Schema_2020_12, "https://example.com", "/additionalProperties", "",
+      false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://example.com#/additionalProperties/type",
+      "https://example.com", "/additionalProperties/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "/additionalProperties/type",
+      "/additionalProperties", false, false);
+
+  EXPECT_EQ(frame.references().size(), 1);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt,
+      "https://json-schema.org/draft/2020-12/schema");
+}
+
+TEST(no_id_with_default_id_fallback_mode) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "https://other.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
+
+  EXPECT_EQ(frame.root(), "https://other.com");
+  EXPECT_EQ(frame.locations().size(), 4);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://other.com", "https://other.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://other.com", "", std::nullopt, false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://other.com#/$schema", "https://other.com", "/$schema",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://other.com", "/$schema", "", false, false);
+  EXPECT_FRAME_STATIC_SUBSCHEMA(
+      frame, "https://other.com#/additionalProperties", "https://other.com",
+      "/additionalProperties", "https://json-schema.org/draft/2020-12/schema",
+      JSON_Schema_2020_12, "https://other.com", "/additionalProperties", "",
+      false, false);
+  EXPECT_FRAME_STATIC_POINTER(
+      frame, "https://other.com#/additionalProperties/type",
+      "https://other.com", "/additionalProperties/type",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://other.com", "/additionalProperties/type",
+      "/additionalProperties", false, false);
+
+  EXPECT_EQ(frame.references().size(), 1);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt,
+      "https://json-schema.org/draft/2020-12/schema");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

