### PR TITLE
Add a `SchemaFrame` mode that only analyses the top-level schema

### DIFF
--- a/benchmark/frame.cc
+++ b/benchmark/frame.cc
@@ -66,6 +66,20 @@ static void Schema_Frame_ISO_Language_Locations(benchmark::State &state) {
   }
 }
 
+static void Schema_Frame_ISO_Language_Root(benchmark::State &state) {
+  const auto schema{sourcemeta::core::read_json(
+      std::filesystem::path{CURRENT_DIRECTORY} / "files" /
+      "2020_12_iso_language_2023_set_3.json")};
+
+  for (auto _ : state) {
+    sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::Root};
+    frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    benchmark::DoNotOptimize(frame);
+  }
+}
+
 static void Schema_Frame_KrakenD_References(benchmark::State &state) {
   const auto schema{
       sourcemeta::core::read_json(std::filesystem::path{CURRENT_DIRECTORY} /
@@ -155,6 +169,7 @@ BENCHMARK(Schema_Frame_WoT_References);
 BENCHMARK(Schema_Frame_OMC_References);
 BENCHMARK(Schema_Frame_OMC_Locations);
 BENCHMARK(Schema_Frame_ISO_Language_Locations);
+BENCHMARK(Schema_Frame_ISO_Language_Root);
 BENCHMARK(Schema_Frame_KrakenD_References);
 BENCHMARK(Schema_Frame_KrakenD_Reachable);
 BENCHMARK(Schema_Frame_ISO_Language_Locations_To_JSON);

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -575,6 +575,10 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                           const SchemaFrame::IdentifierMode identifier_mode,
                           const SchemaFrame::Paths &paths) -> void {
   this->reset();
+  // This mode reports on a single top-level schema, so framing a wrapper
+  // that holds more than one has no meaning here
+  assert(this->mode_ != SchemaFrame::Mode::Root ||
+         (paths.size() == 1 && paths.front().empty()));
   assert((std::unordered_set<sourcemeta::core::WeakPointer,
                              sourcemeta::core::WeakPointer::Hasher>(
               paths.cbegin(), paths.cend())
@@ -673,6 +677,28 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
     }
 
     if (this->mode_ == SchemaFrame::Mode::Root) {
+      // The schema may pin a custom meta-schema inside its own containers.
+      // Cache it, as the vocabulary lookups that this mode exists to serve
+      // consult that cache
+      if (!sourcemeta::blaze::to_base_dialect(root_dialect).has_value()) {
+        const sourcemeta::core::JSON::String dialect_key{root_dialect};
+        const auto *embedded{sourcemeta::blaze::metaschema_try_embedded(
+            schema, root_dialect, resolver)};
+        if (embedded) {
+          this->probed_metaschemas_.emplace(dialect_key, embedded);
+        }
+      }
+
+      if (root_id.has_value()) {
+        const sourcemeta::core::URI identifier{root_id.value()};
+        const auto fragment{identifier.fragment()};
+        if (fragment.has_value() && !fragment.value().empty()) {
+          throw SchemaFrameError(
+              root_id.value(),
+              "Identifiers must not contain non-empty fragments");
+        }
+      }
+
       store(this->locations_, SchemaReferenceType::Static,
             root_id.has_value() ? SchemaFrame::LocationType::Resource
                                 : SchemaFrame::LocationType::Subschema,

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -575,11 +575,9 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                           const SchemaFrame::IdentifierMode identifier_mode,
                           const SchemaFrame::Paths &paths) -> void {
   this->reset();
-  // This mode reports on the top-level schema of the given document. Framing
-  // a wrapper that holds its schemas elsewhere has no top-level schema to
-  // report on, so there is nothing to analyse
-  if (this->mode_ == SchemaFrame::Mode::Root &&
-      (paths.size() != 1 || !paths.front().empty())) {
+  // This mode reports on a single schema. Framing a wrapper that holds more
+  // than one has no single schema to report on, so there is nothing to analyse
+  if (this->mode_ == SchemaFrame::Mode::Root && paths.size() != 1) {
     return;
   }
   assert((std::unordered_set<sourcemeta::core::WeakPointer,
@@ -637,8 +635,10 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
 
     // If we are dealing with nested schemas, then by definition
     // the root has no identifier
+    // This mode analyses a single schema, which the caller may have pointed
+    // at through a container, so its identifier is the one we report
     std::optional<sourcemeta::core::JSON::String> root_id{std::nullopt};
-    if (path.empty()) {
+    if (path.empty() || this->mode_ == SchemaFrame::Mode::Root) {
       const auto maybe_id{sourcemeta::blaze::identify(
           schema, root_base_dialect.value(), default_id)};
       if (!maybe_id.empty()) {

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -672,6 +672,17 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
       base_uris.insert({path, {root_id.value(), default_id_canonical}});
     }
 
+    if (this->mode_ == SchemaFrame::Mode::Root) {
+      store(this->locations_, SchemaReferenceType::Static,
+            root_id.has_value() ? SchemaFrame::LocationType::Resource
+                                : SchemaFrame::LocationType::Subschema,
+            root_id.value_or(sourcemeta::core::JSON::String{}),
+            root_id.value_or(sourcemeta::core::JSON::String{}), path,
+            path.size(), root_dialect, root_base_dialect.value(), std::nullopt,
+            false, false, false, true);
+      continue;
+    }
+
     std::vector<std::size_t> current_subschema_entries;
     for (const auto &relative_entry : sourcemeta::blaze::SchemaIterator{
              schema, walker, effective_resolver, default_dialect}) {
@@ -828,7 +839,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
         }
       }
 
-      if (this->mode_ != SchemaFrame::Mode::Locations) {
+      if (this->mode_ == SchemaFrame::Mode::References) {
         // Handle metaschema references
         const auto maybe_metaschema{sourcemeta::blaze::dialect(
             entry.common.subschema.get(), {}, false)};
@@ -1095,7 +1106,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
     }
   }
 
-  if (this->mode_ == SchemaFrame::Mode::Locations) {
+  if (this->mode_ != SchemaFrame::Mode::References) {
     return;
   }
 
@@ -1323,6 +1334,11 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
       set_base_and_fragment(it->second);
     }
   }
+}
+
+auto SchemaFrame::root_location() const
+    -> std::optional<std::reference_wrapper<const Location>> {
+  return this->traverse(this->root_);
 }
 
 auto SchemaFrame::locations() const noexcept -> const Locations & {

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -575,10 +575,13 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                           const SchemaFrame::IdentifierMode identifier_mode,
                           const SchemaFrame::Paths &paths) -> void {
   this->reset();
-  // This mode reports on a single top-level schema, so framing a wrapper
-  // that holds more than one has no meaning here
-  assert(this->mode_ != SchemaFrame::Mode::Root ||
-         (paths.size() == 1 && paths.front().empty()));
+  // This mode reports on the top-level schema of the given document. Framing
+  // a wrapper that holds its schemas elsewhere has no top-level schema to
+  // report on, so there is nothing to analyse
+  if (this->mode_ == SchemaFrame::Mode::Root &&
+      (paths.size() != 1 || !paths.front().empty())) {
+    return;
+  }
   assert((std::unordered_set<sourcemeta::core::WeakPointer,
                              sourcemeta::core::WeakPointer::Hasher>(
               paths.cbegin(), paths.cend())
@@ -699,13 +702,13 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
         }
       }
 
+      const auto location_uri{
+          root_id.value_or(sourcemeta::core::JSON::String{})};
       store(this->locations_, SchemaReferenceType::Static,
             root_id.has_value() ? SchemaFrame::LocationType::Resource
                                 : SchemaFrame::LocationType::Subschema,
-            root_id.value_or(sourcemeta::core::JSON::String{}),
-            root_id.value_or(sourcemeta::core::JSON::String{}), path,
-            path.size(), root_dialect, root_base_dialect.value(), std::nullopt,
-            false, false, false, true);
+            location_uri, location_uri, path, path.size(), root_dialect,
+            root_base_dialect.value(), std::nullopt, false, false, false, true);
       continue;
     }
 

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -71,9 +71,8 @@ class SOURCEMETA_BLAZE_FRAME_EXPORT SchemaFrame {
 public:
   /// The mode of framing. More extensive analysis can be compute and memory
   /// intensive. Each mode is a superset of the previous one. Note that
-  /// sourcemeta::blaze::SchemaFrame::Mode::Root only reports on the top-level
-  /// schema of the given document, so analysing a wrapper that holds its
-  /// schemas elsewhere yields an empty frame
+  /// sourcemeta::blaze::SchemaFrame::Mode::Root reports on a single schema,
+  /// so analysing a wrapper that holds more than one yields an empty frame
   enum class Mode : std::uint8_t { Root, Locations, References };
 
   /// How a caller-provided default identifier relates to the one that the

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -70,7 +70,10 @@ namespace sourcemeta::blaze {
 class SOURCEMETA_BLAZE_FRAME_EXPORT SchemaFrame {
 public:
   /// The mode of framing. More extensive analysis can be compute and memory
-  /// intensive. Each mode is a superset of the previous one
+  /// intensive. Each mode is a superset of the previous one. Note that
+  /// sourcemeta::blaze::SchemaFrame::Mode::Root only reports on the top-level
+  /// schema of the given document, so analysing a wrapper that holds its
+  /// schemas elsewhere yields an empty frame
   enum class Mode : std::uint8_t { Root, Locations, References };
 
   /// How a caller-provided default identifier relates to the one that the

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -70,8 +70,8 @@ namespace sourcemeta::blaze {
 class SOURCEMETA_BLAZE_FRAME_EXPORT SchemaFrame {
 public:
   /// The mode of framing. More extensive analysis can be compute and memory
-  /// intensive
-  enum class Mode : std::uint8_t { Locations, References };
+  /// intensive. Each mode is a superset of the previous one
+  enum class Mode : std::uint8_t { Root, Locations, References };
 
   /// How a caller-provided default identifier relates to the one that the
   /// schema declares, if any
@@ -197,6 +197,11 @@ public:
   /// Get the root schema identifier (empty if none)
   [[nodiscard]] auto root() const noexcept
       -> const sourcemeta::core::JSON::String &;
+
+  /// Get the location entry of the schema that was analysed. Unlike
+  /// sourcemeta::blaze::SchemaFrame::root, this works for anonymous schemas
+  [[nodiscard]] auto root_location() const
+      -> std::optional<std::reference_wrapper<const Location>>;
 
   /// Get the vocabularies associated with a location entry
   [[nodiscard]] auto vocabularies(const Location &location,

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4252,3 +4252,64 @@ TEST(root_location_without_analysis) {
   EXPECT_TRUE(frame.empty());
   EXPECT_FALSE(frame.root_location().has_value());
 }
+
+TEST(root_mode_embedded_custom_metaschema) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://example.com/meta",
+    "$defs": {
+      "https://example.com/meta": {
+        "$id": "https://example.com/meta",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": {
+          "https://json-schema.org/draft/2020-12/vocab/core": true,
+          "https://example.com/vocab/custom": true
+        }
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.root(), "https://example.com/schema");
+  EXPECT_EQ(frame.locations().size(), 1);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().dialect, "https://example.com/meta");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+
+  const auto result{frame.vocabularies(location.value().get(),
+                                       sourcemeta::blaze::schema_resolver)};
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.has_unknown());
+
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Core);
+  EXPECT_TRUE(result.contains("https://example.com/vocab/custom"));
+  EXPECT_TRUE(result.get("https://example.com/vocab/custom").value());
+}
+
+TEST(root_mode_identifier_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com#foo",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers must not contain non-empty fragments");
+    EXPECT_EQ(error.identifier(), "https://example.com#foo");
+  }
+}

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4313,3 +4313,71 @@ TEST(root_mode_identifier_with_non_empty_fragment) {
     EXPECT_EQ(error.identifier(), "https://example.com#foo");
   }
 }
+
+TEST(root_mode_single_container_yields_nothing) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "wrapper": {
+      "$id": "https://example.com",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  const sourcemeta::core::Pointer wrapper_path{"wrapper"};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+                {sourcemeta::core::to_weak_pointer(wrapper_path)});
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_TRUE(frame.root().empty());
+  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_EQ(frame.references().size(), 0);
+  EXPECT_FALSE(frame.root_location().has_value());
+}
+
+TEST(root_mode_multiple_containers_yield_nothing) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "a": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string"
+    },
+    "b": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "number"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  const sourcemeta::core::Pointer path_a{"a"};
+  const sourcemeta::core::Pointer path_b{"b"};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+                {sourcemeta::core::to_weak_pointer(path_a),
+                 sourcemeta::core::to_weak_pointer(path_b)});
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_FALSE(frame.root_location().has_value());
+}
+
+TEST(root_mode_zero_containers_yields_nothing) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional, {});
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_FALSE(frame.root_location().has_value());
+}

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4081,3 +4081,174 @@ TEST(no_id_with_default_id_fallback_mode) {
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
 }
+
+TEST(root_mode_with_identifier) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.mode(), sourcemeta::blaze::SchemaFrame::Mode::Root);
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "", std::nullopt, false, false);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
+}
+
+TEST(root_mode_anonymous) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_TRUE(frame.root().empty());
+  EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
+  EXPECT_FALSE(location.value().get().parent.has_value());
+}
+
+TEST(root_mode_with_default_id_fallback) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "https://other.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
+
+  EXPECT_EQ(frame.root(), "https://other.com");
+  EXPECT_EQ(frame.locations().size(), 1);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://other.com", "https://other.com", "",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://other.com", "", std::nullopt, false, false);
+}
+
+TEST(root_mode_draft7) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 1);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().dialect,
+            "http://json-schema.org/draft-07/schema#");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+}
+
+TEST(root_mode_vocabularies) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+
+  const auto result{frame.vocabularies(location.value().get(),
+                                       sourcemeta::blaze::schema_resolver)};
+
+  EXPECT_EQ(result.size(), 7);
+  EXPECT_FALSE(result.has_unknown());
+
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Applicator);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Unevaluated);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Validation);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Meta_Data);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Format_Annotation);
+  EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Content);
+}
+
+TEST(root_location_in_references_mode) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+}
+
+TEST(root_location_without_analysis) {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_FALSE(frame.root_location().has_value());
+}

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4314,7 +4314,7 @@ TEST(root_mode_identifier_with_non_empty_fragment) {
   }
 }
 
-TEST(root_mode_single_container_yields_nothing) {
+TEST(root_mode_single_container_with_identifier) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "wrapper": {
       "$id": "https://example.com",
@@ -4331,11 +4331,75 @@ TEST(root_mode_single_container_yields_nothing) {
                 sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
                 {sourcemeta::core::to_weak_pointer(wrapper_path)});
 
-  EXPECT_TRUE(frame.empty());
-  EXPECT_TRUE(frame.root().empty());
-  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_FALSE(frame.empty());
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 1);
   EXPECT_EQ(frame.references().size(), 0);
-  EXPECT_FALSE(frame.root_location().has_value());
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com", "https://example.com", "/wrapper",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://example.com", "", std::nullopt, false, false);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+}
+
+TEST(root_mode_single_container_anonymous) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "wrapper": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  const sourcemeta::core::Pointer wrapper_path{"wrapper"};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+                {sourcemeta::core::to_weak_pointer(wrapper_path)});
+
+  EXPECT_FALSE(frame.empty());
+  EXPECT_TRUE(frame.root().empty());
+  EXPECT_EQ(frame.locations().size(), 1);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
+  EXPECT_EQ(location.value().get().dialect,
+            "http://json-schema.org/draft-07/schema#");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+}
+
+TEST(root_mode_single_container_with_default_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "wrapper": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  const sourcemeta::core::Pointer wrapper_path{"wrapper"};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, "", "https://other.com",
+                sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback,
+                {sourcemeta::core::to_weak_pointer(wrapper_path)});
+
+  EXPECT_EQ(frame.root(), "https://other.com");
+  EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_TRUE(frame.root_location().has_value());
 }
 
 TEST(root_mode_multiple_containers_yield_nothing) {

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4097,6 +4097,7 @@ TEST(root_mode_with_identifier) {
                 sourcemeta::blaze::schema_resolver);
 
   EXPECT_EQ(frame.mode(), sourcemeta::blaze::SchemaFrame::Mode::Root);
+  EXPECT_FALSE(frame.empty());
   EXPECT_EQ(frame.root(), "https://example.com");
   EXPECT_EQ(frame.locations().size(), 1);
   EXPECT_EQ(frame.references().size(), 0);
@@ -4108,13 +4109,16 @@ TEST(root_mode_with_identifier) {
 
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://example.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer), "");
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
   EXPECT_EQ(location.value().get().dialect,
             "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
-  EXPECT_EQ(location.value().get().type,
-            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
-  EXPECT_FALSE(location.value().get().parent.has_value());
   EXPECT_FALSE(location.value().get().property_name);
   EXPECT_FALSE(location.value().get().orphan);
 }
@@ -4132,19 +4136,29 @@ TEST(root_mode_anonymous) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver);
 
+  EXPECT_FALSE(frame.empty());
   EXPECT_TRUE(frame.root().empty());
   EXPECT_EQ(frame.locations().size(), 1);
   EXPECT_EQ(frame.references().size(), 0);
 
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "https://json-schema.org/draft/2020-12/schema",
+      JSON_Schema_2020_12, std::nullopt, false, false);
+
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
+  EXPECT_EQ(location.value().get().base, "");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer), "");
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
   EXPECT_EQ(location.value().get().dialect,
             "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
-  EXPECT_EQ(location.value().get().type,
-            sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
-  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
 TEST(root_mode_with_default_id_fallback) {
@@ -4159,13 +4173,30 @@ TEST(root_mode_with_default_id_fallback) {
                 sourcemeta::blaze::schema_resolver, "", "https://other.com",
                 sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
 
+  EXPECT_FALSE(frame.empty());
   EXPECT_EQ(frame.root(), "https://other.com");
   EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
 
   EXPECT_FRAME_STATIC_RESOURCE(
       frame, "https://other.com", "https://other.com", "",
       "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
       "https://other.com", "", std::nullopt, false, false);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://other.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer), "");
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
 TEST(root_mode_draft7) {
@@ -4182,15 +4213,30 @@ TEST(root_mode_draft7) {
   frame.analyse(document, sourcemeta::blaze::schema_walker,
                 sourcemeta::blaze::schema_resolver);
 
+  EXPECT_FALSE(frame.empty());
   EXPECT_EQ(frame.root(), "https://example.com");
   EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "http://json-schema.org/draft-07/schema#", JSON_Schema_Draft_7,
+      "https://example.com", "", std::nullopt, false, false);
 
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://example.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer), "");
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
   EXPECT_EQ(location.value().get().dialect,
             "http://json-schema.org/draft-07/schema#");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
 TEST(root_mode_vocabularies) {
@@ -4223,36 +4269,6 @@ TEST(root_mode_vocabularies) {
   EXPECT_VOCABULARY_REQUIRED(result, JSON_Schema_2020_12_Content);
 }
 
-TEST(root_location_in_references_mode) {
-  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "additionalProperties": {
-      "type": "string"
-    }
-  })JSON");
-
-  sourcemeta::blaze::SchemaFrame frame{
-      sourcemeta::blaze::SchemaFrame::Mode::References};
-  frame.analyse(document, sourcemeta::blaze::schema_walker,
-                sourcemeta::blaze::schema_resolver);
-
-  const auto location{frame.root_location()};
-  EXPECT_TRUE(location.has_value());
-  EXPECT_EQ(location.value().get().type,
-            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
-  EXPECT_EQ(location.value().get().dialect,
-            "https://json-schema.org/draft/2020-12/schema");
-}
-
-TEST(root_location_without_analysis) {
-  sourcemeta::blaze::SchemaFrame frame{
-      sourcemeta::blaze::SchemaFrame::Mode::Root};
-
-  EXPECT_TRUE(frame.empty());
-  EXPECT_FALSE(frame.root_location().has_value());
-}
-
 TEST(root_mode_embedded_custom_metaschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/schema",
@@ -4276,12 +4292,21 @@ TEST(root_mode_embedded_custom_metaschema) {
 
   EXPECT_EQ(frame.root(), "https://example.com/schema");
   EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://example.com/schema", "https://example.com/schema", "",
+      "https://example.com/meta", JSON_Schema_2020_12,
+      "https://example.com/schema", "", std::nullopt, false, false);
 
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
   EXPECT_EQ(location.value().get().dialect, "https://example.com/meta");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
 
   const auto result{frame.vocabularies(location.value().get(),
                                        sourcemeta::blaze::schema_resolver)};
@@ -4343,12 +4368,19 @@ TEST(root_mode_single_container_with_identifier) {
 
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
   EXPECT_EQ(location.value().get().type,
             sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://example.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer),
+            "/wrapper");
+  EXPECT_EQ(location.value().get().relative_pointer, 1);
   EXPECT_EQ(location.value().get().dialect,
             "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
 TEST(root_mode_single_container_anonymous) {
@@ -4370,18 +4402,30 @@ TEST(root_mode_single_container_anonymous) {
   EXPECT_FALSE(frame.empty());
   EXPECT_TRUE(frame.root().empty());
   EXPECT_EQ(frame.locations().size(), 1);
+  EXPECT_EQ(frame.references().size(), 0);
+
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "/wrapper", "http://json-schema.org/draft-07/schema#",
+      JSON_Schema_Draft_7, std::nullopt, false, false);
 
   const auto location{frame.root_location()};
   EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
   EXPECT_EQ(location.value().get().type,
             sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
+  EXPECT_EQ(location.value().get().base, "");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer),
+            "/wrapper");
+  EXPECT_EQ(location.value().get().relative_pointer, 1);
   EXPECT_EQ(location.value().get().dialect,
             "http://json-schema.org/draft-07/schema#");
   EXPECT_EQ(location.value().get().base_dialect,
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
-TEST(root_mode_single_container_with_default_id) {
+TEST(root_mode_single_container_with_default_id_fallback) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "wrapper": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -4397,18 +4441,42 @@ TEST(root_mode_single_container_with_default_id) {
                 sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback,
                 {sourcemeta::core::to_weak_pointer(wrapper_path)});
 
+  EXPECT_FALSE(frame.empty());
   EXPECT_EQ(frame.root(), "https://other.com");
   EXPECT_EQ(frame.locations().size(), 1);
-  EXPECT_TRUE(frame.root_location().has_value());
+  EXPECT_EQ(frame.references().size(), 0);
+
+  EXPECT_FRAME_STATIC_RESOURCE(
+      frame, "https://other.com", "https://other.com", "/wrapper",
+      "https://json-schema.org/draft/2020-12/schema", JSON_Schema_2020_12,
+      "https://other.com", "", std::nullopt, false, false);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://other.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer),
+            "/wrapper");
+  EXPECT_EQ(location.value().get().relative_pointer, 1);
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
 }
 
 TEST(root_mode_multiple_containers_yield_nothing) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "a": {
+      "$id": "https://example.com/a",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "string"
     },
     "b": {
+      "$id": "https://example.com/b",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "number"
     }
@@ -4425,11 +4493,15 @@ TEST(root_mode_multiple_containers_yield_nothing) {
                  sourcemeta::core::to_weak_pointer(path_b)});
 
   EXPECT_TRUE(frame.empty());
+  EXPECT_TRUE(frame.root().empty());
   EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_EQ(frame.references().size(), 0);
   EXPECT_FALSE(frame.root_location().has_value());
+  EXPECT_FALSE(frame.traverse("https://example.com/a").has_value());
+  EXPECT_FALSE(frame.traverse("https://example.com/b").has_value());
 }
 
-TEST(root_mode_zero_containers_yields_nothing) {
+TEST(root_mode_zero_containers_yield_nothing) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com",
     "$schema": "https://json-schema.org/draft/2020-12/schema"
@@ -4442,6 +4514,53 @@ TEST(root_mode_zero_containers_yields_nothing) {
                 sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional, {});
 
   EXPECT_TRUE(frame.empty());
+  EXPECT_TRUE(frame.root().empty());
   EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_EQ(frame.references().size(), 0);
+  EXPECT_FALSE(frame.root_location().has_value());
+  EXPECT_FALSE(frame.traverse("https://example.com").has_value());
+}
+
+TEST(root_location_in_references_mode) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": {
+      "type": "string"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  EXPECT_EQ(frame.root(), "https://example.com");
+  EXPECT_EQ(frame.locations().size(), 5);
+
+  const auto location{frame.root_location()};
+  EXPECT_TRUE(location.has_value());
+  EXPECT_FALSE(location.value().get().parent.has_value());
+  EXPECT_EQ(location.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ(location.value().get().base, "https://example.com");
+  EXPECT_EQ(sourcemeta::core::to_string(location.value().get().pointer), "");
+  EXPECT_EQ(location.value().get().relative_pointer, 0);
+  EXPECT_EQ(location.value().get().dialect,
+            "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(location.value().get().base_dialect,
+            sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12);
+  EXPECT_FALSE(location.value().get().property_name);
+  EXPECT_FALSE(location.value().get().orphan);
+}
+
+TEST(root_location_without_analysis) {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+
+  EXPECT_TRUE(frame.empty());
+  EXPECT_TRUE(frame.root().empty());
+  EXPECT_EQ(frame.locations().size(), 0);
+  EXPECT_EQ(frame.references().size(), 0);
   EXPECT_FALSE(frame.root_location().has_value());
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

