### PR TITLE
Let `SchemaFrame` own the vocabularies it hands out

### DIFF
--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -102,7 +102,7 @@ auto WALK_UP(const JSON &root, const SchemaFrame &frame,
     assert(!relative_pointer.empty() && relative_pointer.at(0).is_property());
     const auto parent{frame.traverse(frame.uri(parent_pointer).value().get())};
     assert(parent.has_value());
-    const auto parent_vocabularies{
+    const auto &parent_vocabularies{
         frame.vocabularies(parent.value().get(), resolver)};
     const auto keyword_type{
         walker(relative_pointer.at(0).to_property(), parent_vocabularies).type};

--- a/src/alterschema/transformer.cc
+++ b/src/alterschema/transformer.cc
@@ -75,7 +75,8 @@ auto check_rules(
     subschema_count += 1;
 
     const auto &current{sourcemeta::core::get(schema, entry_pointer)};
-    const auto current_vocabularies{frame.vocabularies(entry.second, resolver)};
+    const auto &current_vocabularies{
+        frame.vocabularies(entry.second, resolver)};
 
     bool subschema_failed{false};
     for (const auto &[rule, mutates, _] : rules) {

--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -310,7 +310,7 @@ private:
       if (!subschema.is_object() || !subschema.defines("unevaluatedItems")) {
         continue;
       }
-      const auto location_vocabularies{
+      const auto &location_vocabularies{
           frame.vocabularies(entry.second, resolver)};
       const auto &keyword_metadata{
           walker("unevaluatedItems", location_vocabularies)};

--- a/src/canonicalizer/helpers.h
+++ b/src/canonicalizer/helpers.h
@@ -64,7 +64,7 @@ auto WALK_UP(const sourcemeta::core::JSON &root, const SchemaFrame &frame,
     assert(!relative_pointer.empty() && relative_pointer.at(0).is_property());
     const auto parent{frame.traverse(frame.uri(parent_pointer).value().get())};
     assert(parent.has_value());
-    const auto parent_vocabularies{
+    const auto &parent_vocabularies{
         frame.vocabularies(parent.value().get(), resolver)};
     const auto keyword_type{
         walker(relative_pointer.at(0).to_property(), parent_vocabularies).type};

--- a/src/canonicalizer/rules/type_inherit_in_place.h
+++ b/src/canonicalizer/rules/type_inherit_in_place.h
@@ -78,7 +78,7 @@ public:
       if (!walk_entry.has_value()) {
         break;
       }
-      const auto walk_vocabularies{
+      const auto &walk_vocabularies{
           frame.vocabularies(walk_entry.value().get(), resolver)};
       const auto walk_keyword_type{
           walker(walk_relative.at(0).to_property(), walk_vocabularies).type};

--- a/src/canonicalizer/rules/type_union_implicit.h
+++ b/src/canonicalizer/rules/type_union_implicit.h
@@ -89,7 +89,7 @@ private:
       if (!walk_entry.has_value()) {
         break;
       }
-      const auto walk_vocabularies{
+      const auto &walk_vocabularies{
           frame.vocabularies(walk_entry.value().get(), resolver)};
       const auto walk_keyword_type{
           walker(walk_relative.at(0).to_property(), walk_vocabularies).type};

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -35,7 +35,7 @@ auto is_validation_subschema(
     return false;
   }
 
-  const auto vocabularies{
+  const auto &vocabularies{
       frame.vocabularies(parent_location.value().get(), resolver)};
   const auto &walker_result{walker(keyword_token.to_property(), vocabularies)};
   using Type = sourcemeta::blaze::SchemaKeywordType;

--- a/src/codegen/codegen_default_compiler.h
+++ b/src/codegen/codegen_default_compiler.h
@@ -680,7 +680,7 @@ auto default_compiler(const sourcemeta::core::JSON &schema,
                       const sourcemeta::blaze::SchemaResolver &resolver,
                       const sourcemeta::core::JSON &subschema)
     -> CodegenIREntity {
-  const auto vocabularies{frame.vocabularies(location, resolver)};
+  const auto &vocabularies{frame.vocabularies(location, resolver)};
   assert(!vocabularies.empty());
 
   // Be strict with vocabulary support

--- a/src/compiler/unevaluated.cc
+++ b/src/compiler/unevaluated.cc
@@ -24,7 +24,7 @@ auto find_adjacent_dependencies(
     return;
   }
 
-  const auto subschema_vocabularies{frame.vocabularies(entry, resolver)};
+  const auto &subschema_vocabularies{frame.vocabularies(entry, resolver)};
 
   for (const auto &property : subschema.as_object()) {
     if (property.first == current && entry.pointer == root.pointer) {
@@ -215,7 +215,7 @@ auto unevaluated(const JSON &schema, const SchemaFrame &frame,
       continue;
     }
 
-    const auto subschema_vocabularies{
+    const auto &subschema_vocabularies{
         frame.vocabularies(entry.second, resolver)};
 
     // The same pointer may be reachable through alternate identifiers whose

--- a/src/editor/editor.cc
+++ b/src/editor/editor.cc
@@ -185,7 +185,7 @@ auto for_editor(sourcemeta::core::JSON &schema,
 
       const bool add_schema =
           entry.second.pointer.empty() && !subschema.defines("$schema");
-      const auto vocabularies{frame.vocabularies(entry.second, resolver)};
+      const auto &vocabularies{frame.vocabularies(entry.second, resolver)};
 
       subschema_changes.push_back(
           {.pointer = sourcemeta::core::to_pointer(entry.second.pointer),

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -1400,26 +1400,37 @@ auto SchemaFrame::root() const noexcept
 
 auto SchemaFrame::vocabularies(const Location &location,
                                const SchemaResolver &resolver) const
-    -> Vocabularies {
+    -> const Vocabularies & {
+  const std::pair<SchemaBaseDialect, std::string_view> key{
+      location.base_dialect, location.dialect};
+  const auto match{this->vocabularies_.find(key)};
+  if (match != this->vocabularies_.cend()) {
+    return match->second;
+  }
+
   if (this->probed_metaschemas_.empty()) {
-    return sourcemeta::blaze::vocabularies(resolver, location.base_dialect,
-                                           location.dialect);
+    return this->vocabularies_
+        .emplace(key, sourcemeta::blaze::vocabularies(
+                          resolver, location.base_dialect, location.dialect))
+        .first->second;
   }
 
   // Meta-schemas embedded in the analysed document take precedence
   // over what the caller's resolver knows about
-  return sourcemeta::blaze::vocabularies(
-      [this, &resolver](const std::string_view identifier)
-          -> std::optional<sourcemeta::core::JSON> {
-        const auto hit{this->probed_metaschemas_.find(
-            sourcemeta::core::JSON::String{identifier})};
-        if (hit != this->probed_metaschemas_.cend()) {
-          return *(hit->second);
-        }
+  return this->vocabularies_
+      .emplace(key, sourcemeta::blaze::vocabularies(
+                        [this, &resolver](const std::string_view identifier)
+                            -> std::optional<sourcemeta::core::JSON> {
+                          const auto hit{this->probed_metaschemas_.find(
+                              sourcemeta::core::JSON::String{identifier})};
+                          if (hit != this->probed_metaschemas_.cend()) {
+                            return *(hit->second);
+                          }
 
-        return resolver(identifier);
-      },
-      location.base_dialect, location.dialect);
+                          return resolver(identifier);
+                        },
+                        location.base_dialect, location.dialect))
+      .first->second;
 }
 
 auto SchemaFrame::uri(
@@ -1671,6 +1682,7 @@ auto SchemaFrame::reset() -> void {
   this->locations_.clear();
   this->references_.clear();
   this->probed_metaschemas_.clear();
+  this->vocabularies_.clear();
   this->standalone_ = false;
 }
 

--- a/src/frame/frame.cc
+++ b/src/frame/frame.cc
@@ -1401,36 +1401,36 @@ auto SchemaFrame::root() const noexcept
 auto SchemaFrame::vocabularies(const Location &location,
                                const SchemaResolver &resolver) const
     -> const Vocabularies & {
-  const std::pair<SchemaBaseDialect, std::string_view> key{
-      location.base_dialect, location.dialect};
-  const auto match{this->vocabularies_.find(key)};
-  if (match != this->vocabularies_.cend()) {
-    return match->second;
+  for (const auto &entry : this->vocabularies_) {
+    if (std::get<0>(entry) == location.base_dialect &&
+        std::get<1>(entry) == location.dialect) {
+      return std::get<2>(entry);
+    }
   }
 
   if (this->probed_metaschemas_.empty()) {
-    return this->vocabularies_
-        .emplace(key, sourcemeta::blaze::vocabularies(
-                          resolver, location.base_dialect, location.dialect))
-        .first->second;
+    return std::get<2>(this->vocabularies_.emplace_back(
+        location.base_dialect, location.dialect,
+        sourcemeta::blaze::vocabularies(resolver, location.base_dialect,
+                                        location.dialect)));
   }
 
   // Meta-schemas embedded in the analysed document take precedence
   // over what the caller's resolver knows about
-  return this->vocabularies_
-      .emplace(key, sourcemeta::blaze::vocabularies(
-                        [this, &resolver](const std::string_view identifier)
-                            -> std::optional<sourcemeta::core::JSON> {
-                          const auto hit{this->probed_metaschemas_.find(
-                              sourcemeta::core::JSON::String{identifier})};
-                          if (hit != this->probed_metaschemas_.cend()) {
-                            return *(hit->second);
-                          }
+  return std::get<2>(this->vocabularies_.emplace_back(
+      location.base_dialect, location.dialect,
+      sourcemeta::blaze::vocabularies(
+          [this, &resolver](const std::string_view identifier)
+              -> std::optional<sourcemeta::core::JSON> {
+            const auto hit{this->probed_metaschemas_.find(
+                sourcemeta::core::JSON::String{identifier})};
+            if (hit != this->probed_metaschemas_.cend()) {
+              return *(hit->second);
+            }
 
-                          return resolver(identifier);
-                        },
-                        location.base_dialect, location.dialect))
-      .first->second;
+            return resolver(identifier);
+          },
+          location.base_dialect, location.dialect)));
 }
 
 auto SchemaFrame::uri(

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -205,10 +205,11 @@ public:
   [[nodiscard]] auto root_location() const
       -> std::optional<std::reference_wrapper<const Location>>;
 
-  /// Get the vocabularies associated with a location entry
+  /// Get the vocabularies associated with a location entry. The frame owns
+  /// the result, computing it at most once per dialect that it came across
   [[nodiscard]] auto vocabularies(const Location &location,
                                   const SchemaResolver &resolver) const
-      -> Vocabularies;
+      -> const Vocabularies &;
 
   /// Get the URI associated with a location entry
   [[nodiscard]] auto
@@ -321,6 +322,10 @@ private:
   std::unordered_map<sourcemeta::core::JSON::String,
                      const sourcemeta::core::JSON *>
       probed_metaschemas_;
+  // Vocabularies are a function of the base dialect and dialect alone, and a
+  // schema only tends to make use of a handful of those
+  mutable std::map<std::pair<SchemaBaseDialect, std::string_view>, Vocabularies>
+      vocabularies_;
   mutable std::unordered_map<
       std::reference_wrapper<const sourcemeta::core::WeakPointer>,
       std::vector<const Location *>, sourcemeta::core::WeakPointer::Hasher,

--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -25,6 +25,7 @@
 
 #include <concepts>      // std::invocable
 #include <cstdint>       // std::uint8_t
+#include <deque>         // std::deque
 #include <functional>    // std::reference_wrapper
 #include <map>           // std::map
 #include <optional>      // std::optional
@@ -206,7 +207,10 @@ public:
       -> std::optional<std::reference_wrapper<const Location>>;
 
   /// Get the vocabularies associated with a location entry. The frame owns
-  /// the result, computing it at most once per dialect that it came across
+  /// the result, computing it at most once per dialect that it came across.
+  /// Note that as with the meta-schemas that `analyse` found embedded in the
+  /// document, what the first resolver reported for a given dialect is what
+  /// every later call reports, whichever resolver they pass
   [[nodiscard]] auto vocabularies(const Location &location,
                                   const SchemaResolver &resolver) const
       -> const Vocabularies &;
@@ -323,8 +327,13 @@ private:
                      const sourcemeta::core::JSON *>
       probed_metaschemas_;
   // Vocabularies are a function of the base dialect and dialect alone, and a
-  // schema only tends to make use of a handful of those
-  mutable std::map<std::pair<SchemaBaseDialect, std::string_view>, Vocabularies>
+  // schema only tends to make use of a handful of those. We own the dialect
+  // that we key on, as the view that the location holds may point into a
+  // default dialect that the caller of `analyse` only kept around for the
+  // duration of that call. A deque, as handing out references to the
+  // vocabularies means they must survive later insertions
+  mutable std::deque<std::tuple<SchemaBaseDialect,
+                                sourcemeta::core::JSON::String, Vocabularies>>
       vocabularies_;
   mutable std::unordered_map<
       std::reference_wrapper<const sourcemeta::core::WeakPointer>,

--- a/test/frame/frame_test.cc
+++ b/test/frame/frame_test.cc
@@ -4564,3 +4564,44 @@ TEST(root_location_without_analysis) {
   EXPECT_EQ(frame.references().size(), 0);
   EXPECT_FALSE(frame.root_location().has_value());
 }
+
+TEST(vocabularies_reference_survives_later_dialects) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "older": {
+        "$id": "https://example.com/older",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  const auto root{frame.traverse("https://example.com")};
+  EXPECT_TRUE(root.has_value());
+  const auto &first{
+      frame.vocabularies(root->get(), sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(first.size(), 7);
+
+  const auto older{frame.traverse("https://example.com/older")};
+  EXPECT_TRUE(older.has_value());
+  const auto &second{
+      frame.vocabularies(older->get(), sourcemeta::blaze::schema_resolver)};
+  EXPECT_EQ(second.size(), 1);
+
+  EXPECT_EQ(first.size(), 7);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Core);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Applicator);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Unevaluated);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Validation);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Meta_Data);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Format_Annotation);
+  EXPECT_VOCABULARY_REQUIRED(first, JSON_Schema_2020_12_Content);
+  EXPECT_VOCABULARY_REQUIRED(second, JSON_Schema_Draft_7);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

