### PR TITLE
Better describe `SchemaFrame` ownership rules

### DIFF
--- a/src/frame/include/sourcemeta/blaze/frame.h
+++ b/src/frame/include/sourcemeta/blaze/frame.h
@@ -174,6 +174,12 @@ public:
 
   /// Analyse a schema or set of schemas from a given root. Passing
   /// multiple paths that have any overlap is undefined behaviour
+  ///
+  /// The resulting locations point into the schema rather than copying from
+  /// it, so the schema must outlive the frame. The same goes for
+  /// `default_dialect`, as a location that has no dialect of its own reports
+  /// the default back as a view into what the caller passed. In contrast,
+  /// `default_id` is copied, so it does not need to outlive this call
   auto analyse(const sourcemeta::core::JSON &root, const SchemaWalker &walker,
                const SchemaResolver &resolver,
                std::string_view default_dialect = "",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

