### PR TITLE
Revise `TraceOutput` to make it usable by One

### DIFF
--- a/src/output/include/sourcemeta/blaze/output_trace.h
+++ b/src/output/include/sourcemeta/blaze/output_trace.h
@@ -61,6 +61,12 @@ namespace sourcemeta::blaze {
 /// ```
 class SOURCEMETA_BLAZE_OUTPUT_EXPORT TraceOutput {
 public:
+  /// The kind of entry being reported. Note that an entry of type
+  /// sourcemeta::blaze::TraceOutput::EntryType::Annotation always corresponds
+  /// to a successful step, as the evaluator reports annotations as valid by
+  /// construction. Every other type maps to validity as you would expect,
+  /// which is how a consumer recovers what
+  /// sourcemeta::blaze::describe expects
   enum class EntryType : std::uint8_t { Push, Pass, Fail, Annotation };
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
@@ -68,6 +74,9 @@ public:
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     const EntryType type;
     const std::string_view name;
+    /// The instruction that produced this entry, for describing it with
+    /// sourcemeta::blaze::describe or with a describer of your own
+    const Instruction &step;
     const sourcemeta::core::WeakPointer &instance_location;
     const sourcemeta::core::WeakPointer &evaluate_path;
     const std::string_view keyword_location;
@@ -80,6 +89,14 @@ public:
   // TODO(C++23): Use std::move_only_function when available in libc++
   using Callback = std::function<void(const Entry &)>;
 
+  /// Answer with the previously exported locations of a schema, given its
+  /// identifier. Tracing may cross into schemas other than the one it started
+  /// from, so this is how it asks about them without having to analyse
+  /// anything. The expected value is the `locations` member of what
+  /// sourcemeta::blaze::SchemaFrame::to_json produces
+  using FrameResolverJSON = std::function<std::optional<
+      std::reference_wrapper<const sourcemeta::core::JSON>>(std::string_view)>;
+
   TraceOutput(
       sourcemeta::blaze::SchemaWalker walker,
       sourcemeta::blaze::SchemaResolver resolver, Callback callback,
@@ -87,6 +104,19 @@ public:
       const std::optional<
           std::reference_wrapper<const sourcemeta::blaze::SchemaFrame>> &frame =
           std::nullopt);
+
+  /// Report vocabularies out of previously exported frames, for callers that
+  /// hold those rather than a live schema frame
+  TraceOutput(sourcemeta::blaze::SchemaWalker walker,
+              sourcemeta::blaze::SchemaResolver resolver, Callback callback,
+              sourcemeta::core::WeakPointer base, FrameResolverJSON frames);
+
+  /// Answer out of a single exported set of locations, no matter the schema
+  /// that is being asked about. A keyword location that the given export does
+  /// not know about goes unanswered, the same way that a live schema frame
+  /// that cannot traverse to it does
+  [[nodiscard]] static auto frames(const sourcemeta::core::JSON &locations)
+      -> FrameResolverJSON;
 
   // Prevent accidental copies
   TraceOutput(const TraceOutput &) = delete;
@@ -112,6 +142,7 @@ private:
   const std::optional<
       std::reference_wrapper<const sourcemeta::blaze::SchemaFrame>>
       frame_;
+  const FrameResolverJSON frames_;
   Callback callback_;
   std::vector<
       std::pair<bool, std::optional<sourcemeta::blaze::Vocabularies::URI>>>

--- a/src/output/include/sourcemeta/blaze/output_trace.h
+++ b/src/output/include/sourcemeta/blaze/output_trace.h
@@ -61,12 +61,7 @@ namespace sourcemeta::blaze {
 /// ```
 class SOURCEMETA_BLAZE_OUTPUT_EXPORT TraceOutput {
 public:
-  /// The kind of entry being reported. Note that an entry of type
-  /// sourcemeta::blaze::TraceOutput::EntryType::Annotation always corresponds
-  /// to a successful step, as the evaluator reports annotations as valid by
-  /// construction. Every other type maps to validity as you would expect,
-  /// which is how a consumer recovers what
-  /// sourcemeta::blaze::describe expects
+  /// The kind of entry being reported. Annotations are always valid
   enum class EntryType : std::uint8_t { Push, Pass, Fail, Annotation };
 
   // NOLINTNEXTLINE(bugprone-exception-escape)
@@ -74,8 +69,7 @@ public:
     // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
     const EntryType type;
     const std::string_view name;
-    /// The instruction that produced this entry, for describing it with
-    /// sourcemeta::blaze::describe or with a describer of your own
+    /// The instruction that produced this entry
     const Instruction &step;
     const sourcemeta::core::WeakPointer &instance_location;
     const sourcemeta::core::WeakPointer &evaluate_path;
@@ -89,11 +83,7 @@ public:
   // TODO(C++23): Use std::move_only_function when available in libc++
   using Callback = std::function<void(const Entry &)>;
 
-  /// Answer with the previously exported locations of a schema, given its
-  /// identifier. Tracing may cross into schemas other than the one it started
-  /// from, so this is how it asks about them without having to analyse
-  /// anything. The expected value is the `locations` member of what
-  /// sourcemeta::blaze::SchemaFrame::to_json produces
+  /// Given a schema identifier, answer with its previously exported locations
   using FrameResolverJSON = std::function<std::optional<
       std::reference_wrapper<const sourcemeta::core::JSON>>(std::string_view)>;
 
@@ -105,8 +95,7 @@ public:
           std::reference_wrapper<const sourcemeta::blaze::SchemaFrame>> &frame =
           std::nullopt);
 
-  /// Report vocabularies out of previously exported frames, for callers that
-  /// hold those rather than a live schema frame
+  /// Report vocabularies out of previously exported frames
   TraceOutput(sourcemeta::blaze::SchemaWalker walker,
               sourcemeta::blaze::SchemaResolver resolver, Callback callback,
               sourcemeta::core::WeakPointer base, FrameResolverJSON frames);

--- a/src/output/include/sourcemeta/blaze/output_trace.h
+++ b/src/output/include/sourcemeta/blaze/output_trace.h
@@ -111,13 +111,6 @@ public:
               sourcemeta::blaze::SchemaResolver resolver, Callback callback,
               sourcemeta::core::WeakPointer base, FrameResolverJSON frames);
 
-  /// Answer out of a single exported set of locations, no matter the schema
-  /// that is being asked about. A keyword location that the given export does
-  /// not know about goes unanswered, the same way that a live schema frame
-  /// that cannot traverse to it does
-  [[nodiscard]] static auto frames(const sourcemeta::core::JSON &locations)
-      -> FrameResolverJSON;
-
   // Prevent accidental copies
   TraceOutput(const TraceOutput &) = delete;
   auto operator=(const TraceOutput &) -> TraceOutput & = delete;

--- a/src/output/output_trace.cc
+++ b/src/output/output_trace.cc
@@ -6,9 +6,8 @@
 #include <utility> // std::move, std::to_underlying
 #include <variant> // std::visit
 
-// The locations that a schema frame exports are keyed by keyword location, but
-// a resolver that answers out of previously exported frames is keyed by the
-// schema those locations belong to, which is the part before the fragment
+// Exported locations are keyed by keyword location, but the frame resolver is
+// keyed by the schema those locations belong to
 static auto schema_of(const std::string &keyword_location) -> std::string_view {
   const auto fragment{keyword_location.find('#')};
   return fragment == std::string::npos
@@ -47,9 +46,7 @@ static auto try_vocabulary_from_export(
     return {false, std::nullopt};
   }
 
-  // An export can name a dialect that the caller's resolver knows nothing
-  // about, as it may have been produced elsewhere. Treat that as not knowing
-  // the vocabulary, like every other case we cannot make sense of
+  // An export produced elsewhere may name a dialect we cannot resolve
   try {
     const auto vocabularies{sourcemeta::blaze::vocabularies(
         resolver, base_dialect.value(), entry.at("dialect").to_string())};

--- a/src/output/output_trace.cc
+++ b/src/output/output_trace.cc
@@ -47,10 +47,18 @@ static auto try_vocabulary_from_export(
     return {false, std::nullopt};
   }
 
-  const auto vocabularies{sourcemeta::blaze::vocabularies(
-      resolver, base_dialect.value(), entry.at("dialect").to_string())};
-  const auto &result{walker(evaluate_path.back().to_property(), vocabularies)};
-  return {true, result.vocabulary};
+  // An export can name a dialect that the caller's resolver knows nothing
+  // about, as it may have been produced elsewhere. Treat that as not knowing
+  // the vocabulary, like every other case we cannot make sense of
+  try {
+    const auto vocabularies{sourcemeta::blaze::vocabularies(
+        resolver, base_dialect.value(), entry.at("dialect").to_string())};
+    const auto &result{
+        walker(evaluate_path.back().to_property(), vocabularies)};
+    return {true, result.vocabulary};
+  } catch (const sourcemeta::blaze::SchemaResolutionError &) {
+    return {false, std::nullopt};
+  }
 }
 
 static auto try_vocabulary(
@@ -104,15 +112,6 @@ TraceOutput::TraceOutput(sourcemeta::blaze::SchemaWalker walker,
     : walker_{std::move(walker)}, resolver_{std::move(resolver)},
       base_{std::move(base)}, frame_{std::nullopt}, frames_{std::move(frames)},
       callback_{std::move(callback)} {}
-
-auto TraceOutput::frames(const sourcemeta::core::JSON &locations)
-    -> FrameResolverJSON {
-  return [&locations](const std::string_view)
-             -> std::optional<
-                 std::reference_wrapper<const sourcemeta::core::JSON>> {
-    return std::cref(locations);
-  };
-}
 
 auto TraceOutput::operator()(
     const EvaluationType type, const bool result, const Instruction &step,

--- a/src/output/output_trace.cc
+++ b/src/output/output_trace.cc
@@ -6,16 +6,72 @@
 #include <utility> // std::move, std::to_underlying
 #include <variant> // std::visit
 
-static auto try_vocabulary(
-    const std::optional<
-        std::reference_wrapper<const sourcemeta::blaze::SchemaFrame>> &frame,
+// The locations that a schema frame exports are keyed by keyword location, but
+// a resolver that answers out of previously exported frames is keyed by the
+// schema those locations belong to, which is the part before the fragment
+static auto schema_of(const std::string &keyword_location) -> std::string_view {
+  const auto fragment{keyword_location.find('#')};
+  return fragment == std::string::npos
+             ? std::string_view{keyword_location}
+             : std::string_view{keyword_location}.substr(0, fragment);
+}
+
+static auto try_vocabulary_from_export(
+    const sourcemeta::blaze::TraceOutput::FrameResolverJSON &frames,
     const sourcemeta::core::WeakPointer &evaluate_path,
     const sourcemeta::blaze::SchemaWalker &walker,
     const sourcemeta::blaze::SchemaResolver &resolver,
     const std::string &keyword_location)
     -> std::pair<bool, std::optional<sourcemeta::blaze::Vocabularies::URI>> {
-  if (!frame.has_value() || evaluate_path.empty() ||
-      !evaluate_path.back().is_property()) {
+  const auto locations{frames(schema_of(keyword_location))};
+  if (!locations.has_value() || !locations.value().get().is_object() ||
+      !locations.value().get().defines("static")) {
+    return {false, std::nullopt};
+  }
+
+  const auto &entries{locations.value().get().at("static")};
+  if (!entries.is_object() || !entries.defines(keyword_location)) {
+    return {false, std::nullopt};
+  }
+
+  const auto &entry{entries.at(keyword_location)};
+  if (!entry.is_object() || !entry.defines("dialect") ||
+      !entry.defines("baseDialect") || !entry.at("dialect").is_string() ||
+      !entry.at("baseDialect").is_string()) {
+    return {false, std::nullopt};
+  }
+
+  const auto base_dialect{
+      sourcemeta::blaze::to_base_dialect(entry.at("baseDialect").to_string())};
+  if (!base_dialect.has_value()) {
+    return {false, std::nullopt};
+  }
+
+  const auto vocabularies{sourcemeta::blaze::vocabularies(
+      resolver, base_dialect.value(), entry.at("dialect").to_string())};
+  const auto &result{walker(evaluate_path.back().to_property(), vocabularies)};
+  return {true, result.vocabulary};
+}
+
+static auto try_vocabulary(
+    const std::optional<
+        std::reference_wrapper<const sourcemeta::blaze::SchemaFrame>> &frame,
+    const sourcemeta::blaze::TraceOutput::FrameResolverJSON &frames,
+    const sourcemeta::core::WeakPointer &evaluate_path,
+    const sourcemeta::blaze::SchemaWalker &walker,
+    const sourcemeta::blaze::SchemaResolver &resolver,
+    const std::string &keyword_location)
+    -> std::pair<bool, std::optional<sourcemeta::blaze::Vocabularies::URI>> {
+  if (evaluate_path.empty() || !evaluate_path.back().is_property()) {
+    return {false, std::nullopt};
+  }
+
+  if (frames) {
+    return try_vocabulary_from_export(frames, evaluate_path, walker, resolver,
+                                      keyword_location);
+  }
+
+  if (!frame.has_value()) {
     return {false, std::nullopt};
   }
 
@@ -24,7 +80,7 @@ static auto try_vocabulary(
     return {false, std::nullopt};
   }
 
-  const auto vocabularies{
+  const auto &vocabularies{
       frame.value().get().vocabularies(entry.value().get(), resolver)};
   const auto &result{walker(evaluate_path.back().to_property(), vocabularies)};
   return {true, result.vocabulary};
@@ -41,6 +97,23 @@ TraceOutput::TraceOutput(
     : walker_{std::move(walker)}, resolver_{std::move(resolver)},
       base_{std::move(base)}, frame_{frame}, callback_{std::move(callback)} {}
 
+TraceOutput::TraceOutput(sourcemeta::blaze::SchemaWalker walker,
+                         sourcemeta::blaze::SchemaResolver resolver,
+                         Callback callback, sourcemeta::core::WeakPointer base,
+                         FrameResolverJSON frames)
+    : walker_{std::move(walker)}, resolver_{std::move(resolver)},
+      base_{std::move(base)}, frame_{std::nullopt}, frames_{std::move(frames)},
+      callback_{std::move(callback)} {}
+
+auto TraceOutput::frames(const sourcemeta::core::JSON &locations)
+    -> FrameResolverJSON {
+  return [&locations](const std::string_view)
+             -> std::optional<
+                 std::reference_wrapper<const sourcemeta::core::JSON>> {
+    return std::cref(locations);
+  };
+}
+
 auto TraceOutput::operator()(
     const EvaluationType type, const bool result, const Instruction &step,
     const InstructionExtra &step_metadata,
@@ -56,14 +129,14 @@ auto TraceOutput::operator()(
       return;
     }
 
-    auto vocabulary{try_vocabulary(this->frame_, evaluate_path, this->walker_,
-                                   this->resolver_,
+    auto vocabulary{try_vocabulary(this->frame_, this->frames_, evaluate_path,
+                                   this->walker_, this->resolver_,
                                    step_metadata.keyword_location)};
     this->vocabulary_stack_.push_back(std::move(vocabulary));
   } else if (type == EvaluationType::Pre) {
-    this->vocabulary_stack_.push_back(
-        try_vocabulary(this->frame_, evaluate_path, this->walker_,
-                       this->resolver_, step_metadata.keyword_location));
+    this->vocabulary_stack_.push_back(try_vocabulary(
+        this->frame_, this->frames_, evaluate_path, this->walker_,
+        this->resolver_, step_metadata.keyword_location));
   }
 
   const auto &vocabulary{this->vocabulary_stack_.back()};
@@ -83,6 +156,7 @@ auto TraceOutput::operator()(
   if (this->base_.empty()) {
     const Entry entry{.type = entry_type,
                       .name = short_step_name,
+                      .step = step,
                       .instance_location = instance_location,
                       .evaluate_path = evaluate_path,
                       .keyword_location = step_metadata.keyword_location,
@@ -93,6 +167,7 @@ auto TraceOutput::operator()(
     auto effective_evaluate_path{evaluate_path.resolve_from(this->base_)};
     const Entry entry{.type = entry_type,
                       .name = short_step_name,
+                      .step = step,
                       .instance_location = instance_location,
                       .evaluate_path = effective_evaluate_path,
                       .keyword_location = step_metadata.keyword_location,

--- a/test/output/output_trace_test.cc
+++ b/test/output/output_trace_test.cc
@@ -488,7 +488,11 @@ TEST(vocabulary_from_an_exported_frame) {
   sourcemeta::blaze::TraceOutput output{
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
       collect(traces), sourcemeta::core::EMPTY_WEAK_POINTER,
-      sourcemeta::blaze::TraceOutput::frames(locations)};
+      [&locations](const std::string_view)
+          -> std::optional<
+              std::reference_wrapper<const sourcemeta::core::JSON>> {
+        return std::cref(locations);
+      }};
 
   sourcemeta::blaze::Evaluator evaluator;
   const auto result{
@@ -545,32 +549,128 @@ TEST(vocabulary_from_an_exported_frame_matches_a_live_frame) {
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
       collect(from_live), sourcemeta::core::EMPTY_WEAK_POINTER,
       std::cref(frame)};
-  [[maybe_unused]] const auto live_result{
+  const auto live_result{
       evaluator.validate(schema_template, instance, std::ref(live))};
+  EXPECT_TRUE(live_result);
 
   std::vector<StoredTrace> from_export;
   sourcemeta::blaze::TraceOutput exported{
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
       collect(from_export), sourcemeta::core::EMPTY_WEAK_POINTER,
-      sourcemeta::blaze::TraceOutput::frames(locations)};
-  [[maybe_unused]] const auto export_result{
+      [&locations](const std::string_view)
+          -> std::optional<
+              std::reference_wrapper<const sourcemeta::core::JSON>> {
+        return std::cref(locations);
+      }};
+  const auto export_result{
       evaluator.validate(schema_template, instance, std::ref(exported))};
+  EXPECT_TRUE(export_result);
 
-  EXPECT_EQ(from_live.size(), from_export.size());
   EXPECT_EQ(from_live.size(), 7);
+  EXPECT_EQ(from_export.size(), 7);
 
-  for (std::size_t index = 0; index < from_live.size(); index++) {
-    EXPECT_EQ(from_export.at(index).vocabulary.first,
-              from_live.at(index).vocabulary.first);
-    EXPECT_EQ(from_export.at(index).vocabulary.second.has_value(),
-              from_live.at(index).vocabulary.second.has_value());
-    if (from_live.at(index).vocabulary.second.has_value()) {
-      EXPECT_EQ(sourcemeta::blaze::to_string(
-                    from_export.at(index).vocabulary.second.value()),
-                sourcemeta::blaze::to_string(
-                    from_live.at(index).vocabulary.second.value()));
-    }
-  }
+  EXPECT_EQ(from_live.at(0).keyword_location, "https://example.com#/title");
+  EXPECT_TRUE(from_live.at(0).vocabulary.first);
+  EXPECT_TRUE(from_live.at(0).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(0).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/meta-data");
+  EXPECT_EQ(from_export.at(0).keyword_location, "https://example.com#/title");
+  EXPECT_TRUE(from_export.at(0).vocabulary.first);
+  EXPECT_TRUE(from_export.at(0).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(0).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/meta-data");
+
+  EXPECT_EQ(from_live.at(1).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_live.at(1).vocabulary.first);
+  EXPECT_TRUE(from_live.at(1).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(1).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(1).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_export.at(1).vocabulary.first);
+  EXPECT_TRUE(from_export.at(1).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(1).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+
+  EXPECT_EQ(from_live.at(2).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_live.at(2).vocabulary.first);
+  EXPECT_TRUE(from_live.at(2).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(2).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(2).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_export.at(2).vocabulary.first);
+  EXPECT_TRUE(from_export.at(2).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(2).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+
+  EXPECT_EQ(from_live.at(3).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_live.at(3).vocabulary.first);
+  EXPECT_TRUE(from_live.at(3).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(3).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(3).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_export.at(3).vocabulary.first);
+  EXPECT_TRUE(from_export.at(3).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(3).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+
+  EXPECT_EQ(from_live.at(4).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_live.at(4).vocabulary.first);
+  EXPECT_TRUE(from_live.at(4).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(4).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(4).keyword_location,
+            "https://example.com#/properties");
+  EXPECT_TRUE(from_export.at(4).vocabulary.first);
+  EXPECT_TRUE(from_export.at(4).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(4).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+
+  EXPECT_EQ(from_live.at(5).keyword_location,
+            "https://example.com#/additionalProperties");
+  EXPECT_TRUE(from_live.at(5).vocabulary.first);
+  EXPECT_TRUE(from_live.at(5).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(5).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(5).keyword_location,
+            "https://example.com#/additionalProperties");
+  EXPECT_TRUE(from_export.at(5).vocabulary.first);
+  EXPECT_TRUE(from_export.at(5).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(5).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+
+  EXPECT_EQ(from_live.at(6).keyword_location,
+            "https://example.com#/additionalProperties");
+  EXPECT_TRUE(from_live.at(6).vocabulary.first);
+  EXPECT_TRUE(from_live.at(6).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_live.at(6).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
+  EXPECT_EQ(from_export.at(6).keyword_location,
+            "https://example.com#/additionalProperties");
+  EXPECT_TRUE(from_export.at(6).vocabulary.first);
+  EXPECT_TRUE(from_export.at(6).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(from_export.at(6).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/applicator");
 }
 
 TEST(vocabulary_absent_when_the_export_does_not_know_the_location) {
@@ -595,11 +695,16 @@ TEST(vocabulary_absent_when_the_export_does_not_know_the_location) {
   sourcemeta::blaze::TraceOutput output{
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
       collect(traces), sourcemeta::core::EMPTY_WEAK_POINTER,
-      sourcemeta::blaze::TraceOutput::frames(locations)};
+      [&locations](const std::string_view)
+          -> std::optional<
+              std::reference_wrapper<const sourcemeta::core::JSON>> {
+        return std::cref(locations);
+      }};
 
   sourcemeta::blaze::Evaluator evaluator;
-  [[maybe_unused]] const auto result{
+  const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_FALSE(result);
 
   EXPECT_EQ(traces.size(), 2);
   EXPECT_FALSE(traces.at(0).vocabulary.first);
@@ -607,66 +712,6 @@ TEST(vocabulary_absent_when_the_export_does_not_know_the_location) {
   EXPECT_FALSE(traces.at(1).vocabulary.first);
   EXPECT_FALSE(traces.at(1).vocabulary.second.has_value());
 }
-
-TEST(construction_matching_the_command_line_usage) {
-  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "string"
-  })JSON")};
-
-  sourcemeta::blaze::SchemaFrame frame{
-      sourcemeta::blaze::SchemaFrame::Mode::References};
-  frame.analyse(schema, sourcemeta::blaze::schema_walker,
-                sourcemeta::blaze::schema_resolver);
-
-  const auto schema_template{
-      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
-                                 sourcemeta::blaze::schema_resolver,
-                                 sourcemeta::blaze::default_schema_compiler)};
-
-  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
-
-  std::vector<std::string> rendered;
-  sourcemeta::blaze::TraceOutput output{
-      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
-      [&rendered](const sourcemeta::blaze::TraceOutput::Entry &entry) -> void {
-        if (entry.evaluate_path.empty()) {
-          return;
-        }
-
-        std::ostringstream line;
-        switch (entry.type) {
-          case sourcemeta::blaze::TraceOutput::EntryType::Push:
-            line << "-> (push) ";
-            break;
-          case sourcemeta::blaze::TraceOutput::EntryType::Pass:
-            line << "<- (pass) ";
-            break;
-          case sourcemeta::blaze::TraceOutput::EntryType::Fail:
-            line << "<- (fail) ";
-            break;
-          case sourcemeta::blaze::TraceOutput::EntryType::Annotation:
-            line << "@- (annotation) ";
-            break;
-        }
-
-        line << "\"";
-        sourcemeta::core::stringify(entry.evaluate_path, line);
-        line << "\" (" << entry.name << ")";
-        rendered.push_back(line.str());
-      },
-      sourcemeta::core::EMPTY_WEAK_POINTER, frame};
-
-  sourcemeta::blaze::Evaluator evaluator;
-  [[maybe_unused]] const auto result{
-      evaluator.validate(schema_template, instance, std::ref(output))};
-
-  EXPECT_EQ(rendered.size(), 2);
-  EXPECT_EQ(rendered.at(0), "-> (push) \"/type\" (AssertionTypeStrict)");
-  EXPECT_EQ(rendered.at(1), "<- (fail) \"/type\" (AssertionTypeStrict)");
-}
-
 TEST(vocabulary_across_schemas_from_separate_exports) {
   const sourcemeta::core::JSON remote{sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/remote",
@@ -724,21 +769,90 @@ TEST(vocabulary_across_schemas_from_separate_exports) {
       }};
 
   sourcemeta::blaze::Evaluator evaluator;
-  [[maybe_unused]] const auto result{
+  const auto result{
       evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_FALSE(result);
 
-  EXPECT_TRUE(traces.size() > 0);
+  EXPECT_EQ(traces.size(), 2);
 
-  bool saw_remote{false};
-  for (const auto &trace : traces) {
-    if (trace.keyword_location.starts_with("https://example.com/remote")) {
-      saw_remote = true;
-      EXPECT_TRUE(trace.vocabulary.first);
-      EXPECT_TRUE(trace.vocabulary.second.has_value());
-      EXPECT_EQ(sourcemeta::blaze::to_string(trace.vocabulary.second.value()),
-                "https://json-schema.org/draft/2020-12/vocab/validation");
+  EXPECT_EQ(traces.at(0).type, sourcemeta::blaze::TraceOutput::EntryType::Push);
+  EXPECT_EQ(traces.at(0).name, "AssertionTypeStrict");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(0).instance_location), "");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(0).evaluate_path),
+            "/$ref/type");
+  EXPECT_EQ(traces.at(0).keyword_location, "https://example.com/remote#/type");
+  EXPECT_TRUE(traces.at(0).vocabulary.first);
+  EXPECT_TRUE(traces.at(0).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(traces.at(0).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/validation");
+
+  EXPECT_EQ(traces.at(1).type, sourcemeta::blaze::TraceOutput::EntryType::Fail);
+  EXPECT_EQ(traces.at(1).name, "AssertionTypeStrict");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(1).instance_location), "");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(1).evaluate_path),
+            "/$ref/type");
+  EXPECT_EQ(traces.at(1).keyword_location, "https://example.com/remote#/type");
+  EXPECT_TRUE(traces.at(1).vocabulary.first);
+  EXPECT_TRUE(traces.at(1).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(traces.at(1).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/validation");
+}
+
+TEST(vocabulary_absent_when_the_export_names_an_unresolvable_dialect) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const sourcemeta::core::JSON locations{sourcemeta::core::parse_json(R"JSON({
+    "static": {
+      "https://example.com#/type": {
+        "dialect": "https://example.com/unknown-meta",
+        "baseDialect": "https://json-schema.org/draft/2020-12/schema"
+      }
     }
-  }
+  })JSON")};
 
-  EXPECT_TRUE(saw_remote);
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<StoredTrace> traces;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      collect(traces), sourcemeta::core::EMPTY_WEAK_POINTER,
+      [&locations](const std::string_view)
+          -> std::optional<
+              std::reference_wrapper<const sourcemeta::core::JSON>> {
+        return std::cref(locations);
+      }};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+  EXPECT_FALSE(result);
+
+  EXPECT_EQ(traces.size(), 2);
+
+  EXPECT_EQ(traces.at(0).type, sourcemeta::blaze::TraceOutput::EntryType::Push);
+  EXPECT_EQ(traces.at(0).name, "AssertionTypeStrict");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(0).instance_location), "");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(0).evaluate_path), "/type");
+  EXPECT_EQ(traces.at(0).keyword_location, "https://example.com#/type");
+  EXPECT_FALSE(traces.at(0).vocabulary.first);
+  EXPECT_FALSE(traces.at(0).vocabulary.second.has_value());
+
+  EXPECT_EQ(traces.at(1).type, sourcemeta::blaze::TraceOutput::EntryType::Fail);
+  EXPECT_EQ(traces.at(1).name, "AssertionTypeStrict");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(1).instance_location), "");
+  EXPECT_EQ(sourcemeta::core::to_string(traces.at(1).evaluate_path), "/type");
+  EXPECT_EQ(traces.at(1).keyword_location, "https://example.com#/type");
+  EXPECT_FALSE(traces.at(1).vocabulary.first);
+  EXPECT_FALSE(traces.at(1).vocabulary.second.has_value());
 }

--- a/test/output/output_trace_test.cc
+++ b/test/output/output_trace_test.cc
@@ -8,8 +8,10 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-#include <string> // std::string
-#include <vector> // std::vector
+#include <map>     // std::map
+#include <sstream> // std::ostringstream
+#include <string>  // std::string
+#include <vector>  // std::vector
 
 struct StoredTrace {
   sourcemeta::blaze::TraceOutput::EntryType type;
@@ -421,4 +423,322 @@ TEST(nested_vocabulary_correctness) {
       traces, 5, Pass, "LoopPropertiesMatchClosed", "", "/properties",
       "#/properties", std::nullopt,
       sourcemeta::blaze::Vocabularies::Known::JSON_Schema_2020_12_Applicator);
+}
+
+TEST(entry_carries_the_instruction_for_describing) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<std::string> messages;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      [&messages,
+       &instance](const sourcemeta::blaze::TraceOutput::Entry &entry) -> void {
+        if (entry.type == sourcemeta::blaze::TraceOutput::EntryType::Push) {
+          return;
+        }
+
+        const auto valid{entry.type !=
+                         sourcemeta::blaze::TraceOutput::EntryType::Fail};
+        messages.push_back(sourcemeta::blaze::describe(
+            valid, entry.step, entry.evaluate_path, entry.instance_location,
+            instance, entry.annotation));
+      }};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(messages.size(), 1);
+  EXPECT_EQ(messages.at(0), "The value was expected to be of type string but "
+                            "it was of type integer");
+}
+
+TEST(vocabulary_from_an_exported_frame) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+  const auto locations{frame.to_json().at("locations")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<StoredTrace> traces;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      collect(traces), sourcemeta::core::EMPTY_WEAK_POINTER,
+      sourcemeta::blaze::TraceOutput::frames(locations)};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_FALSE(result);
+  EXPECT_EQ(traces.size(), 2);
+
+  EXPECT_TRUE(traces.at(0).vocabulary.first);
+  EXPECT_TRUE(traces.at(0).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(traces.at(0).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/validation");
+  EXPECT_TRUE(traces.at(1).vocabulary.first);
+  EXPECT_TRUE(traces.at(1).vocabulary.second.has_value());
+  EXPECT_EQ(
+      sourcemeta::blaze::to_string(traces.at(1).vocabulary.second.value()),
+      "https://json-schema.org/draft/2020-12/vocab/validation");
+}
+
+TEST(vocabulary_from_an_exported_frame_matches_a_live_frame) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Foo Bar",
+    "additionalProperties": false,
+    "properties": {
+      "foo": true,
+      "bar": true
+    }
+  })JSON")};
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+  const auto locations{frame.to_json().at("locations")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler,
+                                 sourcemeta::blaze::Mode::Exhaustive)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json(R"JSON({
+    "foo": "bar",
+    "bar": "baz"
+  })JSON")};
+
+  sourcemeta::blaze::Evaluator evaluator;
+
+  std::vector<StoredTrace> from_live;
+  sourcemeta::blaze::TraceOutput live{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      collect(from_live), sourcemeta::core::EMPTY_WEAK_POINTER,
+      std::cref(frame)};
+  [[maybe_unused]] const auto live_result{
+      evaluator.validate(schema_template, instance, std::ref(live))};
+
+  std::vector<StoredTrace> from_export;
+  sourcemeta::blaze::TraceOutput exported{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      collect(from_export), sourcemeta::core::EMPTY_WEAK_POINTER,
+      sourcemeta::blaze::TraceOutput::frames(locations)};
+  [[maybe_unused]] const auto export_result{
+      evaluator.validate(schema_template, instance, std::ref(exported))};
+
+  EXPECT_EQ(from_live.size(), from_export.size());
+  EXPECT_EQ(from_live.size(), 7);
+
+  for (std::size_t index = 0; index < from_live.size(); index++) {
+    EXPECT_EQ(from_export.at(index).vocabulary.first,
+              from_live.at(index).vocabulary.first);
+    EXPECT_EQ(from_export.at(index).vocabulary.second.has_value(),
+              from_live.at(index).vocabulary.second.has_value());
+    if (from_live.at(index).vocabulary.second.has_value()) {
+      EXPECT_EQ(sourcemeta::blaze::to_string(
+                    from_export.at(index).vocabulary.second.value()),
+                sourcemeta::blaze::to_string(
+                    from_live.at(index).vocabulary.second.value()));
+    }
+  }
+}
+
+TEST(vocabulary_absent_when_the_export_does_not_know_the_location) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const auto locations{sourcemeta::core::parse_json(R"JSON({
+    "static": {},
+    "dynamic": {}
+  })JSON")};
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<StoredTrace> traces;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      collect(traces), sourcemeta::core::EMPTY_WEAK_POINTER,
+      sourcemeta::blaze::TraceOutput::frames(locations)};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  [[maybe_unused]] const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_EQ(traces.size(), 2);
+  EXPECT_FALSE(traces.at(0).vocabulary.first);
+  EXPECT_FALSE(traces.at(0).vocabulary.second.has_value());
+  EXPECT_FALSE(traces.at(1).vocabulary.first);
+  EXPECT_FALSE(traces.at(1).vocabulary.second.has_value());
+}
+
+TEST(construction_matching_the_command_line_usage) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  frame.analyse(schema, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver);
+
+  const auto schema_template{
+      sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<std::string> rendered;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver,
+      [&rendered](const sourcemeta::blaze::TraceOutput::Entry &entry) -> void {
+        if (entry.evaluate_path.empty()) {
+          return;
+        }
+
+        std::ostringstream line;
+        switch (entry.type) {
+          case sourcemeta::blaze::TraceOutput::EntryType::Push:
+            line << "-> (push) ";
+            break;
+          case sourcemeta::blaze::TraceOutput::EntryType::Pass:
+            line << "<- (pass) ";
+            break;
+          case sourcemeta::blaze::TraceOutput::EntryType::Fail:
+            line << "<- (fail) ";
+            break;
+          case sourcemeta::blaze::TraceOutput::EntryType::Annotation:
+            line << "@- (annotation) ";
+            break;
+        }
+
+        line << "\"";
+        sourcemeta::core::stringify(entry.evaluate_path, line);
+        line << "\" (" << entry.name << ")";
+        rendered.push_back(line.str());
+      },
+      sourcemeta::core::EMPTY_WEAK_POINTER, frame};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  [[maybe_unused]] const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_EQ(rendered.size(), 2);
+  EXPECT_EQ(rendered.at(0), "-> (push) \"/type\" (AssertionTypeStrict)");
+  EXPECT_EQ(rendered.at(1), "<- (fail) \"/type\" (AssertionTypeStrict)");
+}
+
+TEST(vocabulary_across_schemas_from_separate_exports) {
+  const sourcemeta::core::JSON remote{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/remote",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/main",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/remote"
+  })JSON")};
+
+  const auto resolver{[&remote](const std::string_view identifier)
+                          -> std::optional<sourcemeta::core::JSON> {
+    if (identifier == "https://example.com/remote") {
+      return remote;
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  }};
+
+  sourcemeta::blaze::SchemaFrame main_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  main_frame.analyse(schema, sourcemeta::blaze::schema_walker, resolver);
+  sourcemeta::blaze::SchemaFrame remote_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  remote_frame.analyse(remote, sourcemeta::blaze::schema_walker, resolver);
+
+  std::map<std::string, sourcemeta::core::JSON> exports;
+  exports.emplace("https://example.com/main",
+                  main_frame.to_json().at("locations"));
+  exports.emplace("https://example.com/remote",
+                  remote_frame.to_json().at("locations"));
+
+  const auto schema_template{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker, resolver,
+      sourcemeta::blaze::default_schema_compiler)};
+
+  const sourcemeta::core::JSON instance{sourcemeta::core::parse_json("1")};
+
+  std::vector<StoredTrace> traces;
+  sourcemeta::blaze::TraceOutput output{
+      sourcemeta::blaze::schema_walker, resolver, collect(traces),
+      sourcemeta::core::EMPTY_WEAK_POINTER,
+      [&exports](const std::string_view schema_uri)
+          -> std::optional<
+              std::reference_wrapper<const sourcemeta::core::JSON>> {
+        const auto match{exports.find(std::string{schema_uri})};
+        if (match == exports.cend()) {
+          return std::nullopt;
+        }
+
+        return std::cref(match->second);
+      }};
+
+  sourcemeta::blaze::Evaluator evaluator;
+  [[maybe_unused]] const auto result{
+      evaluator.validate(schema_template, instance, std::ref(output))};
+
+  EXPECT_TRUE(traces.size() > 0);
+
+  bool saw_remote{false};
+  for (const auto &trace : traces) {
+    if (trace.keyword_location.starts_with("https://example.com/remote")) {
+      saw_remote = true;
+      EXPECT_TRUE(trace.vocabulary.first);
+      EXPECT_TRUE(trace.vocabulary.second.has_value());
+      EXPECT_EQ(sourcemeta::blaze::to_string(trace.vocabulary.second.value()),
+                "https://json-schema.org/draft/2020-12/vocab/validation");
+    }
+  }
+
+  EXPECT_TRUE(saw_remote);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

