### PR TITLE
Stringify only through `operator<<` and `std::formatter`

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -4,8 +4,8 @@
 #include <sourcemeta/blaze/foundation.h>
 
 #include <algorithm> // std::move, std::sort, std::unique
-#include <cassert>
-#include <format> // std::format   // assert
+#include <cassert>   // assert
+#include <format>    // std::format
 // TODO(C++23): Consider std::flat_map/std::flat_set when available in libc++
 #include <map>           // std::map
 #include <set>           // std::set

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -4,7 +4,8 @@
 #include <sourcemeta/blaze/foundation.h>
 
 #include <algorithm> // std::move, std::sort, std::unique
-#include <cassert>   // assert
+#include <cassert>
+#include <format> // std::format   // assert
 // TODO(C++23): Consider std::flat_map/std::flat_set when available in libc++
 #include <map>           // std::map
 #include <set>           // std::set
@@ -355,7 +356,7 @@ auto compile(const sourcemeta::core::JSON &schema,
       sourcemeta::blaze::unevaluated(schema, frame, walker, resolver)};
 
   std::vector<InstructionExtra> instruction_extra;
-  std::vector<std::string> instruction_vocabularies;
+  std::vector<Vocabularies::URI> instruction_vocabularies;
   const Context context{.root = schema,
                         .frame = frame,
                         .resources = std::move(resources),
@@ -476,6 +477,14 @@ auto compile(const sourcemeta::core::JSON &schema,
   // (8) Return final template
   ///////////////////////////////////////////////////////////////////
 
+  // The template stores vocabularies as plain strings, as the evaluator does
+  // not otherwise depend on the schema machinery
+  std::vector<std::string> template_vocabularies;
+  template_vocabularies.reserve(instruction_vocabularies.size());
+  for (const auto &vocabulary : instruction_vocabularies) {
+    template_vocabularies.push_back(std::format("{}", vocabulary));
+  }
+
   const bool track{
       context.mode != Mode::FastValidation ||
       requires_evaluation(context, entrypoint_location.pointer) ||
@@ -490,7 +499,7 @@ auto compile(const sourcemeta::core::JSON &schema,
           .targets = std::move(compiled_targets),
           .labels = std::move(labels_map),
           .extra = std::move(instruction_extra),
-          .vocabularies = std::move(instruction_vocabularies)};
+          .vocabularies = std::move(template_vocabularies)};
 }
 
 auto compile(const sourcemeta::core::JSON &schema,

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -73,7 +73,7 @@ inline auto schema_resource_id(const std::vector<std::string> &resources,
 
 // Intern the vocabulary that owns a keyword, as an index into
 // Template::vocabularies where zero means the keyword has none
-inline auto vocabulary_intern(std::vector<std::string> &vocabularies,
+inline auto vocabulary_intern(std::vector<Vocabularies::URI> &vocabularies,
                               const sourcemeta::blaze::SchemaWalker &walker,
                               const std::string_view keyword,
                               const sourcemeta::blaze::Vocabularies &active)
@@ -83,10 +83,12 @@ inline auto vocabulary_intern(std::vector<std::string> &vocabularies,
     return 0;
   }
 
-  const auto uri{sourcemeta::blaze::to_string(result.vocabulary.value())};
-  const auto iterator{std::ranges::find(vocabularies, uri)};
+  // Intern on the vocabulary itself rather than on its string form, as the
+  // known ones are a single byte and comparing them allocates nothing
+  const auto iterator{
+      std::ranges::find(vocabularies, result.vocabulary.value())};
   if (iterator == vocabularies.end()) {
-    vocabularies.emplace_back(uri);
+    vocabularies.push_back(result.vocabulary.value());
     return vocabularies.size();
   }
 
@@ -94,7 +96,7 @@ inline auto vocabulary_intern(std::vector<std::string> &vocabularies,
                  std::distance(vocabularies.begin(), iterator));
 }
 
-inline auto vocabulary_id(std::vector<std::string> &vocabularies,
+inline auto vocabulary_id(std::vector<Vocabularies::URI> &vocabularies,
                           const sourcemeta::blaze::SchemaFrame &frame,
                           const sourcemeta::blaze::SchemaWalker &walker,
                           const std::string_view keyword,
@@ -130,20 +132,8 @@ inline auto vocabulary_id(std::vector<std::string> &vocabularies,
     return 0;
   }
 
-  const auto &result{walker(relative_pointer.back().to_property(), active)};
-  if (!result.vocabulary.has_value()) {
-    return 0;
-  }
-
-  const auto uri{sourcemeta::blaze::to_string(result.vocabulary.value())};
-  const auto iterator{std::ranges::find(vocabularies, uri)};
-  if (iterator == vocabularies.end()) {
-    vocabularies.emplace_back(uri);
-    return vocabularies.size();
-  }
-
-  return 1 + static_cast<std::size_t>(
-                 std::distance(vocabularies.begin(), iterator));
+  return vocabulary_intern(vocabularies, walker,
+                           relative_pointer.back().to_property(), active);
 }
 
 // Instantiate a value-oriented step with a custom resource

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -140,8 +140,8 @@ struct Context {
       targets;
   /// Accumulator for instruction extra data during compilation
   std::vector<InstructionExtra> &extra;
-  /// Accumulator for the vocabulary URIs that instructions refer to
-  std::vector<std::string> &vocabularies;
+  /// Accumulator for the vocabularies that instructions refer to
+  std::vector<Vocabularies::URI> &vocabularies;
   // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 

--- a/src/editor/editor.cc
+++ b/src/editor/editor.cc
@@ -5,6 +5,7 @@
 #include "helpers.h"
 
 #include <cassert> // assert
+#include <format>  // std::format
 #include <map>     // std::map
 
 namespace {
@@ -140,8 +141,7 @@ auto for_editor(sourcemeta::core::JSON &schema,
           reference_changes.push_back(
               {.pointer = sourcemeta::core::to_pointer(key.second),
                .new_value =
-                   sourcemeta::core::JSON::String{sourcemeta::blaze::to_string(
-                       origin.value().get().base_dialect)},
+                   std::format("{}", origin.value().get().base_dialect),
                .keyword = keyword,
                .rename_to_ref = false});
           continue;
@@ -217,9 +217,8 @@ auto for_editor(sourcemeta::core::JSON &schema,
     auto &subschema{sourcemeta::core::get(schema, change.pointer)};
 
     if (change.add_schema_declaration) {
-      subschema.assign_assume_new(
-          "$schema", sourcemeta::core::JSON{sourcemeta::core::JSON::String{
-                         sourcemeta::blaze::to_string(change.base_dialect)}});
+      subschema.assign_assume_new("$schema", sourcemeta::core::JSON{std::format(
+                                                 "{}", change.base_dialect)});
     }
 
     sourcemeta::blaze::anonymize(subschema, change.base_dialect);

--- a/src/foundation/foundation.cc
+++ b/src/foundation/foundation.cc
@@ -21,7 +21,7 @@ auto sourcemeta::blaze::is_empty_schema(const sourcemeta::core::JSON &schema)
          (schema.is_object() && schema.empty());
 }
 
-auto sourcemeta::blaze::to_string(const SchemaBaseDialect base_dialect)
+auto sourcemeta::blaze::base_dialect_uri(const SchemaBaseDialect base_dialect)
     -> std::string_view {
   switch (base_dialect) {
     case SchemaBaseDialect::JSON_Schema_2020_12:
@@ -58,6 +58,12 @@ auto sourcemeta::blaze::to_string(const SchemaBaseDialect base_dialect)
 
   assert(false);
   return {};
+}
+
+auto sourcemeta::blaze::operator<<(std::ostream &stream,
+                                   const SchemaBaseDialect base_dialect)
+    -> std::ostream & {
+  return stream << base_dialect_uri(base_dialect);
 }
 
 auto sourcemeta::blaze::to_base_dialect(const std::string_view base_dialect)
@@ -639,7 +645,7 @@ auto sourcemeta::blaze::vocabularies(const SchemaResolver &resolver,
                                      const SchemaBaseDialect base_dialect,
                                      std::string_view dialect)
     -> sourcemeta::blaze::Vocabularies {
-  const auto base_dialect_string{to_string(base_dialect)};
+  const auto base_dialect_string{base_dialect_uri(base_dialect)};
   // As a performance optimization shortcut
   if (base_dialect_string == dialect ||
       to_base_dialect(dialect) == base_dialect) {

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -506,7 +506,7 @@ auto SchemaFrame::to_json(
                        location.second.dialect}});
     entry.assign_assume_new(
         "baseDialect", sourcemeta::core::JSON{sourcemeta::core::JSON::String{
-                           to_string(location.second.base_dialect)}});
+                           base_dialect_uri(location.second.base_dialect)}});
     entry.assign_assume_new(
         "propertyName", sourcemeta::core::JSON{location.second.property_name});
     entry.assign_assume_new("orphan",

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -16,6 +16,10 @@
 
 namespace sourcemeta::blaze {
 
+auto base_dialect_uri(const SchemaBaseDialect base_dialect) -> std::string_view;
+auto vocabulary_uri(Vocabularies::Known vocabulary) -> std::string_view;
+auto vocabulary_uri(const Vocabularies::URI &vocabulary) -> std::string_view;
+
 inline auto id_keyword(const SchemaBaseDialect base_dialect)
     -> std::string_view {
   switch (base_dialect) {

--- a/src/foundation/include/sourcemeta/blaze/foundation.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation.h
@@ -14,7 +14,10 @@
 #include <sourcemeta/blaze/foundation_types.h>
 // NOLINTEND(misc-include-cleaner)
 
+#include <format>      // std::formatter, std::format_to
 #include <optional>    // std::optional, std::nullopt
+#include <ostream>     // std::ostream
+#include <sstream>     // std::ostringstream
 #include <string_view> // std::string_view
 
 /// @defgroup foundation Foundation
@@ -53,9 +56,10 @@ auto schema_walker(const std::string_view keyword,
     -> const SchemaWalkerResult &;
 
 /// @ingroup foundation
-/// Stringify a base dialect to its URI
+/// Write a base dialect to a stream as its URI
 SOURCEMETA_BLAZE_FOUNDATION_EXPORT
-auto to_string(const SchemaBaseDialect base_dialect) -> std::string_view;
+auto operator<<(std::ostream &stream, const SchemaBaseDialect base_dialect)
+    -> std::ostream &;
 
 /// @ingroup foundation
 /// Parse a base dialect URI to its enum representation
@@ -332,5 +336,19 @@ auto parse_schema_type(const sourcemeta::core::JSON &type)
     -> sourcemeta::core::JSON::TypeSet;
 
 } // namespace sourcemeta::blaze
+
+template <> struct std::formatter<sourcemeta::blaze::SchemaBaseDialect> {
+  constexpr auto parse(std::format_parse_context &context)
+      -> decltype(context.begin()) {
+    return context.begin();
+  }
+
+  auto format(const sourcemeta::blaze::SchemaBaseDialect value,
+              std::format_context &context) const -> decltype(context.out()) {
+    std::ostringstream stream;
+    stream << value;
+    return std::format_to(context.out(), "{}", stream.str());
+  }
+};
 
 #endif

--- a/src/foundation/include/sourcemeta/blaze/foundation.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation.h
@@ -14,10 +14,7 @@
 #include <sourcemeta/blaze/foundation_types.h>
 // NOLINTEND(misc-include-cleaner)
 
-#include <format>      // std::formatter, std::format_to
 #include <optional>    // std::optional, std::nullopt
-#include <ostream>     // std::ostream
-#include <sstream>     // std::ostringstream
 #include <string_view> // std::string_view
 
 /// @defgroup foundation Foundation
@@ -54,12 +51,6 @@ SOURCEMETA_BLAZE_FOUNDATION_EXPORT
 auto schema_walker(const std::string_view keyword,
                    const Vocabularies &vocabularies)
     -> const SchemaWalkerResult &;
-
-/// @ingroup foundation
-/// Write a base dialect to a stream as its URI
-SOURCEMETA_BLAZE_FOUNDATION_EXPORT
-auto operator<<(std::ostream &stream, const SchemaBaseDialect base_dialect)
-    -> std::ostream &;
 
 /// @ingroup foundation
 /// Parse a base dialect URI to its enum representation
@@ -336,19 +327,5 @@ auto parse_schema_type(const sourcemeta::core::JSON &type)
     -> sourcemeta::core::JSON::TypeSet;
 
 } // namespace sourcemeta::blaze
-
-template <> struct std::formatter<sourcemeta::blaze::SchemaBaseDialect> {
-  constexpr auto parse(std::format_parse_context &context)
-      -> decltype(context.begin()) {
-    return context.begin();
-  }
-
-  auto format(const sourcemeta::blaze::SchemaBaseDialect value,
-              std::format_context &context) const -> decltype(context.out()) {
-    std::ostringstream stream;
-    stream << value;
-    return std::format_to(context.out(), "{}", stream.str());
-  }
-};
 
 #endif

--- a/src/foundation/include/sourcemeta/blaze/foundation_types.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_types.h
@@ -6,8 +6,11 @@
 #include <sourcemeta/core/jsonpointer.h>
 
 #include <cstdint>       // std::uint8_t
+#include <format>        // std::formatter, std::format_to
 #include <functional>    // std::function, std::reference_wrapper
 #include <optional>      // std::optional
+#include <ostream>       // std::ostream
+#include <sstream>       // std::ostringstream
 #include <string>        // std::string
 #include <string_view>   // std::string_view
 #include <unordered_set> // std::unordered_set
@@ -55,6 +58,12 @@ enum class SchemaBaseDialect : std::uint8_t {
   JSON_Schema_Draft_1_Hyper,
   JSON_Schema_Draft_0_Hyper
 };
+
+/// @ingroup foundation
+/// Write a base dialect to a stream as its URI
+SOURCEMETA_BLAZE_FOUNDATION_EXPORT
+auto operator<<(std::ostream &stream, const SchemaBaseDialect base_dialect)
+    -> std::ostream &;
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -217,5 +226,19 @@ using SchemaWalker = std::function<const SchemaWalkerResult &(
     std::string_view, const Vocabularies &)>;
 
 } // namespace sourcemeta::blaze
+
+template <> struct std::formatter<sourcemeta::blaze::SchemaBaseDialect> {
+  constexpr auto parse(std::format_parse_context &context)
+      -> decltype(context.begin()) {
+    return context.begin();
+  }
+
+  auto format(const sourcemeta::blaze::SchemaBaseDialect value,
+              std::format_context &context) const -> decltype(context.out()) {
+    std::ostringstream stream;
+    stream << value;
+    return std::format_to(context.out(), "{}", stream.str());
+  }
+};
 
 #endif

--- a/src/foundation/include/sourcemeta/blaze/foundation_vocabularies.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_vocabularies.h
@@ -162,14 +162,6 @@ SOURCEMETA_BLAZE_FOUNDATION_EXPORT auto
 operator<<(std::ostream &stream, const Vocabularies::URI &vocabulary)
     -> std::ostream &;
 
-/// Stringify a known vocabulary to a string
-SOURCEMETA_BLAZE_FOUNDATION_EXPORT auto
-to_string(Vocabularies::Known vocabulary) -> std::string_view;
-
-/// Stringify a vocabulary URI to a string
-SOURCEMETA_BLAZE_FOUNDATION_EXPORT auto
-to_string(const Vocabularies::URI &vocabulary) -> std::string_view;
-
 } // namespace sourcemeta::blaze
 
 template <> struct std::formatter<sourcemeta::blaze::Vocabularies::Known> {

--- a/src/foundation/vocabularies.cc
+++ b/src/foundation/vocabularies.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/blaze/foundation_vocabularies.h>
 
+#include "helpers.h"
+
 #include <sourcemeta/blaze/foundation_error.h>
 
 #include <cassert>  // assert
@@ -229,22 +231,10 @@ auto sourcemeta::blaze::Vocabularies::has_unknown() const noexcept -> bool {
 auto sourcemeta::blaze::operator<<(std::ostream &stream,
                                    Vocabularies::Known vocabulary)
     -> std::ostream & {
-  switch (vocabulary) {
-// NOLINTNEXTLINE(bugprone-macro-parentheses)
-#define X_ENUM_TO_URI(enumerator, uri_string)                                  \
-  case Vocabularies::Known::enumerator:                                        \
-    return stream << (uri_string);
-
-    SOURCEMETA_VOCABULARIES_X(X_ENUM_TO_URI)
-
-#undef X_ENUM_TO_URI
-  }
-
-  assert(false);
-  return stream;
+  return stream << vocabulary_uri(vocabulary);
 }
 
-auto sourcemeta::blaze::to_string(Vocabularies::Known vocabulary)
+auto sourcemeta::blaze::vocabulary_uri(Vocabularies::Known vocabulary)
     -> std::string_view {
   switch (vocabulary) {
 // NOLINTNEXTLINE(bugprone-macro-parentheses)
@@ -261,11 +251,11 @@ auto sourcemeta::blaze::to_string(Vocabularies::Known vocabulary)
   return {};
 }
 
-auto sourcemeta::blaze::to_string(const Vocabularies::URI &vocabulary)
+auto sourcemeta::blaze::vocabulary_uri(const Vocabularies::URI &vocabulary)
     -> std::string_view {
   const auto *known{std::get_if<Vocabularies::Known>(&vocabulary)};
   if (known) {
-    return to_string(*known);
+    return vocabulary_uri(*known);
   } else {
     return *std::get_if<sourcemeta::core::JSON::String>(&vocabulary);
   }
@@ -274,7 +264,7 @@ auto sourcemeta::blaze::to_string(const Vocabularies::URI &vocabulary)
 auto sourcemeta::blaze::operator<<(std::ostream &stream,
                                    const Vocabularies::URI &vocabulary)
     -> std::ostream & {
-  return stream << to_string(vocabulary);
+  return stream << vocabulary_uri(vocabulary);
 }
 
 auto sourcemeta::blaze::Vocabularies::throw_if_any_unsupported(

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -1,7 +1,11 @@
 #include <sourcemeta/core/test.h>
 
 #include <sourcemeta/blaze/foundation.h>
+
 #include <sourcemeta/core/json.h>
+
+#include <format>  // std::format
+#include <sstream> // std::ostringstream
 
 static auto test_resolver(std::string_view identifier)
     -> std::optional<sourcemeta::core::JSON> {
@@ -313,101 +317,116 @@ TEST(override_unresolvable_throws) {
   }
 }
 
-TEST(to_string_2020_12) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12),
-            "https://json-schema.org/draft/2020-12/schema");
+TEST(format_2020_12) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12),
+      "https://json-schema.org/draft/2020-12/schema");
 }
 
-TEST(to_string_2020_12_hyper) {
+TEST(format_2020_12_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12_Hyper),
       "https://json-schema.org/draft/2020-12/hyper-schema");
 }
 
-TEST(to_string_2019_09) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2019_09),
-            "https://json-schema.org/draft/2019-09/schema");
+TEST(format_2019_09) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2019_09),
+      "https://json-schema.org/draft/2019-09/schema");
 }
 
-TEST(to_string_2019_09_hyper) {
+TEST(format_2019_09_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2019_09_Hyper),
       "https://json-schema.org/draft/2019-09/hyper-schema");
 }
 
-TEST(to_string_draft7) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7),
-            "http://json-schema.org/draft-07/schema#");
+TEST(format_draft7) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7),
+      "http://json-schema.org/draft-07/schema#");
 }
 
-TEST(to_string_draft7_hyper) {
+TEST(format_draft7_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_7_Hyper),
       "http://json-schema.org/draft-07/hyper-schema#");
 }
 
-TEST(to_string_draft6) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_6),
-            "http://json-schema.org/draft-06/schema#");
+TEST(format_draft6) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_6),
+      "http://json-schema.org/draft-06/schema#");
 }
 
-TEST(to_string_draft6_hyper) {
+TEST(format_draft6_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_6_Hyper),
       "http://json-schema.org/draft-06/hyper-schema#");
 }
 
-TEST(to_string_draft4) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_4),
-            "http://json-schema.org/draft-04/schema#");
+TEST(format_draft4) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_4),
+      "http://json-schema.org/draft-04/schema#");
 }
 
-TEST(to_string_draft4_hyper) {
+TEST(format_draft4_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_4_Hyper),
       "http://json-schema.org/draft-04/hyper-schema#");
 }
 
-TEST(to_string_draft3) {
-  EXPECT_EQ(sourcemeta::blaze::to_string(
-                sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_3),
-            "http://json-schema.org/draft-03/schema#");
+TEST(format_draft3) {
+  EXPECT_EQ(
+      std::format("{}",
+                  sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_3),
+      "http://json-schema.org/draft-03/schema#");
 }
 
-TEST(to_string_draft3_hyper) {
+TEST(format_draft3_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_3_Hyper),
       "http://json-schema.org/draft-03/hyper-schema#");
 }
 
-TEST(to_string_draft2_hyper) {
+TEST(format_draft2_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_2_Hyper),
       "http://json-schema.org/draft-02/hyper-schema#");
 }
 
-TEST(to_string_draft1_hyper) {
+TEST(format_draft1_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_1_Hyper),
       "http://json-schema.org/draft-01/hyper-schema#");
 }
 
-TEST(to_string_draft0_hyper) {
+TEST(format_draft0_hyper) {
   EXPECT_EQ(
-      sourcemeta::blaze::to_string(
+      std::format(
+          "{}",
           sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_0_Hyper),
       "http://json-schema.org/draft-00/hyper-schema#");
 }
@@ -1180,4 +1199,16 @@ TEST(embedded_custom_metaschema_draft3) {
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_3);
+}
+
+TEST(stream_2020_12) {
+  std::ostringstream stream;
+  stream << sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_2020_12;
+  EXPECT_EQ(stream.str(), "https://json-schema.org/draft/2020-12/schema");
+}
+
+TEST(stream_draft4_hyper) {
+  std::ostringstream stream;
+  stream << sourcemeta::blaze::SchemaBaseDialect::JSON_Schema_Draft_4_Hyper;
+  EXPECT_EQ(stream.str(), "http://json-schema.org/draft-04/hyper-schema#");
 }

--- a/test/foundation/foundation_base_dialect_test.cc
+++ b/test/foundation/foundation_base_dialect_test.cc
@@ -1,7 +1,6 @@
 #include <sourcemeta/core/test.h>
 
 #include <sourcemeta/blaze/foundation.h>
-
 #include <sourcemeta/core/json.h>
 
 #include <format>  // std::format

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/test.h>
 
 #include <sourcemeta/blaze/foundation.h>
+
+#include <format> // std::format
 #include <sourcemeta/core/json.h>
 
 #include "foundation_test_utils.h"
@@ -405,37 +407,36 @@ TEST(uri_to_string_custom_variant) {
   EXPECT_EQ(stream.str(), "https://example.com/custom-vocab");
 }
 
-TEST(to_string_known) {
+TEST(format_known) {
   using Known = sourcemeta::blaze::Vocabularies::Known;
 
-  EXPECT_EQ(sourcemeta::blaze::to_string(Known::JSON_Schema_2020_12_Core),
+  EXPECT_EQ(std::format("{}", Known::JSON_Schema_2020_12_Core),
             "https://json-schema.org/draft/2020-12/vocab/core");
-  EXPECT_EQ(sourcemeta::blaze::to_string(Known::JSON_Schema_2019_09_Applicator),
+  EXPECT_EQ(std::format("{}", Known::JSON_Schema_2019_09_Applicator),
             "https://json-schema.org/draft/2019-09/vocab/applicator");
-  EXPECT_EQ(sourcemeta::blaze::to_string(Known::JSON_Schema_Draft_7),
+  EXPECT_EQ(std::format("{}", Known::JSON_Schema_Draft_7),
             "http://json-schema.org/draft-07/schema#");
-  EXPECT_EQ(sourcemeta::blaze::to_string(Known::OpenAPI_3_1_Base),
+  EXPECT_EQ(std::format("{}", Known::OpenAPI_3_1_Base),
             "https://spec.openapis.org/oas/3.1/vocab/base");
-  EXPECT_EQ(sourcemeta::blaze::to_string(Known::OpenAPI_3_2_Base),
+  EXPECT_EQ(std::format("{}", Known::OpenAPI_3_2_Base),
             "https://spec.openapis.org/oas/3.2/vocab/base");
 }
 
-TEST(to_string_uri_known_variant) {
+TEST(format_uri_known_variant) {
   using Known = sourcemeta::blaze::Vocabularies::Known;
   using URI = sourcemeta::blaze::Vocabularies::URI;
 
   const URI vocabulary{Known::JSON_Schema_2020_12_Validation};
-  EXPECT_EQ(sourcemeta::blaze::to_string(vocabulary),
+  EXPECT_EQ(std::format("{}", vocabulary),
             "https://json-schema.org/draft/2020-12/vocab/validation");
 }
 
-TEST(to_string_uri_custom_variant) {
+TEST(format_uri_custom_variant) {
   using URI = sourcemeta::blaze::Vocabularies::URI;
 
   const URI vocabulary{
       sourcemeta::core::JSON::String{"https://example.com/my-vocab"}};
-  EXPECT_EQ(sourcemeta::blaze::to_string(vocabulary),
-            "https://example.com/my-vocab");
+  EXPECT_EQ(std::format("{}", vocabulary), "https://example.com/my-vocab");
 }
 
 TEST(has_unknown_empty_vocabularies) {

--- a/test/foundation/foundation_vocabulary_test.cc
+++ b/test/foundation/foundation_vocabulary_test.cc
@@ -1,9 +1,9 @@
 #include <sourcemeta/core/test.h>
 
 #include <sourcemeta/blaze/foundation.h>
+#include <sourcemeta/core/json.h>
 
 #include <format> // std::format
-#include <sourcemeta/core/json.h>
 
 #include "foundation_test_utils.h"
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

