### PR TITLE
Stop reaching for dialect outside of `bundle`

### DIFF
--- a/src/alterschema/common/ignored_metaschema.h
+++ b/src/alterschema/common/ignored_metaschema.h
@@ -20,7 +20,7 @@ public:
     ONLY_CONTINUE_IF(schema.is_object());
     const auto *schema_keyword{schema.try_at("$schema")};
     ONLY_CONTINUE_IF(schema_keyword && schema_keyword->is_string());
-    const auto dialect{sourcemeta::blaze::dialect(schema)};
+    const auto dialect{declared_dialect(schema)};
     ONLY_CONTINUE_IF(!dialect.empty());
     ONLY_CONTINUE_IF(dialect != location.dialect);
     return APPLIES_TO_KEYWORDS("$schema");

--- a/src/alterschema/schema_helpers.h
+++ b/src/alterschema/schema_helpers.h
@@ -3,7 +3,8 @@
 
 #include <sourcemeta/core/json.h>
 
-#include <utility> // std::to_underlying
+#include <string_view> // std::string_view
+#include <utility>     // std::to_underlying
 
 namespace sourcemeta::blaze {
 
@@ -49,6 +50,28 @@ inline auto parse_schema_type(const sourcemeta::core::JSON &type)
   }
 
   return result;
+}
+
+// The dialect a schema declares, honouring the marker that the upgrade rules
+// leave behind while they walk a document across drafts
+inline auto declared_dialect(const sourcemeta::core::JSON &schema)
+    -> std::string_view {
+  if (!schema.is_object()) {
+    return {};
+  }
+
+  const auto *override_value{
+      schema.try_at("x-sourcemeta-dialect-override-subschema")};
+  if (override_value != nullptr && override_value->is_string()) {
+    return override_value->to_string();
+  }
+
+  const auto *dialect{schema.try_at("$schema")};
+  if (dialect != nullptr && dialect->is_string()) {
+    return dialect->to_string();
+  }
+
+  return {};
 }
 
 } // namespace sourcemeta::blaze

--- a/src/alterschema/upgrade/helpers.h
+++ b/src/alterschema/upgrade/helpers.h
@@ -9,17 +9,7 @@ static auto mark_dialect_override(sourcemeta::core::JSON &schema,
 
 static auto current_dialect_or_override(const sourcemeta::core::JSON &schema)
     -> std::string_view {
-  if (!schema.is_object()) {
-    return {};
-  }
-  const auto *override_value{schema.try_at(DIALECT_OVERRIDE_KEYWORD)};
-  if (override_value != nullptr && override_value->is_string()) {
-    return override_value->to_string();
-  }
-  if (schema.defines("$schema") && schema.at("$schema").is_string()) {
-    return schema.at("$schema").to_string();
-  }
-  return {};
+  return declared_dialect(schema);
 }
 
 static auto

--- a/src/canonicalizer/rules/ignored_metaschema.h
+++ b/src/canonicalizer/rules/ignored_metaschema.h
@@ -14,7 +14,7 @@ public:
     ONLY_CONTINUE_IF(schema.is_object());
     const auto *schema_keyword{schema.try_at("$schema")};
     ONLY_CONTINUE_IF(schema_keyword && schema_keyword->is_string());
-    const auto dialect{sourcemeta::blaze::dialect(schema)};
+    const auto dialect{declared_dialect(schema)};
     ONLY_CONTINUE_IF(!dialect.empty());
     ONLY_CONTINUE_IF(dialect != location.dialect);
     return true;

--- a/src/canonicalizer/schema_helpers.h
+++ b/src/canonicalizer/schema_helpers.h
@@ -3,7 +3,8 @@
 
 #include <sourcemeta/core/json.h>
 
-#include <utility> // std::to_underlying
+#include <string_view> // std::string_view
+#include <utility>     // std::to_underlying
 
 namespace sourcemeta::blaze {
 
@@ -49,6 +50,28 @@ inline auto parse_schema_type(const sourcemeta::core::JSON &type)
   }
 
   return result;
+}
+
+// The dialect a schema declares, honouring the marker that the upgrade rules
+// leave behind while they walk a document across drafts
+inline auto declared_dialect(const sourcemeta::core::JSON &schema)
+    -> std::string_view {
+  if (!schema.is_object()) {
+    return {};
+  }
+
+  const auto *override_value{
+      schema.try_at("x-sourcemeta-dialect-override-subschema")};
+  if (override_value != nullptr && override_value->is_string()) {
+    return override_value->to_string();
+  }
+
+  const auto *dialect{schema.try_at("$schema")};
+  if (dialect != nullptr && dialect->is_string()) {
+    return dialect->to_string();
+  }
+
+  return {};
 }
 
 } // namespace sourcemeta::blaze


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

