### PR TITLE
Stop depending on `dialect` outside of Foundation

### DIFF
--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -168,7 +168,7 @@ auto elevate_embedded_resources(
 
   auto &defs{remote.at(keyword_string)};
   const auto remote_dialect_uri{
-      sourcemeta::blaze::dialect(remote, default_dialect)};
+      sourcemeta::blaze::declared_dialect(remote, default_dialect)};
 
   // Navigate to the root container once, as it doesn't change per entry
   const sourcemeta::core::JSON *root_container{&root};
@@ -228,9 +228,9 @@ auto elevate_embedded_resources(
             // extraction, so compare against a candidate that is stamped in
             // the same way
             auto candidate{value};
-            candidate.assign("$schema",
-                             sourcemeta::core::JSON{sourcemeta::blaze::dialect(
-                                 value, remote_dialect_uri)});
+            candidate.assign("$schema", sourcemeta::core::JSON{
+                                            sourcemeta::blaze::declared_dialect(
+                                                value, remote_dialect_uri)});
             if (root_entry.second != candidate) {
               throw sourcemeta::blaze::SchemaError(
                   "Conflicting embedded resources with the same identifier");
@@ -255,8 +255,9 @@ auto elevate_embedded_resources(
     // dialect of the schema it gets embedded into, which can differ from
     // the dialect it inherited from the remote it was elevated out of
     if (needs_dialect) {
-      value.assign("$schema", sourcemeta::core::JSON{sourcemeta::blaze::dialect(
-                                  value, remote_dialect_uri)});
+      value.assign("$schema",
+                   sourcemeta::core::JSON{sourcemeta::blaze::declared_dialect(
+                       value, remote_dialect_uri)});
     }
 
     embed_schema(root, container, key, std::move(value));
@@ -400,9 +401,10 @@ auto bundle_schema(sourcemeta::core::JSON &root,
       // dialect of the schema it gets embedded into, which can differ from
       // the default dialect that the remote was resolved with
       if (!remote.value().defines("$schema")) {
-        remote.value().assign("$schema",
-                              sourcemeta::core::JSON{sourcemeta::blaze::dialect(
-                                  remote.value(), default_dialect)});
+        remote.value().assign(
+            "$schema",
+            sourcemeta::core::JSON{sourcemeta::blaze::declared_dialect(
+                remote.value(), default_dialect)});
       }
 
       sourcemeta::blaze::schema_reidentify(remote.value(), effective_id,

--- a/src/bundle/helpers.h
+++ b/src/bundle/helpers.h
@@ -3,6 +3,8 @@
 
 #include <sourcemeta/blaze/foundation.h>
 
+#include <sourcemeta/core/json.h>
+
 #include <cassert>     // assert
 #include <string_view> // std::string_view
 
@@ -82,6 +84,22 @@ ref_overrides_adjacent_keywords(const SchemaBaseDialect base_dialect) -> bool {
     default:
       return false;
   }
+}
+
+// The dialect a schema declares, falling back to the given default. Unlike
+// the equivalent helper in alterschema, this one knows nothing about the
+// dialect override marker, as only the upgrade rules ever write one and
+// bundling can never observe a document while those are live
+inline auto declared_dialect(const sourcemeta::core::JSON &schema,
+                             const std::string_view default_dialect)
+    -> std::string_view {
+  if (!schema.is_object()) {
+    return default_dialect;
+  }
+
+  const auto *dialect{schema.try_at("$schema")};
+  return (dialect != nullptr && dialect->is_string()) ? dialect->to_string()
+                                                      : default_dialect;
 }
 
 } // namespace sourcemeta::blaze

--- a/src/foundation/helpers.h
+++ b/src/foundation/helpers.h
@@ -18,6 +18,10 @@ namespace sourcemeta::blaze {
 
 auto base_dialect_uri(const SchemaBaseDialect base_dialect) -> std::string_view;
 
+auto dialect(const sourcemeta::core::JSON &schema,
+             std::string_view default_dialect = "",
+             bool allow_dialect_override = true) -> std::string_view;
+
 auto vocabularies(const sourcemeta::core::JSON &schema,
                   const SchemaResolver &resolver,
                   std::string_view default_dialect = "") -> SchemaVocabularies;

--- a/src/foundation/include/sourcemeta/blaze/foundation.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation.h
@@ -131,31 +131,6 @@ auto schema_reidentify(sourcemeta::core::JSON &schema,
 
 /// @ingroup foundation
 ///
-/// Get the dialect URI that corresponds to a JSON Schema instance.
-/// The result is empty if the dialect cannot be determined. For example:
-///
-/// ```cpp
-/// #include <sourcemeta/core/json.h>
-/// #include <sourcemeta/blaze/foundation.h>
-/// #include <cassert>
-///
-/// const sourcemeta::core::JSON document =
-///   sourcemeta::core::parse_json(R"JSON({
-///   "$schema": "https://json-schema.org/draft/2020-12/schema",
-///   "type": "object"
-/// })JSON");
-///
-/// const auto dialect{sourcemeta::blaze::dialect(document)};
-/// assert(!dialect.empty());
-/// assert(dialect == "https://json-schema.org/draft/2020-12/schema");
-/// ```
-SOURCEMETA_BLAZE_FOUNDATION_EXPORT
-auto dialect(const sourcemeta::core::JSON &schema,
-             std::string_view default_dialect = "",
-             bool allow_dialect_override = true) -> std::string_view;
-
-/// @ingroup foundation
-///
 /// Get the base dialect that applies to the given schema. If you set
 /// a default dialect URI, this will be used if the given schema does not
 /// declare the `$schema` keyword. For example:

--- a/test/foundation/foundation_dialect_2019_09_test.cc
+++ b/test/foundation/foundation_dialect_2019_09_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_schema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_hyperschema) {
     "$schema": "https://json-schema.org/draft/2019-09/hyper-schema",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/hyper-schema");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/links"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/links");
 }
 
@@ -33,7 +46,7 @@ TEST(jsonschema_output) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/output/schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/output/schema");
 }
 
@@ -41,7 +54,7 @@ TEST(jsonschema_output_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/output/hyper-schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect,
             "https://json-schema.org/draft/2019-09/output/hyper-schema");
 }
@@ -50,7 +63,7 @@ TEST(jsonschema_meta_applicator) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/applicator"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/applicator");
 }
 
@@ -58,7 +71,7 @@ TEST(jsonschema_meta_content) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/content"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/content");
 }
 
@@ -66,7 +79,7 @@ TEST(jsonschema_meta_core) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/core"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/core");
 }
 
@@ -74,7 +87,7 @@ TEST(jsonschema_meta_format) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/format"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/format");
 }
 
@@ -82,7 +95,7 @@ TEST(jsonschema_meta_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/hyper-schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/hyper-schema");
 }
 
@@ -90,7 +103,7 @@ TEST(jsonschema_meta_meta_data) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/meta-data"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/meta-data");
 }
 
@@ -98,6 +111,6 @@ TEST(jsonschema_meta_validation) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/meta/validation"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2019-09/meta/validation");
 }

--- a/test/foundation/foundation_dialect_2020_12_test.cc
+++ b/test/foundation/foundation_dialect_2020_12_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_schema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_hyperschema) {
     "$schema": "https://json-schema.org/draft/2020-12/hyper-schema",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/hyper-schema");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/links"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/links");
 }
 
@@ -33,7 +46,7 @@ TEST(jsonschema_output) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/output/schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/output/schema");
 }
 
@@ -41,7 +54,7 @@ TEST(jsonschema_meta_applicator) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/applicator"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/applicator");
 }
 
@@ -49,7 +62,7 @@ TEST(jsonschema_meta_content) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/content"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/content");
 }
 
@@ -57,7 +70,7 @@ TEST(jsonschema_meta_core) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/core"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/core");
 }
 
@@ -65,7 +78,7 @@ TEST(jsonschema_meta_format_annotation) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/format-annotation"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect,
             "https://json-schema.org/draft/2020-12/meta/format-annotation");
 }
@@ -74,7 +87,7 @@ TEST(jsonschema_meta_format_assertion) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/format-assertion"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect,
             "https://json-schema.org/draft/2020-12/meta/format-assertion");
 }
@@ -83,7 +96,7 @@ TEST(jsonschema_meta_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/hyper-schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/hyper-schema");
 }
 
@@ -91,7 +104,7 @@ TEST(jsonschema_meta_meta_data) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/meta-data"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/meta-data");
 }
 
@@ -99,7 +112,7 @@ TEST(jsonschema_meta_unevaluated) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/unevaluated"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/unevaluated");
 }
 
@@ -107,6 +120,6 @@ TEST(jsonschema_meta_validation) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/meta/validation"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/meta/validation");
 }

--- a/test/foundation/foundation_dialect_draft0_test.cc
+++ b/test/foundation/foundation_dialect_draft0_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-00/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-00/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-00/schema#");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_draft_jsonref) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/json-ref#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-00/json-ref#");
 }
 
@@ -33,6 +46,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-00/links#");
 }

--- a/test/foundation/foundation_dialect_draft1_test.cc
+++ b/test/foundation/foundation_dialect_draft1_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-01/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-01/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-01/schema#");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_draft_jsonref) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/json-ref#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-01/json-ref#");
 }
 
@@ -33,6 +46,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-01/links#");
 }

--- a/test/foundation/foundation_dialect_draft2_test.cc
+++ b/test/foundation/foundation_dialect_draft2_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-02/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-02/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-02/schema#");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_draft_jsonref) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/json-ref#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-02/json-ref#");
 }
 
@@ -33,6 +46,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-02/links#");
 }

--- a/test/foundation/foundation_dialect_draft3_test.cc
+++ b/test/foundation/foundation_dialect_draft3_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-03/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-03/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-03/schema#");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_draft_jsonref) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/json-ref#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-03/json-ref#");
 }
 
@@ -33,6 +46,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-03/links#");
 }

--- a/test/foundation/foundation_dialect_draft4_test.cc
+++ b/test/foundation/foundation_dialect_draft4_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-04/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-04/schema#");
 }
 
@@ -25,6 +38,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-04/links#");
 }

--- a/test/foundation/foundation_dialect_draft6_test.cc
+++ b/test/foundation/foundation_dialect_draft6_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-06/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-06/schema#");
 }
 
@@ -25,6 +38,6 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-06/links#");
 }

--- a/test/foundation/foundation_dialect_draft7_test.cc
+++ b/test/foundation/foundation_dialect_draft7_test.cc
@@ -3,12 +3,25 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(jsonschema_draft_hyperschema) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/hyper-schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-07/hyper-schema#");
 }
 
@@ -17,7 +30,7 @@ TEST(jsonschema_draft_schema) {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-07/schema#");
 }
 
@@ -25,7 +38,7 @@ TEST(jsonschema_draft_links) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/links#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-07/links#");
 }
 
@@ -33,6 +46,6 @@ TEST(jsonschema_draft_hyperschema_output) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/hyper-schema-output"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-07/hyper-schema-output");
 }

--- a/test/foundation/foundation_dialect_test.cc
+++ b/test/foundation/foundation_dialect_test.cc
@@ -3,28 +3,56 @@
 #include <sourcemeta/blaze/foundation.h>
 #include <sourcemeta/core/json.h>
 
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static auto DIALECT_OF(const sourcemeta::core::JSON &document,
+                       const std::string_view default_dialect = "")
+    -> std::string {
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Root};
+  frame.analyse(document, sourcemeta::blaze::schema_walker,
+                sourcemeta::blaze::schema_resolver, default_dialect);
+  return std::string{frame.root_location().value().get().dialect};
+}
+
 TEST(dialect_true) {
   const sourcemeta::core::JSON document{true};
-  const auto dialect{sourcemeta::blaze::dialect(document)};
-  EXPECT_TRUE(dialect.empty());
+  try {
+    [[maybe_unused]] const auto dialect{DIALECT_OF(document)};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaUnknownBaseDialectError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Could not determine the base dialect of the schema");
+  }
 }
 
 TEST(dialect_false) {
   const sourcemeta::core::JSON document{false};
-  const auto dialect{sourcemeta::blaze::dialect(document)};
-  EXPECT_TRUE(dialect.empty());
+  try {
+    [[maybe_unused]] const auto dialect{DIALECT_OF(document)};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaUnknownBaseDialectError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Could not determine the base dialect of the schema");
+  }
 }
 
 TEST(dialect_empty_object) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
-  EXPECT_TRUE(dialect.empty());
+  try {
+    [[maybe_unused]] const auto dialect{DIALECT_OF(document)};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaUnknownBaseDialectError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Could not determine the base dialect of the schema");
+  }
 }
 
 TEST(dialect_empty_object_with_default) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
-  const auto dialect{sourcemeta::blaze::dialect(
-      document, "https://json-schema.org/draft/2020-12/schema")};
+  const auto dialect{
+      DIALECT_OF(document, "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -34,7 +62,7 @@ TEST(override_takes_precedence_over_schema) {
     "x-sourcemeta-dialect-override-subschema":
       "https://json-schema.org/draft/2020-12/schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -43,7 +71,7 @@ TEST(override_without_schema) {
     "x-sourcemeta-dialect-override-subschema":
       "https://json-schema.org/draft/2020-12/schema"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -52,8 +80,8 @@ TEST(override_takes_precedence_over_default) {
     "x-sourcemeta-dialect-override-subschema":
       "http://json-schema.org/draft-04/schema#"
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(
-      document, "https://json-schema.org/draft/2020-12/schema")};
+  const auto dialect{
+      DIALECT_OF(document, "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_EQ(dialect, "http://json-schema.org/draft-04/schema#");
 }
 
@@ -62,7 +90,7 @@ TEST(override_non_string_falls_back_to_schema) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "x-sourcemeta-dialect-override-subschema": 42
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -70,8 +98,8 @@ TEST(override_null_falls_back_to_default) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "x-sourcemeta-dialect-override-subschema": null
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(
-      document, "https://json-schema.org/draft/2020-12/schema")};
+  const auto dialect{
+      DIALECT_OF(document, "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -82,7 +110,7 @@ TEST(override_object_falls_back_to_schema) {
       "value": "http://json-schema.org/draft-04/schema#"
     }
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -91,7 +119,7 @@ TEST(override_empty_string_falls_back_to_schema) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "x-sourcemeta-dialect-override-subschema": ""
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(document)};
+  const auto dialect{DIALECT_OF(document)};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -99,7 +127,7 @@ TEST(override_empty_string_falls_back_to_default) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "x-sourcemeta-dialect-override-subschema": ""
   })JSON");
-  const auto dialect{sourcemeta::blaze::dialect(
-      document, "https://json-schema.org/draft/2020-12/schema")};
+  const auto dialect{
+      DIALECT_OF(document, "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_EQ(dialect, "https://json-schema.org/draft/2020-12/schema");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

