### PR TITLE
Fix `SchemaFrame::metaschema`

### DIFF
--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -1463,7 +1463,7 @@ auto SchemaFrame::metaschema(const SchemaResolver &resolver) const
     return *(embedded->second);
   }
 
-  const auto result{resolver(dialect)};
+  auto result{resolver(dialect)};
   if (!result.has_value()) {
     if (sourcemeta::core::URI{sourcemeta::core::JSON::String{dialect}}
             .is_relative()) {
@@ -1477,7 +1477,7 @@ auto SchemaFrame::metaschema(const SchemaResolver &resolver) const
 
   return this->metaschemas_
       .emplace(sourcemeta::core::JSON::String{dialect},
-               std::move(result).value())
+               std::move(result).to_owned())
       .first->second;
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

