### PR TITLE
Distinguish the `$id` fragment error message per dialect era

### DIFF
--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -777,7 +777,10 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
         if (fragment.has_value() && !fragment.value().empty()) {
           throw SchemaFrameError(
               root_id.value(),
-              "Identifiers must not contain non-empty fragments");
+              supports_id_anchors(root_base_dialect.value())
+                  ? "Identifiers may only carry a fragment when they consist "
+                    "of nothing else"
+                  : "Identifiers must not contain non-empty fragments");
         }
       }
 
@@ -906,9 +909,15 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
             // See
             // https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#section-8.2.1-5
             if (maybe_fragment.has_value() && !maybe_fragment.value().empty()) {
+              // Before 2019-09 an identifier may carry a fragment, but only by
+              // consisting of nothing else, in which case it declares an anchor
+              // and never reaches here
               throw SchemaFrameError(
                   entry.id.value(),
-                  "Identifiers must not contain non-empty fragments");
+                  supports_id_anchors(entry.common.base_dialect.value())
+                      ? "Identifiers may only carry a fragment when they "
+                        "consist of nothing else"
+                      : "Identifiers must not contain non-empty fragments");
             }
 
             const bool maybe_relative_is_absolute{maybe_relative.is_absolute()};

--- a/test/foundation/foundation_frame_error_test.cc
+++ b/test/foundation/foundation_frame_error_test.cc
@@ -178,6 +178,83 @@ TEST(draft3_embedded_custom_metaschema_wrong_id_keyword) {
   }
 }
 
+TEST(draft3_top_level_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "id": "https://www.sourcemeta.com/schema#foo",
+    "$schema": "http://json-schema.org/draft-03/schema#"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft3_nested_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "properties": {
+      "foo": {
+        "id": "https://www.sourcemeta.com/nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft3_nested_id_relative_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "properties": {
+      "foo": {
+        "id": "nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
 TEST(draft4_id_override) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "id": "https://www.sourcemeta.com/schema",
@@ -310,6 +387,83 @@ TEST(draft4_embedded_custom_metaschema_wrong_id_keyword) {
     FAIL();
   } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
     EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft4_top_level_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "id": "https://www.sourcemeta.com/schema#foo",
+    "$schema": "http://json-schema.org/draft-04/schema#"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft4_nested_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+      "foo": {
+        "id": "https://www.sourcemeta.com/nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft4_nested_id_relative_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+      "foo": {
+        "id": "nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "nested#foo");
   } catch (...) {
     FAIL();
   }
@@ -462,6 +616,83 @@ TEST(draft6_embedded_custom_metaschema_wrong_id_keyword) {
   }
 }
 
+TEST(draft6_top_level_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema#foo",
+    "$schema": "http://json-schema.org/draft-06/schema#"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft6_nested_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+      "foo": {
+        "$id": "https://www.sourcemeta.com/nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft6_nested_id_relative_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+      "foo": {
+        "$id": "nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
 TEST(draft7_id_override) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://www.sourcemeta.com/schema",
@@ -602,6 +833,83 @@ TEST(draft7_embedded_custom_metaschema_wrong_container) {
     FAIL();
   } catch (const sourcemeta::blaze::SchemaResolutionError &error) {
     EXPECT_EQ(error.identifier(), "https://example.com/meta");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft7_top_level_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema#foo",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft7_nested_id_absolute_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "foo": {
+        "$id": "https://www.sourcemeta.com/nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(draft7_nested_id_relative_with_non_empty_fragment) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "foo": {
+        "$id": "nested#foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers may only carry a fragment when they consist of "
+                 "nothing else");
+    EXPECT_EQ(error.identifier(), "nested#foo");
   } catch (...) {
     FAIL();
   }
@@ -883,6 +1191,8 @@ TEST(2019_09_top_level_id_absolute_with_non_empty_fragment) {
                   sourcemeta::blaze::schema_resolver);
     FAIL();
   } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers must not contain non-empty fragments");
     EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
   } catch (...) {
     FAIL();
@@ -908,6 +1218,8 @@ TEST(2019_09_nested_id_absolute_with_non_empty_fragment) {
                   sourcemeta::blaze::schema_resolver);
     FAIL();
   } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers must not contain non-empty fragments");
     EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
   } catch (...) {
     FAIL();
@@ -1509,6 +1821,8 @@ TEST(2020_12_top_level_id_absolute_with_non_empty_fragment) {
                   sourcemeta::blaze::schema_resolver);
     FAIL();
   } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers must not contain non-empty fragments");
     EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
   } catch (...) {
     FAIL();
@@ -1534,6 +1848,8 @@ TEST(2020_12_nested_id_absolute_with_non_empty_fragment) {
                   sourcemeta::blaze::schema_resolver);
     FAIL();
   } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Identifiers must not contain non-empty fragments");
     EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/nested#foo");
   } catch (...) {
     FAIL();


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

