### PR TITLE
Reject an anchor name claimed twice in one schema resource

### DIFF
--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -394,7 +394,6 @@ auto store(sourcemeta::blaze::SchemaFrame::Locations &frame,
            const sourcemeta::blaze::SchemaBaseDialect base_dialect,
            const std::optional<sourcemeta::core::WeakPointer> &parent,
            const bool property_name, const bool orphan,
-           const bool ignore_if_present = false,
            const bool already_canonical = false) -> void {
   auto canonical{already_canonical ? std::move(uri)
                                    : sourcemeta::core::URI::canonicalize(uri)};
@@ -409,7 +408,7 @@ auto store(sourcemeta::blaze::SchemaFrame::Locations &frame,
                      .base_dialect = base_dialect,
                      .property_name = property_name,
                      .orphan = orphan}});
-  if (!ignore_if_present && !inserted) {
+  if (!inserted) {
     if (entry_type == sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
       throw sourcemeta::blaze::SchemaAnchorCollisionError(
           iterator->first.second,
@@ -790,7 +789,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
             root_id.has_value() ? SchemaFrame::LocationType::Resource
                                 : SchemaFrame::LocationType::Subschema,
             location_uri, location_uri, path, path.size(), root_dialect,
-            root_base_dialect.value(), std::nullopt, false, false, false, true);
+            root_base_dialect.value(), std::nullopt, false, false, true);
       continue;
     }
 
@@ -1023,15 +1022,18 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                   common_parent, entry.common.property_name,
                   entry.common.orphan);
 
-            // Register a dynamic anchor as a static anchor if possible too
-            if (entry.common.vocabularies.contains(
+            // A dynamic anchor declares a static anchor of the same name
+            // too. When the location also carries `$anchor`, the branch above
+            // already registered it
+            if (type == AnchorType::Dynamic &&
+                entry.common.vocabularies.contains(
                     SchemaVocabularies::Known::JSON_Schema_2020_12_Core)) {
               store(this->locations_, SchemaReferenceType::Static,
                     SchemaFrame::LocationType::Anchor, relative_anchor_uri, "",
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, true);
+                    entry.common.orphan);
             }
           }
         } else {
@@ -1074,7 +1076,8 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                     common_parent, entry.common.property_name,
                     entry.common.orphan);
 
-              if (entry.common.vocabularies.contains(
+              if (type == AnchorType::Dynamic &&
+                  entry.common.vocabularies.contains(
                       SchemaVocabularies::Known::JSON_Schema_2020_12_Core)) {
                 store(this->locations_,
                       sourcemeta::blaze::SchemaReferenceType::Static,
@@ -1082,7 +1085,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                       common_pointer_weak, bases.second.size(),
                       entry.common.dialect, entry.common.base_dialect.value(),
                       common_parent, entry.common.property_name,
-                      entry.common.orphan, true);
+                      entry.common.orphan);
               }
             }
 
@@ -1185,7 +1188,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                   dialect_for_pointer, base_dialect_for_pointer,
                   subschema_it->second.parent,
                   subschema_it->second.property_name,
-                  subschema_it->second.orphan, false, true);
+                  subschema_it->second.orphan, true);
           } else {
             const auto &parent_pointer{
                 combined.dialect_match.has_value()
@@ -1202,7 +1205,7 @@ auto SchemaFrame::analyse(const sourcemeta::core::JSON &root,
                   SchemaFrame::LocationType::Pointer, std::move(result),
                   base_view, pointer_weak, nearest_base_depth,
                   dialect_for_pointer, base_dialect_for_pointer, parent_pointer,
-                  parent_property_name, parent_orphan, false, true);
+                  parent_property_name, parent_orphan, true);
           }
         }
       }

--- a/test/foundation/foundation_frame_error_test.cc
+++ b/test/foundation/foundation_frame_error_test.cc
@@ -1292,6 +1292,170 @@ TEST(2020_12_dynamic_anchor_same_on_schema_resource) {
   }
 }
 
+TEST(2020_12_static_anchor_then_dynamic_anchor_same_on_schema_resource) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": {
+        "$anchor": "test"
+      },
+      "bar": {
+        "$dynamicAnchor": "test"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$defs/bar");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "/$defs/foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(2020_12_dynamic_anchor_then_static_anchor_same_on_schema_resource) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "bar": {
+        "$dynamicAnchor": "test"
+      },
+      "foo": {
+        "$anchor": "test"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$defs/foo");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "/$defs/bar");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(2020_12_root_static_anchor_then_nested_dynamic_anchor) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$anchor": "test",
+    "items": {
+      "$dynamicAnchor": "test"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(2020_12_root_dynamic_anchor_then_nested_static_anchor) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$dynamicAnchor": "test",
+    "items": {
+      "$anchor": "test"
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(2020_12_static_anchor_then_dynamic_anchor_same_without_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": {
+        "$anchor": "test"
+      },
+      "bar": {
+        "$dynamicAnchor": "test"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$defs/bar");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "/$defs/foo");
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(2020_12_dynamic_anchor_then_static_anchor_same_without_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "bar": {
+        "$dynamicAnchor": "test"
+      },
+      "foo": {
+        "$anchor": "test"
+      }
+    }
+  })JSON");
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References};
+  try {
+    frame.analyse(document, sourcemeta::blaze::schema_walker,
+                  sourcemeta::blaze::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::blaze::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$defs/foo");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "/$defs/bar");
+  } catch (...) {
+    FAIL();
+  }
+}
+
 TEST(2020_12_location_independent_identifier_anonymous) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

