### PR TITLE
Get rid of frame `locations()` / `references()` leaky getters

### DIFF
--- a/benchmark/frame.cc
+++ b/benchmark/frame.cc
@@ -104,24 +104,26 @@ static void Schema_Frame_KrakenD_Reachable(benchmark::State &state) {
                   sourcemeta::blaze::schema_resolver);
     state.ResumeTiming();
 
-    for (const auto &entry : frame->locations()) {
-      if (entry.second.type ==
-          sourcemeta::blaze::SchemaFrame::LocationType::Pointer) {
-        continue;
-      }
+    frame->for_each_location(
+        [&frame](
+            const sourcemeta::blaze::SchemaReferenceType,
+            const std::string_view,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          if (entry.type ==
+              sourcemeta::blaze::SchemaFrame::LocationType::Pointer) {
+            return;
+          }
 
-      for (const auto &subentry : frame->locations()) {
-        if (subentry.second.type ==
-                sourcemeta::blaze::SchemaFrame::LocationType::Resource ||
-            subentry.second.type ==
-                sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-          auto result{frame->is_reachable(subentry.second, entry.second,
-                                          sourcemeta::blaze::schema_walker,
-                                          sourcemeta::blaze::schema_resolver)};
-          benchmark::DoNotOptimize(result);
-        }
-      }
-    }
+          frame->for_each_subschema(
+              [&frame,
+               &entry](const sourcemeta::blaze::SchemaFrame::Location &subentry)
+                  -> void {
+                auto result{frame->is_reachable(
+                    subentry, entry, sourcemeta::blaze::schema_walker,
+                    sourcemeta::blaze::schema_resolver)};
+                benchmark::DoNotOptimize(result);
+              });
+        });
   }
 }
 

--- a/src/alterschema/common/orphan_definitions.h
+++ b/src/alterschema/common/orphan_definitions.h
@@ -88,7 +88,7 @@ private:
         pointer,
         [&](const sourcemeta::blaze::SchemaReferenceType,
             const sourcemeta::core::WeakPointer &source_pointer,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) -> bool {
+            const sourcemeta::blaze::SchemaFrame::Reference &) -> bool {
           if (source_pointer.empty()) {
             return true;
           }

--- a/src/alterschema/common/orphan_definitions.h
+++ b/src/alterschema/common/orphan_definitions.h
@@ -69,19 +69,13 @@ private:
   static auto
   subtree_has_dynamic_anchor(const sourcemeta::blaze::SchemaFrame &frame,
                              const WeakPointer &entry_pointer) -> bool {
-    for (const auto &[key, location] : frame.locations()) {
-      if (key.first != sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-        continue;
-      }
-      if (location.type !=
-          sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-        continue;
-      }
-      if (location.pointer.starts_with(entry_pointer)) {
-        return true;
-      }
-    }
-    return false;
+    return frame.any_anchor(
+        sourcemeta::blaze::SchemaReferenceType::Dynamic,
+        [&entry_pointer](
+            const std::string_view,
+            const sourcemeta::blaze::SchemaFrame::Location &location) -> bool {
+          return location.pointer.starts_with(entry_pointer);
+        });
   }
 
   static auto has_reachable_reference_through(
@@ -90,31 +84,22 @@ private:
       const sourcemeta::blaze::SchemaWalker &walker,
       const sourcemeta::blaze::SchemaResolver &resolver,
       const WeakPointer &pointer) -> bool {
-    for (const auto &reference : frame.references()) {
-      const auto destination{frame.traverse(reference.second.destination)};
-      if (!destination.has_value()) {
-        continue;
-      }
+    return frame.any_reference_into(
+        pointer,
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const sourcemeta::core::WeakPointer &source_pointer,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) -> bool {
+          if (source_pointer.empty()) {
+            return true;
+          }
 
-      if (!destination->get().pointer.starts_with(pointer)) {
-        continue;
-      }
-
-      const auto &source_pointer{reference.first.second};
-      if (source_pointer.empty()) {
-        return true;
-      }
-
-      const auto source_location{frame.traverse(
-          source_pointer.initial(),
-          sourcemeta::blaze::SchemaFrame::LocationType::Subschema)};
-      if (source_location.has_value() &&
-          frame.is_reachable(base, source_location->get(), walker, resolver)) {
-        return true;
-      }
-    }
-
-    return false;
+          const auto source_location{frame.traverse(
+              source_pointer.initial(),
+              sourcemeta::blaze::SchemaFrame::LocationType::Subschema)};
+          return source_location.has_value() &&
+                 frame.is_reachable(base, source_location->get(), walker,
+                                    resolver);
+        });
   }
 
   static auto

--- a/src/alterschema/linter/invalid_external_ref.h
+++ b/src/alterschema/linter/invalid_external_ref.h
@@ -99,7 +99,7 @@ private:
       frame_cache_;
 
   [[nodiscard]] auto
-  is_fragment_invalid(const SchemaFrame::ReferencesEntry &reference_entry,
+  is_fragment_invalid(const SchemaFrame::Reference &reference_entry,
                       const std::optional<JSON> &remote,
                       const JSON::String &base_key, const SchemaWalker &walker,
                       const SchemaResolver &resolver,

--- a/src/alterschema/transformer.cc
+++ b/src/alterschema/transformer.cc
@@ -57,48 +57,43 @@ auto check_rules(
   std::size_t subschema_count{0};
   std::size_t subschema_failures{0};
 
-  for (const auto &entry : frame.locations()) {
-    if (entry.second.type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-        entry.second.type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-      continue;
-    }
+  frame.for_each_subschema(
 
-    const auto [visited_iterator, inserted] =
-        visited.insert(sourcemeta::core::to_pointer(entry.second.pointer));
-    if (!inserted) {
-      continue;
-    }
-    const auto &entry_pointer{*visited_iterator};
+      [&](const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
+        const auto [visited_iterator, inserted] =
+            visited.insert(sourcemeta::core::to_pointer(location.pointer));
+        if (!inserted) {
+          return;
+        }
+        const auto &entry_pointer{*visited_iterator};
 
-    subschema_count += 1;
+        subschema_count += 1;
 
-    const auto &current{sourcemeta::core::get(schema, entry_pointer)};
-    const auto &current_vocabularies{
-        frame.vocabularies(entry.second, resolver)};
+        const auto &current{sourcemeta::core::get(schema, entry_pointer)};
+        const auto &current_vocabularies{
+            frame.vocabularies(location, resolver)};
 
-    bool subschema_failed{false};
-    for (const auto &[rule, mutates, _] : rules) {
-      if (non_mutating_only && mutates) {
-        continue;
-      }
+        bool subschema_failed{false};
+        for (const auto &[rule, mutates, _] : rules) {
+          if (non_mutating_only && mutates) {
+            continue;
+          }
 
-      const auto outcome{rule->check(current, schema, current_vocabularies,
-                                     walker, resolver, frame, entry.second,
-                                     exclude_keyword, is_metaschema)};
-      if (outcome.applies) {
-        subschema_failed = true;
-        callback(entry_pointer, rule->name(), rule->message(), outcome,
-                 mutates);
-      }
-    }
+          const auto outcome{rule->check(current, schema, current_vocabularies,
+                                         walker, resolver, frame, location,
+                                         exclude_keyword, is_metaschema)};
+          if (outcome.applies) {
+            subschema_failed = true;
+            callback(entry_pointer, rule->name(), rule->message(), outcome,
+                     mutates);
+          }
+        }
 
-    if (subschema_failed) {
-      subschema_failures += 1;
-      result = false;
-    }
-  }
+        if (subschema_failed) {
+          subschema_failures += 1;
+          result = false;
+        }
+      });
 
   return {result,
           calculate_health_percentage(subschema_count, subschema_failures)};
@@ -228,162 +223,171 @@ auto SchemaTransformer::apply(core::JSON &schema,
     std::unordered_set<core::Pointer, core::Pointer::Hasher> visited;
     bool applied{false};
 
-    for (const auto &entry : frame->locations()) {
-      if (entry.second.type != blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type != blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-
-      const auto [visited_iterator, inserted] =
-          visited.insert(core::to_pointer(entry.second.pointer));
-      if (!inserted) {
-        continue;
-      }
-      const auto &entry_pointer{*visited_iterator};
-      auto &current{core::get(schema, entry_pointer)};
-      const auto current_vocabularies{
-          frame->vocabularies(entry.second, resolver)};
-
-      for (const auto &[rule, mutates, reframe_after_transform] : this->rules) {
-        if (!mutates) {
-          continue;
-        }
-
-        auto outcome{rule->check(current, schema, current_vocabularies, walker,
-                                 resolver, *frame, entry.second,
-                                 exclude_keyword, is_metaschema)};
-
-        if (!outcome.applies) {
-          continue;
-        }
-
-        potentially_broken_references.clear();
-        for (const auto &reference : frame->references()) {
-          const auto destination{frame->traverse(reference.second.destination)};
-          if (!destination.has_value() ||
-              !reference.second.fragment.has_value() ||
-              !reference.second.fragment.value().starts_with('/')) {
-            continue;
+    // Stopping the traversal stands in for the restart that the
+    // rules request once they mutate the schema
+    [[maybe_unused]] const auto restarted{frame->any_subschema(
+        [&](const blaze::SchemaFrame::Location &location) -> bool {
+          const auto [visited_iterator, inserted] =
+              visited.insert(core::to_pointer(location.pointer));
+          if (!inserted) {
+            return false;
           }
+          const auto &entry_pointer{*visited_iterator};
+          auto &current{core::get(schema, entry_pointer)};
+          const auto current_vocabularies{
+              frame->vocabularies(location, resolver)};
 
-          const auto &target{destination.value().get()};
-          potentially_broken_references.push_back(
-              {.origin = core::to_pointer(reference.first.second),
-               .original = core::JSON::String{reference.second.original},
-               .destination = reference.second.destination,
-               .fragment =
-                   core::JSON::String{reference.second.fragment.value()},
-               .target_pointer = core::to_pointer(target.pointer),
-               .target_relative_pointer = target.relative_pointer});
-        }
+          for (const auto &[rule, mutates, reframe_after_transform] :
+               this->rules) {
+            if (!mutates) {
+              continue;
+            }
 
-        rule->transform(current, outcome);
-        callback(entry_pointer, rule->name(), rule->message(), outcome, true);
+            auto outcome{rule->check(current, schema, current_vocabularies,
+                                     walker, resolver, *frame, location,
+                                     exclude_keyword, is_metaschema)};
 
-        applied = true;
+            if (!outcome.applies) {
+              continue;
+            }
 
-        if (reframe_after_transform) {
-          frame.emplace(
-              blaze::SchemaFrame::Mode::References, schema, walker, resolver,
-              default_dialect, default_id,
-              sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
-        } else if (current.is_boolean()) {
-          std::tuple<core::Pointer, std::string_view, core::JSON> mark{
-              entry_pointer, rule->name(), current};
-          if (processed_rules.contains(mark)) {
-            throw SchemaTransformRuleProcessedTwiceError(rule->name(),
-                                                         entry_pointer);
-          }
+            potentially_broken_references.clear();
+            frame->for_each_reference(
+                [&](const blaze::SchemaReferenceType,
+                    const core::WeakPointer &origin,
+                    const blaze::SchemaFrame::ReferencesEntry &reference)
+                    -> void {
+                  const auto destination{
+                      frame->traverse(reference.destination)};
+                  if (!destination.has_value() ||
+                      !reference.fragment.has_value() ||
+                      !reference.fragment.value().starts_with('/')) {
+                    return;
+                  }
 
-          processed_rules.emplace(std::move(mark));
-          frame.reset();
-          goto blaze_transformer_start_again;
-        }
+                  const auto &target{destination.value().get()};
+                  potentially_broken_references.push_back(
+                      {.origin = core::to_pointer(origin),
+                       .original = core::JSON::String{reference.original},
+                       .destination = reference.destination,
+                       .fragment =
+                           core::JSON::String{reference.fragment.value()},
+                       .target_pointer = core::to_pointer(target.pointer),
+                       .target_relative_pointer = target.relative_pointer});
+                });
 
-        const auto new_location{
-            frame->traverse(core::to_weak_pointer(entry_pointer))};
-        assert(new_location.has_value());
+            rule->transform(current, outcome);
+            callback(entry_pointer, rule->name(), rule->message(), outcome,
+                     true);
 
-        // Fix broken references before re-checking the condition,
-        // as the re-check may mutate rule state that rereference needs
-        bool references_fixed{false};
-        const auto resource_offset{new_location.value().get().relative_pointer};
-        const auto current_slice{entry_pointer.slice(resource_offset)};
-        for (const auto &saved_reference : potentially_broken_references) {
-          if (core::try_get(schema, saved_reference.target_pointer)) {
-            continue;
-          }
+            applied = true;
 
-          // If the origin was also relocated, resolve its new location
-          auto effective_origin{saved_reference.origin};
-          if (!core::try_get(schema, saved_reference.origin.initial())) {
-            try {
-              const auto new_origin{rule->rereference(
+            if (reframe_after_transform) {
+              frame.emplace(
+                  blaze::SchemaFrame::Mode::References, schema, walker,
+                  resolver, default_dialect, default_id,
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
+            } else if (current.is_boolean()) {
+              std::tuple<core::Pointer, std::string_view, core::JSON> mark{
+                  entry_pointer, rule->name(), current};
+              if (processed_rules.contains(mark)) {
+                throw SchemaTransformRuleProcessedTwiceError(rule->name(),
+                                                             entry_pointer);
+              }
+
+              processed_rules.emplace(std::move(mark));
+              frame.reset();
+              return true;
+            }
+
+            const auto new_location{
+                frame->traverse(core::to_weak_pointer(entry_pointer))};
+            assert(new_location.has_value());
+
+            // Fix broken references before re-checking the condition,
+            // as the re-check may mutate rule state that rereference needs
+            bool references_fixed{false};
+            const auto resource_offset{
+                new_location.value().get().relative_pointer};
+            const auto current_slice{entry_pointer.slice(resource_offset)};
+            for (const auto &saved_reference : potentially_broken_references) {
+              if (core::try_get(schema, saved_reference.target_pointer)) {
+                continue;
+              }
+
+              // If the origin was also relocated, resolve its new location
+              auto effective_origin{saved_reference.origin};
+              if (!core::try_get(schema, saved_reference.origin.initial())) {
+                try {
+                  const auto new_origin{rule->rereference(
+                      saved_reference.destination, saved_reference.origin,
+                      saved_reference.origin.slice(resource_offset),
+                      current_slice)};
+                  effective_origin =
+                      saved_reference.origin.slice(0, resource_offset)
+                          .concat(new_origin);
+                } catch (...) {
+                  continue;
+                }
+                if (!core::try_get(schema, effective_origin.initial())) {
+                  continue;
+                }
+              }
+
+              const auto new_relative{rule->rereference(
                   saved_reference.destination, saved_reference.origin,
-                  saved_reference.origin.slice(resource_offset),
+                  saved_reference.target_pointer.slice(
+                      saved_reference.target_relative_pointer),
                   current_slice)};
-              effective_origin =
-                  saved_reference.origin.slice(0, resource_offset)
-                      .concat(new_origin);
-            } catch (...) {
-              continue;
+              const auto new_fragment{
+                  saved_reference.fragment ==
+                          core::to_string(saved_reference.target_pointer)
+                      ? saved_reference.target_pointer
+                            .slice(0, saved_reference.target_relative_pointer)
+                            .concat(new_relative)
+                      : new_relative};
+
+              core::URI original{saved_reference.original};
+              original.fragment(core::to_string(new_fragment));
+              core::set(schema, effective_origin,
+                        core::JSON{original.recompose()});
+              references_fixed = true;
             }
-            if (!core::try_get(schema, effective_origin.initial())) {
-              continue;
+
+            const auto new_vocabularies{
+                frame->vocabularies(new_location.value().get(), resolver)};
+
+            if (rule->check(current, schema, new_vocabularies, walker, resolver,
+                            *frame, new_location.value().get(), exclude_keyword,
+                            is_metaschema)
+                    .applies) {
+              std::ostringstream error;
+              error << "Rule condition holds after application: "
+                    << rule->name();
+              throw std::runtime_error(error.str());
+            }
+
+            std::tuple<core::Pointer, std::string_view, core::JSON> mark{
+                entry_pointer, rule->name(), current};
+            if (processed_rules.contains(mark)) {
+              throw SchemaTransformRuleProcessedTwiceError(rule->name(),
+                                                           entry_pointer);
+            }
+
+            processed_rules.emplace(std::move(mark));
+
+            if (references_fixed) {
+              frame.reset();
+            }
+
+            if (references_fixed || reframe_after_transform) {
+              return true;
             }
           }
 
-          const auto new_relative{rule->rereference(
-              saved_reference.destination, saved_reference.origin,
-              saved_reference.target_pointer.slice(
-                  saved_reference.target_relative_pointer),
-              current_slice)};
-          const auto new_fragment{
-              saved_reference.fragment ==
-                      core::to_string(saved_reference.target_pointer)
-                  ? saved_reference.target_pointer
-                        .slice(0, saved_reference.target_relative_pointer)
-                        .concat(new_relative)
-                  : new_relative};
+          return false;
+        })};
 
-          core::URI original{saved_reference.original};
-          original.fragment(core::to_string(new_fragment));
-          core::set(schema, effective_origin, core::JSON{original.recompose()});
-          references_fixed = true;
-        }
-
-        const auto new_vocabularies{
-            frame->vocabularies(new_location.value().get(), resolver)};
-
-        if (rule->check(current, schema, new_vocabularies, walker, resolver,
-                        *frame, new_location.value().get(), exclude_keyword,
-                        is_metaschema)
-                .applies) {
-          std::ostringstream error;
-          error << "Rule condition holds after application: " << rule->name();
-          throw std::runtime_error(error.str());
-        }
-
-        std::tuple<core::Pointer, std::string_view, core::JSON> mark{
-            entry_pointer, rule->name(), current};
-        if (processed_rules.contains(mark)) {
-          throw SchemaTransformRuleProcessedTwiceError(rule->name(),
-                                                       entry_pointer);
-        }
-
-        processed_rules.emplace(std::move(mark));
-
-        if (references_fixed) {
-          frame.reset();
-        }
-
-        if (references_fixed || reframe_after_transform) {
-          goto blaze_transformer_start_again;
-        }
-      }
-    }
-
-  blaze_transformer_start_again:
     if (!applied) {
       break;
     }

--- a/src/alterschema/transformer.cc
+++ b/src/alterschema/transformer.cc
@@ -252,29 +252,25 @@ auto SchemaTransformer::apply(core::JSON &schema,
             }
 
             potentially_broken_references.clear();
-            frame->for_each_reference(
-                [&](const blaze::SchemaReferenceType,
-                    const core::WeakPointer &origin,
-                    const blaze::SchemaFrame::ReferencesEntry &reference)
-                    -> void {
-                  const auto destination{
-                      frame->traverse(reference.destination)};
-                  if (!destination.has_value() ||
-                      !reference.fragment.has_value() ||
-                      !reference.fragment.value().starts_with('/')) {
-                    return;
-                  }
+            frame->for_each_reference([&](const blaze::SchemaReferenceType,
+                                          const core::WeakPointer &origin,
+                                          const blaze::SchemaFrame::Reference
+                                              &reference) -> void {
+              const auto destination{frame->traverse(reference.destination)};
+              if (!destination.has_value() || !reference.fragment.has_value() ||
+                  !reference.fragment.value().starts_with('/')) {
+                return;
+              }
 
-                  const auto &target{destination.value().get()};
-                  potentially_broken_references.push_back(
-                      {.origin = core::to_pointer(origin),
-                       .original = core::JSON::String{reference.original},
-                       .destination = reference.destination,
-                       .fragment =
-                           core::JSON::String{reference.fragment.value()},
-                       .target_pointer = core::to_pointer(target.pointer),
-                       .target_relative_pointer = target.relative_pointer});
-                });
+              const auto &target{destination.value().get()};
+              potentially_broken_references.push_back(
+                  {.origin = core::to_pointer(origin),
+                   .original = core::JSON::String{reference.original},
+                   .destination = reference.destination,
+                   .fragment = core::JSON::String{reference.fragment.value()},
+                   .target_pointer = core::to_pointer(target.pointer),
+                   .target_relative_pointer = target.relative_pointer});
+            });
 
             rule->transform(current, outcome);
             callback(entry_pointer, rule->name(), rule->message(), outcome,

--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -298,26 +298,26 @@ private:
       const sourcemeta::blaze::SchemaFrame &frame,
       const sourcemeta::blaze::SchemaWalker &walker,
       const sourcemeta::blaze::SchemaResolver &resolver) -> bool {
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-      const auto absolute{sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &subschema{sourcemeta::core::get(root, absolute)};
-      if (!subschema.is_object() || !subschema.defines("unevaluatedItems")) {
-        continue;
-      }
-      const auto &location_vocabularies{
-          frame.vocabularies(entry.second, resolver)};
-      const auto &keyword_metadata{
-          walker("unevaluatedItems", location_vocabularies)};
-      if (keyword_metadata.type !=
-          sourcemeta::blaze::SchemaKeywordType::Unknown) {
-        return true;
-      }
+    if (frame.any_subschema(
+            [&](const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+              const auto absolute{sourcemeta::core::to_pointer(entry.pointer)};
+              const auto &subschema{sourcemeta::core::get(root, absolute)};
+              if (!subschema.is_object() ||
+                  !subschema.defines("unevaluatedItems")) {
+                return false;
+              }
+              const auto &location_vocabularies{
+                  frame.vocabularies(entry, resolver)};
+              const auto &keyword_metadata{
+                  walker("unevaluatedItems", location_vocabularies)};
+              if (keyword_metadata.type !=
+                  sourcemeta::blaze::SchemaKeywordType::Unknown) {
+                return true;
+              }
+
+              return false;
+            })) {
+      return true;
     }
     return false;
   }
@@ -326,22 +326,18 @@ private:
       const sourcemeta::core::JSON &root,
       const sourcemeta::blaze::SchemaFrame &frame,
       const sourcemeta::blaze::SchemaFrame::Location &location) -> bool {
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-      if (entry.second.pointer.size() <= location.pointer.size() ||
-          !entry.second.pointer.starts_with(location.pointer)) {
-        continue;
-      }
-      const auto absolute{sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &descendant{sourcemeta::core::get(root, absolute)};
-      if (has_pending_pattern(descendant, entry.second)) {
-        return true;
-      }
+    if (frame.any_subschema_under(
+            location.pointer,
+            [&](const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+              const auto absolute{sourcemeta::core::to_pointer(entry.pointer)};
+              const auto &descendant{sourcemeta::core::get(root, absolute)};
+              if (has_pending_pattern(descendant, entry)) {
+                return true;
+              }
+
+              return false;
+            })) {
+      return true;
     }
     return false;
   }
@@ -430,25 +426,28 @@ private:
     std::optional<
         std::reference_wrapper<const sourcemeta::blaze::SchemaFrame::Location>>
         closest;
-    for (const auto &entry : frame.locations()) {
-      const bool entry_is_resource_scope{
-          entry.second.type ==
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource ||
-          entry.second.pointer.empty()};
-      if (!entry_is_resource_scope) {
-        continue;
-      }
-      if (entry.second.pointer.size() > current_location.pointer.size()) {
-        continue;
-      }
-      if (!current_location.pointer.starts_with(entry.second.pointer)) {
-        continue;
-      }
-      if (!closest.has_value() ||
-          entry.second.pointer.size() > closest.value().get().pointer.size()) {
-        closest = std::cref(entry.second);
-      }
-    }
+    frame.for_each_location(
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const std::string_view,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          const bool entry_is_resource_scope{
+              entry.type ==
+                  sourcemeta::blaze::SchemaFrame::LocationType::Resource ||
+              entry.pointer.empty()};
+          if (!entry_is_resource_scope) {
+            return;
+          }
+          if (entry.pointer.size() > current_location.pointer.size()) {
+            return;
+          }
+          if (!current_location.pointer.starts_with(entry.pointer)) {
+            return;
+          }
+          if (!closest.has_value() ||
+              entry.pointer.size() > closest.value().get().pointer.size()) {
+            closest = std::cref(entry);
+          }
+        });
     return closest;
   }
 
@@ -475,29 +474,25 @@ private:
     std::set<std::string> existing_valid;
     std::vector<std::pair<std::string, sourcemeta::core::WeakPointer>> invalid;
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-          sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-        continue;
-      }
-      if (entry.first.first != sourcemeta::blaze::SchemaReferenceType::Static) {
-        continue;
-      }
-      if (!pointer_within_resource(entry.second.pointer, resource_pointer)) {
-        continue;
-      }
-      const sourcemeta::core::URI anchor_uri{entry.first.second};
-      const auto fragment{anchor_uri.fragment()};
-      if (!fragment.has_value() || fragment.value().empty()) {
-        continue;
-      }
-      const std::string anchor_name{fragment.value()};
-      if (is_valid_2020_12_anchor(anchor_name)) {
-        existing_valid.insert(anchor_name);
-      } else {
-        invalid.emplace_back(anchor_name, entry.second.pointer);
-      }
-    }
+    frame.for_each_anchor(
+        sourcemeta::blaze::SchemaReferenceType::Static,
+        [&](const std::string_view uri,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          if (!pointer_within_resource(entry.pointer, resource_pointer)) {
+            return;
+          }
+          const sourcemeta::core::URI anchor_uri{uri};
+          const auto fragment{anchor_uri.fragment()};
+          if (!fragment.has_value() || fragment.value().empty()) {
+            return;
+          }
+          const std::string anchor_name{fragment.value()};
+          if (is_valid_2020_12_anchor(anchor_name)) {
+            existing_valid.insert(anchor_name);
+          } else {
+            invalid.emplace_back(anchor_name, entry.pointer);
+          }
+        });
 
     if (invalid.empty()) {
       return;
@@ -546,32 +541,33 @@ private:
            .new_name = rename_iter->second});
     }
 
-    for (const auto &reference : frame.references()) {
-      if (!pointer_within_resource(reference.first.second, resource_pointer)) {
-        continue;
-      }
-      if (!reference.second.fragment.has_value()) {
-        continue;
-      }
-      const auto &fragment{reference.second.fragment.value()};
-      if (fragment.empty() || fragment.front() == '/') {
-        continue;
-      }
-      const auto rename_iter{rename_map.find(std::string{fragment})};
-      if (rename_iter == rename_map.end()) {
-        continue;
-      }
+    frame.for_each_reference_from(
+        resource_pointer,
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const sourcemeta::core::WeakPointer &origin,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            -> void {
+          if (!reference.fragment.has_value()) {
+            return;
+          }
+          const auto &fragment{reference.fragment.value()};
+          if (fragment.empty() || fragment.front() == '/') {
+            return;
+          }
+          const auto rename_iter{rename_map.find(std::string{fragment})};
+          if (rename_iter == rename_map.end()) {
+            return;
+          }
 
-      sourcemeta::core::URI ref_uri{reference.second.original};
-      ref_uri.fragment(rename_iter->second);
-      const auto new_value{ref_uri.recompose()};
+          sourcemeta::core::URI ref_uri{reference.original};
+          ref_uri.fragment(rename_iter->second);
+          const auto new_value{ref_uri.recompose()};
 
-      const auto relative_weak{
-          reference.first.second.resolve_from(resource_pointer)};
-      this->anchor_ref_rewrites_.push_back(
-          {.ref_pointer = sourcemeta::core::to_pointer(relative_weak),
-           .new_value = new_value});
-    }
+          const auto relative_weak{origin.resolve_from(resource_pointer)};
+          this->anchor_ref_rewrites_.push_back(
+              {.ref_pointer = sourcemeta::core::to_pointer(relative_weak),
+               .new_value = new_value});
+        });
   }
 
   static auto enclosing_resource_has_pending_sanitization(
@@ -585,33 +581,30 @@ private:
     }
     const auto &resource_pointer{closest.value().get().pointer};
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-          sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-        continue;
-      }
-      if (entry.first.first != sourcemeta::blaze::SchemaReferenceType::Static) {
-        continue;
-      }
-      if (!pointer_within_resource(entry.second.pointer, resource_pointer)) {
-        continue;
-      }
-      const sourcemeta::core::URI anchor_uri{entry.first.second};
-      const auto fragment{anchor_uri.fragment()};
-      if (!fragment.has_value() || fragment.value().empty()) {
-        continue;
-      }
-      if (!is_valid_2020_12_anchor(fragment.value())) {
-        const auto absolute{sourcemeta::core::to_pointer(entry.second.pointer)};
-        const auto &subschema{sourcemeta::core::get(root, absolute)};
-        if (subschema.is_object() && subschema.defines("$anchor") &&
-            subschema.at("$anchor").is_string() &&
-            subschema.at("$anchor").to_string() == fragment.value()) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return frame.any_anchor(
+        sourcemeta::blaze::SchemaReferenceType::Static,
+        [&](const std::string_view uri,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+          if (!pointer_within_resource(entry.pointer, resource_pointer)) {
+            return false;
+          }
+          const sourcemeta::core::URI anchor_uri{uri};
+          const auto fragment{anchor_uri.fragment()};
+          if (!fragment.has_value() || fragment.value().empty()) {
+            return false;
+          }
+          if (!is_valid_2020_12_anchor(fragment.value())) {
+            const auto absolute{sourcemeta::core::to_pointer(entry.pointer)};
+            const auto &subschema{sourcemeta::core::get(root, absolute)};
+            if (subschema.is_object() && subschema.defines("$anchor") &&
+                subschema.at("$anchor").is_string() &&
+                subschema.at("$anchor").to_string() == fragment.value()) {
+              return true;
+            }
+          }
+
+          return false;
+        });
   }
 
   auto apply_anchor_sanitization(sourcemeta::core::JSON &schema) const -> void {
@@ -637,38 +630,34 @@ private:
 
     const auto &resource_pointer{closest.value().get().pointer};
     std::set<std::string> seen;
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-      if (!entry.second.pointer.starts_with(resource_pointer)) {
-        continue;
-      }
-      if (entry.second.type ==
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.pointer.size() > resource_pointer.size()) {
-        continue;
-      }
-      const auto pointer_str{sourcemeta::core::to_string(entry.second.pointer)};
-      if (seen.contains(pointer_str)) {
-        continue;
-      }
-      seen.insert(pointer_str);
+    return frame.any_subschema(
+        [&](const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+          if (!entry.pointer.starts_with(resource_pointer)) {
+            return false;
+          }
+          if (entry.type ==
+                  sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
+              entry.pointer.size() > resource_pointer.size()) {
+            return false;
+          }
+          const auto pointer_str{sourcemeta::core::to_string(entry.pointer)};
+          if (seen.contains(pointer_str)) {
+            return false;
+          }
+          seen.insert(pointer_str);
 
-      const auto absolute{sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &subschema{sourcemeta::core::get(root, absolute)};
-      if (!subschema.is_object()) {
-        continue;
-      }
-      if (subschema.defines("$recursiveAnchor") &&
-          subschema.at("$recursiveAnchor").is_boolean() &&
-          subschema.at("$recursiveAnchor").to_boolean()) {
-        return true;
-      }
-    }
-    return false;
+          const auto absolute{sourcemeta::core::to_pointer(entry.pointer)};
+          const auto &subschema{sourcemeta::core::get(root, absolute)};
+          if (!subschema.is_object()) {
+            return false;
+          }
+          if (subschema.defines("$recursiveAnchor") &&
+              subschema.at("$recursiveAnchor").is_boolean() &&
+              subschema.at("$recursiveAnchor").to_boolean()) {
+            return true;
+          }
+
+          return false;
+        });
   }
 };

--- a/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -545,7 +545,7 @@ private:
         resource_pointer,
         [&](const sourcemeta::blaze::SchemaReferenceType,
             const sourcemeta::core::WeakPointer &origin,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            const sourcemeta::blaze::SchemaFrame::Reference &reference)
             -> void {
           if (!reference.fragment.has_value()) {
             return;

--- a/src/alterschema/upgrade/upgrade_draft_3_to_draft_4.h
+++ b/src/alterschema/upgrade/upgrade_draft_3_to_draft_4.h
@@ -24,29 +24,21 @@ public:
     ONLY_CONTINUE_IF(has_pending_draft_3_pattern(schema) ||
                      root_via_default_dialect);
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
+    if (frame.any_subschema_under(
+            location.pointer,
+            [&root](
+                const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+              const auto entry_pointer{
+                  sourcemeta::core::to_pointer(entry.pointer)};
+              const auto &entry_schema{
+                  sourcemeta::core::get(root, entry_pointer)};
+              if (entry_schema.is_object() && entry_schema.defines("$ref")) {
+                return false;
+              }
 
-      if (!is_strict_descendant(location.pointer, entry.second.pointer)) {
-        continue;
-      }
-
-      const auto entry_pointer{
-          sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &entry_schema{sourcemeta::core::get(root, entry_pointer)};
-
-      if (entry_schema.is_object() && entry_schema.defines("$ref")) {
-        continue;
-      }
-
-      if (has_pending_draft_3_pattern(entry_schema)) {
-        return false;
-      }
+              return has_pending_draft_3_pattern(entry_schema);
+            })) {
+      return false;
     }
 
     return true;
@@ -415,19 +407,5 @@ private:
     } else if (name == "ip-address") {
       schema.assign("format", sourcemeta::core::JSON{"ipv4"});
     }
-  }
-
-  static auto
-  is_strict_descendant(const sourcemeta::core::WeakPointer &ancestor,
-                       const sourcemeta::core::WeakPointer &candidate) -> bool {
-    if (candidate.size() <= ancestor.size()) {
-      return false;
-    }
-    for (std::size_t index{0}; index < ancestor.size(); ++index) {
-      if (!(ancestor.at(index) == candidate.at(index))) {
-        return false;
-      }
-    }
-    return true;
   }
 };

--- a/src/alterschema/upgrade/upgrade_draft_4_to_draft_6.h
+++ b/src/alterschema/upgrade/upgrade_draft_4_to_draft_6.h
@@ -40,29 +40,21 @@ public:
     }
 
     if (!sanitization_branch) {
-      for (const auto &entry : frame.locations()) {
-        if (entry.second.type !=
-                sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-            entry.second.type !=
-                sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-          continue;
-        }
+      if (frame.any_subschema_under(
+              location.pointer,
+              [&root](const sourcemeta::blaze::SchemaFrame::Location &entry)
+                  -> bool {
+                const auto entry_pointer{
+                    sourcemeta::core::to_pointer(entry.pointer)};
+                const auto &entry_schema{
+                    sourcemeta::core::get(root, entry_pointer)};
+                if (entry_schema.is_object() && entry_schema.defines("$ref")) {
+                  return false;
+                }
 
-        if (!is_strict_descendant(location.pointer, entry.second.pointer)) {
-          continue;
-        }
-
-        const auto entry_pointer{
-            sourcemeta::core::to_pointer(entry.second.pointer)};
-        const auto &entry_schema{sourcemeta::core::get(root, entry_pointer)};
-
-        if (entry_schema.is_object() && entry_schema.defines("$ref")) {
-          continue;
-        }
-
-        if (has_pending_draft_4_pattern(entry_schema)) {
-          return false;
-        }
+                return has_pending_draft_4_pattern(entry_schema);
+              })) {
+        return false;
       }
     }
 
@@ -174,20 +166,6 @@ private:
     }
 
     return false;
-  }
-
-  static auto
-  is_strict_descendant(const sourcemeta::core::WeakPointer &ancestor,
-                       const sourcemeta::core::WeakPointer &candidate) -> bool {
-    if (candidate.size() <= ancestor.size()) {
-      return false;
-    }
-    for (std::size_t index{0}; index < ancestor.size(); ++index) {
-      if (!(ancestor.at(index) == candidate.at(index))) {
-        return false;
-      }
-    }
-    return true;
   }
 
   static auto is_strict_plain_name_first_char(const char character) -> bool {
@@ -580,32 +558,35 @@ private:
       const sourcemeta::core::JSON &root,
       const sourcemeta::blaze::SchemaFrame &frame) -> bool {
     std::optional<sourcemeta::core::WeakPointer> closest;
-    for (const auto &entry : frame.locations()) {
-      const bool entry_is_resource_scope =
-          entry.second.type ==
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource ||
-          entry.second.pointer.empty();
-      if (!entry_is_resource_scope) {
-        continue;
-      }
-      if (entry.second.pointer.size() > location.pointer.size()) {
-        continue;
-      }
-      bool is_ancestor{true};
-      for (std::size_t index{0}; index < entry.second.pointer.size(); ++index) {
-        if (!(entry.second.pointer.at(index) == location.pointer.at(index))) {
-          is_ancestor = false;
-          break;
-        }
-      }
-      if (!is_ancestor) {
-        continue;
-      }
-      if (!closest.has_value() ||
-          entry.second.pointer.size() > closest.value().size()) {
-        closest = entry.second.pointer;
-      }
-    }
+    frame.for_each_location(
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const std::string_view,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          const bool entry_is_resource_scope =
+              entry.type ==
+                  sourcemeta::blaze::SchemaFrame::LocationType::Resource ||
+              entry.pointer.empty();
+          if (!entry_is_resource_scope) {
+            return;
+          }
+          if (entry.pointer.size() > location.pointer.size()) {
+            return;
+          }
+          bool is_ancestor{true};
+          for (std::size_t index{0}; index < entry.pointer.size(); ++index) {
+            if (!(entry.pointer.at(index) == location.pointer.at(index))) {
+              is_ancestor = false;
+              break;
+            }
+          }
+          if (!is_ancestor) {
+            return;
+          }
+          if (!closest.has_value() ||
+              entry.pointer.size() > closest.value().size()) {
+            closest = entry.pointer;
+          }
+        });
     if (!closest.has_value()) {
       return false;
     }

--- a/src/alterschema/upgrade/upgrade_draft_6_to_draft_7.h
+++ b/src/alterschema/upgrade/upgrade_draft_6_to_draft_7.h
@@ -18,32 +18,17 @@ public:
         vocabularies.contains(SchemaVocabularies::Known::JSON_Schema_Draft_6) &&
         subschema_at_dialect(schema, location, DRAFT_6_URL));
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
+    return !frame.any_subschema_under(
+        location.pointer,
+        [&root](const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+          const auto entry_pointer{sourcemeta::core::to_pointer(entry.pointer)};
+          const auto &entry_schema{sourcemeta::core::get(root, entry_pointer)};
+          if (entry_schema.is_object() && entry_schema.defines("$ref")) {
+            return false;
+          }
 
-      if (!is_strict_descendant(location.pointer, entry.second.pointer)) {
-        continue;
-      }
-
-      const auto entry_pointer{
-          sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &entry_schema{sourcemeta::core::get(root, entry_pointer)};
-
-      if (entry_schema.is_object() && entry_schema.defines("$ref")) {
-        continue;
-      }
-
-      if (has_pending_pattern(entry_schema)) {
-        return false;
-      }
-    }
-
-    return true;
+          return has_pending_pattern(entry_schema);
+        });
   }
 
   auto transform(sourcemeta::core::JSON &schema, const Result &) const
@@ -92,19 +77,5 @@ private:
     }
 
     return false;
-  }
-
-  static auto
-  is_strict_descendant(const sourcemeta::core::WeakPointer &ancestor,
-                       const sourcemeta::core::WeakPointer &candidate) -> bool {
-    if (candidate.size() <= ancestor.size()) {
-      return false;
-    }
-    for (std::size_t index{0}; index < ancestor.size(); ++index) {
-      if (!(ancestor.at(index) == candidate.at(index))) {
-        return false;
-      }
-    }
-    return true;
   }
 };

--- a/src/alterschema/upgrade/upgrade_draft_7_to_draft_2019_09.h
+++ b/src/alterschema/upgrade/upgrade_draft_7_to_draft_2019_09.h
@@ -31,26 +31,18 @@ public:
 
     ONLY_CONTINUE_IF(needs_dialect_transition || needs_metaschema_vocabulary);
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-
-      if (entry.second.pointer.size() <= location.pointer.size() ||
-          !entry.second.pointer.starts_with(location.pointer)) {
-        continue;
-      }
-
-      const auto entry_pointer{
-          sourcemeta::core::to_pointer(entry.second.pointer)};
-      const auto &entry_schema{sourcemeta::core::get(root, entry_pointer)};
-
-      if (has_descendant_pending_pattern(entry_schema, entry.second.dialect)) {
-        return false;
-      }
+    if (frame.any_subschema_under(
+            location.pointer,
+            [&root](
+                const sourcemeta::blaze::SchemaFrame::Location &entry) -> bool {
+              const auto entry_pointer{
+                  sourcemeta::core::to_pointer(entry.pointer)};
+              const auto &entry_schema{
+                  sourcemeta::core::get(root, entry_pointer)};
+              return has_descendant_pending_pattern(entry_schema,
+                                                    entry.dialect);
+            })) {
+      return false;
     }
 
     this->metaschema_synthesis_pending_ = needs_metaschema_vocabulary;

--- a/src/alterschema/wrap.cc
+++ b/src/alterschema/wrap.cc
@@ -35,7 +35,7 @@ auto wrap(const sourcemeta::core::JSON &schema, const SchemaFrame &frame,
   const auto has_internal_references{frame.any_reference_from(
       pointer,
       [](const SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-         const SchemaFrame::ReferencesEntry &) -> bool { return true; })};
+         const SchemaFrame::Reference &) -> bool { return true; })};
 
   if (!has_internal_references) {
     auto subschema{sourcemeta::core::get(schema, pointer)};

--- a/src/alterschema/wrap.cc
+++ b/src/alterschema/wrap.cc
@@ -32,11 +32,10 @@ auto wrap(const sourcemeta::core::JSON &schema, const SchemaFrame &frame,
   }
 
   assert(sourcemeta::core::try_get(schema, pointer));
-  const auto has_internal_references{
-      std::any_of(frame.references().cbegin(), frame.references().cend(),
-                  [&pointer](const auto &reference) -> auto {
-                    return reference.first.second.starts_with(pointer);
-                  })};
+  const auto has_internal_references{frame.any_reference_from(
+      pointer,
+      [](const SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+         const SchemaFrame::ReferencesEntry &) -> bool { return true; })};
 
   if (!has_internal_references) {
     auto subschema{sourcemeta::core::get(schema, pointer)};

--- a/src/canonicalizer/canonicalize.cc
+++ b/src/canonicalizer/canonicalize.cc
@@ -92,143 +92,152 @@ auto apply(const std::vector<Rule> &rules, sourcemeta::core::JSON &schema,
     std::unordered_set<core::Pointer, core::Pointer::Hasher> visited;
     bool applied{false};
 
-    for (const auto &entry : frame->locations()) {
-      if (entry.second.type != blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type != blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-
-      const auto [visited_iterator, inserted] =
-          visited.insert(core::to_pointer(entry.second.pointer));
-      if (!inserted) {
-        continue;
-      }
-      const auto &entry_pointer{*visited_iterator};
-      auto &current{core::get(schema, entry_pointer)};
-      const auto current_vocabularies{
-          frame->vocabularies(entry.second, resolver)};
-
-      for (const auto &[rule, reframe_after_transform] : rules) {
-        const auto outcome{rule->condition(current, schema,
-                                           current_vocabularies, *frame,
-                                           entry.second, walker, resolver)};
-
-        if (!outcome) {
-          continue;
-        }
-
-        potentially_broken_references.clear();
-        for (const auto &reference : frame->references()) {
-          const auto destination{frame->traverse(reference.second.destination)};
-          if (!destination.has_value() ||
-              !reference.second.fragment.has_value() ||
-              !reference.second.fragment.value().starts_with('/')) {
-            continue;
+    // Stopping the traversal stands in for the restart that the
+    // rules request once they mutate the schema
+    [[maybe_unused]] const auto restarted{frame->any_subschema(
+        [&](const blaze::SchemaFrame::Location &location) -> bool {
+          const auto [visited_iterator, inserted] =
+              visited.insert(core::to_pointer(location.pointer));
+          if (!inserted) {
+            return false;
           }
+          const auto &entry_pointer{*visited_iterator};
+          auto &current{core::get(schema, entry_pointer)};
+          const auto current_vocabularies{
+              frame->vocabularies(location, resolver)};
 
-          const auto &target{destination.value().get()};
-          potentially_broken_references.push_back(
-              {.origin = core::to_pointer(reference.first.second),
-               .original = core::JSON::String{reference.second.original},
-               .destination = reference.second.destination,
-               .fragment =
-                   core::JSON::String{reference.second.fragment.value()},
-               .target_pointer = core::to_pointer(target.pointer),
-               .target_relative_pointer = target.relative_pointer});
-        }
+          for (const auto &[rule, reframe_after_transform] : rules) {
+            const auto outcome{rule->condition(current, schema,
+                                               current_vocabularies, *frame,
+                                               location, walker, resolver)};
 
-        rule->transform(current);
-
-        applied = true;
-
-        if (reframe_after_transform) {
-          frame.emplace(
-              blaze::SchemaFrame::Mode::References, schema, walker, resolver,
-              default_dialect, default_id,
-              sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
-        } else if (current.is_boolean()) {
-          std::tuple<core::Pointer, std::string_view, core::JSON> mark{
-              entry_pointer, rule->name(), current};
-          assert(!processed_rules.contains(mark));
-          processed_rules.emplace(std::move(mark));
-          frame.reset();
-          goto blaze_transformer_start_again;
-        }
-
-        const auto new_location{
-            frame->traverse(core::to_weak_pointer(entry_pointer))};
-        assert(new_location.has_value());
-
-        // Fix broken references before re-checking the condition,
-        // as the re-check may mutate rule state that rereference needs
-        bool references_fixed{false};
-        const auto resource_offset{new_location.value().get().relative_pointer};
-        const auto current_slice{entry_pointer.slice(resource_offset)};
-        for (const auto &saved_reference : potentially_broken_references) {
-          if (core::try_get(schema, saved_reference.target_pointer)) {
-            continue;
-          }
-
-          // If the origin was also relocated, resolve its new location
-          auto effective_origin{saved_reference.origin};
-          if (!core::try_get(schema, saved_reference.origin.initial())) {
-            const auto new_origin{rule->rereference(
-                saved_reference.destination, saved_reference.origin,
-                saved_reference.origin.slice(resource_offset), current_slice)};
-            if (!new_origin.has_value()) {
+            if (!outcome) {
               continue;
             }
-            effective_origin = saved_reference.origin.slice(0, resource_offset)
-                                   .concat(new_origin.value());
-            if (!core::try_get(schema, effective_origin.initial())) {
-              continue;
+
+            potentially_broken_references.clear();
+            frame->for_each_reference(
+                [&](const blaze::SchemaReferenceType,
+                    const core::WeakPointer &origin,
+                    const blaze::SchemaFrame::ReferencesEntry &reference)
+                    -> void {
+                  const auto destination{
+                      frame->traverse(reference.destination)};
+                  if (!destination.has_value() ||
+                      !reference.fragment.has_value() ||
+                      !reference.fragment.value().starts_with('/')) {
+                    return;
+                  }
+
+                  const auto &target{destination.value().get()};
+                  potentially_broken_references.push_back(
+                      {.origin = core::to_pointer(origin),
+                       .original = core::JSON::String{reference.original},
+                       .destination = reference.destination,
+                       .fragment =
+                           core::JSON::String{reference.fragment.value()},
+                       .target_pointer = core::to_pointer(target.pointer),
+                       .target_relative_pointer = target.relative_pointer});
+                });
+
+            rule->transform(current);
+
+            applied = true;
+
+            if (reframe_after_transform) {
+              frame.emplace(
+                  blaze::SchemaFrame::Mode::References, schema, walker,
+                  resolver, default_dialect, default_id,
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
+            } else if (current.is_boolean()) {
+              std::tuple<core::Pointer, std::string_view, core::JSON> mark{
+                  entry_pointer, rule->name(), current};
+              assert(!processed_rules.contains(mark));
+              processed_rules.emplace(std::move(mark));
+              frame.reset();
+              return true;
+            }
+
+            const auto new_location{
+                frame->traverse(core::to_weak_pointer(entry_pointer))};
+            assert(new_location.has_value());
+
+            // Fix broken references before re-checking the condition,
+            // as the re-check may mutate rule state that rereference needs
+            bool references_fixed{false};
+            const auto resource_offset{
+                new_location.value().get().relative_pointer};
+            const auto current_slice{entry_pointer.slice(resource_offset)};
+            for (const auto &saved_reference : potentially_broken_references) {
+              if (core::try_get(schema, saved_reference.target_pointer)) {
+                continue;
+              }
+
+              // If the origin was also relocated, resolve its new location
+              auto effective_origin{saved_reference.origin};
+              if (!core::try_get(schema, saved_reference.origin.initial())) {
+                const auto new_origin{rule->rereference(
+                    saved_reference.destination, saved_reference.origin,
+                    saved_reference.origin.slice(resource_offset),
+                    current_slice)};
+                if (!new_origin.has_value()) {
+                  continue;
+                }
+                effective_origin =
+                    saved_reference.origin.slice(0, resource_offset)
+                        .concat(new_origin.value());
+                if (!core::try_get(schema, effective_origin.initial())) {
+                  continue;
+                }
+              }
+
+              const auto new_relative{rule->rereference(
+                  saved_reference.destination, saved_reference.origin,
+                  saved_reference.target_pointer.slice(
+                      saved_reference.target_relative_pointer),
+                  current_slice)};
+              if (!new_relative.has_value()) {
+                continue;
+              }
+              const auto new_fragment{
+                  saved_reference.fragment ==
+                          core::to_string(saved_reference.target_pointer)
+                      ? saved_reference.target_pointer
+                            .slice(0, saved_reference.target_relative_pointer)
+                            .concat(new_relative.value())
+                      : new_relative.value()};
+
+              core::URI original{saved_reference.original};
+              original.fragment(core::to_string(new_fragment));
+              core::set(schema, effective_origin,
+                        core::JSON{original.recompose()});
+              references_fixed = true;
+            }
+
+            const auto new_vocabularies{
+                frame->vocabularies(new_location.value().get(), resolver)};
+
+            assert(!rule->condition(current, schema, new_vocabularies, *frame,
+                                    new_location.value().get(), walker,
+                                    resolver));
+
+            std::tuple<core::Pointer, std::string_view, core::JSON> mark{
+                entry_pointer, rule->name(), current};
+            assert(!processed_rules.contains(mark));
+            processed_rules.emplace(std::move(mark));
+
+            if (references_fixed) {
+              frame.reset();
+            }
+
+            if (references_fixed || reframe_after_transform) {
+              return true;
             }
           }
 
-          const auto new_relative{rule->rereference(
-              saved_reference.destination, saved_reference.origin,
-              saved_reference.target_pointer.slice(
-                  saved_reference.target_relative_pointer),
-              current_slice)};
-          if (!new_relative.has_value()) {
-            continue;
-          }
-          const auto new_fragment{
-              saved_reference.fragment ==
-                      core::to_string(saved_reference.target_pointer)
-                  ? saved_reference.target_pointer
-                        .slice(0, saved_reference.target_relative_pointer)
-                        .concat(new_relative.value())
-                  : new_relative.value()};
+          return false;
+        })};
 
-          core::URI original{saved_reference.original};
-          original.fragment(core::to_string(new_fragment));
-          core::set(schema, effective_origin, core::JSON{original.recompose()});
-          references_fixed = true;
-        }
-
-        const auto new_vocabularies{
-            frame->vocabularies(new_location.value().get(), resolver)};
-
-        assert(!rule->condition(current, schema, new_vocabularies, *frame,
-                                new_location.value().get(), walker, resolver));
-
-        std::tuple<core::Pointer, std::string_view, core::JSON> mark{
-            entry_pointer, rule->name(), current};
-        assert(!processed_rules.contains(mark));
-        processed_rules.emplace(std::move(mark));
-
-        if (references_fixed) {
-          frame.reset();
-        }
-
-        if (references_fixed || reframe_after_transform) {
-          goto blaze_transformer_start_again;
-        }
-      }
-    }
-
-  blaze_transformer_start_again:
     if (!applied) {
       break;
     }

--- a/src/canonicalizer/canonicalize.cc
+++ b/src/canonicalizer/canonicalize.cc
@@ -116,29 +116,25 @@ auto apply(const std::vector<Rule> &rules, sourcemeta::core::JSON &schema,
             }
 
             potentially_broken_references.clear();
-            frame->for_each_reference(
-                [&](const blaze::SchemaReferenceType,
-                    const core::WeakPointer &origin,
-                    const blaze::SchemaFrame::ReferencesEntry &reference)
-                    -> void {
-                  const auto destination{
-                      frame->traverse(reference.destination)};
-                  if (!destination.has_value() ||
-                      !reference.fragment.has_value() ||
-                      !reference.fragment.value().starts_with('/')) {
-                    return;
-                  }
+            frame->for_each_reference([&](const blaze::SchemaReferenceType,
+                                          const core::WeakPointer &origin,
+                                          const blaze::SchemaFrame::Reference
+                                              &reference) -> void {
+              const auto destination{frame->traverse(reference.destination)};
+              if (!destination.has_value() || !reference.fragment.has_value() ||
+                  !reference.fragment.value().starts_with('/')) {
+                return;
+              }
 
-                  const auto &target{destination.value().get()};
-                  potentially_broken_references.push_back(
-                      {.origin = core::to_pointer(origin),
-                       .original = core::JSON::String{reference.original},
-                       .destination = reference.destination,
-                       .fragment =
-                           core::JSON::String{reference.fragment.value()},
-                       .target_pointer = core::to_pointer(target.pointer),
-                       .target_relative_pointer = target.relative_pointer});
-                });
+              const auto &target{destination.value().get()};
+              potentially_broken_references.push_back(
+                  {.origin = core::to_pointer(origin),
+                   .original = core::JSON::String{reference.original},
+                   .destination = reference.destination,
+                   .fragment = core::JSON::String{reference.fragment.value()},
+                   .target_pointer = core::to_pointer(target.pointer),
+                   .target_relative_pointer = target.relative_pointer});
+            });
 
             rule->transform(current);
 

--- a/src/canonicalizer/rules/inline_single_use_ref.h
+++ b/src/canonicalizer/rules/inline_single_use_ref.h
@@ -63,16 +63,21 @@ public:
     ONLY_CONTINUE_IF(container == "definitions" || container == "$defs");
 
     std::size_t ref_count{0};
-    for (const auto &reference : frame.references()) {
-      const auto dest{frame.traverse(reference.second.destination)};
-      if (!dest.has_value()) {
-        continue;
-      }
-      if (dest->get().pointer.starts_with(target_pointer) ||
-          target_pointer.starts_with(dest->get().pointer)) {
-        ++ref_count;
-      }
-    }
+    frame.for_each_reference(
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const sourcemeta::core::WeakPointer &,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            -> void {
+          const auto dest{frame.traverse(reference.destination)};
+          if (!dest.has_value()) {
+            return;
+          }
+
+          if (dest->get().pointer.starts_with(target_pointer) ||
+              target_pointer.starts_with(dest->get().pointer)) {
+            ++ref_count;
+          }
+        });
 
     ONLY_CONTINUE_IF(ref_count == 1);
 

--- a/src/canonicalizer/rules/inline_single_use_ref.h
+++ b/src/canonicalizer/rules/inline_single_use_ref.h
@@ -66,7 +66,7 @@ public:
     frame.for_each_reference(
         [&](const sourcemeta::blaze::SchemaReferenceType,
             const sourcemeta::core::WeakPointer &,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            const sourcemeta::blaze::SchemaFrame::Reference &reference)
             -> void {
           const auto dest{frame.traverse(reference.destination)};
           if (!dest.has_value()) {

--- a/src/canonicalizer/rules/orphan_definitions.h
+++ b/src/canonicalizer/rules/orphan_definitions.h
@@ -85,7 +85,7 @@ private:
         pointer,
         [&](const sourcemeta::blaze::SchemaReferenceType,
             const sourcemeta::core::WeakPointer &source_pointer,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) -> bool {
+            const sourcemeta::blaze::SchemaFrame::Reference &) -> bool {
           if (source_pointer.empty()) {
             return true;
           }

--- a/src/canonicalizer/rules/orphan_definitions.h
+++ b/src/canonicalizer/rules/orphan_definitions.h
@@ -66,19 +66,13 @@ private:
   subtree_has_dynamic_anchor(const sourcemeta::blaze::SchemaFrame &frame,
                              const sourcemeta::core::WeakPointer &entry_pointer)
       -> bool {
-    for (const auto &[key, location] : frame.locations()) {
-      if (key.first != sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-        continue;
-      }
-      if (location.type !=
-          sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-        continue;
-      }
-      if (location.pointer.starts_with(entry_pointer)) {
-        return true;
-      }
-    }
-    return false;
+    return frame.any_anchor(
+        sourcemeta::blaze::SchemaReferenceType::Dynamic,
+        [&entry_pointer](
+            const std::string_view,
+            const sourcemeta::blaze::SchemaFrame::Location &location) -> bool {
+          return location.pointer.starts_with(entry_pointer);
+        });
   }
 
   static auto has_reachable_reference_through(
@@ -87,31 +81,22 @@ private:
       const sourcemeta::blaze::SchemaWalker &walker,
       const sourcemeta::blaze::SchemaResolver &resolver,
       const sourcemeta::core::WeakPointer &pointer) -> bool {
-    for (const auto &reference : frame.references()) {
-      const auto destination{frame.traverse(reference.second.destination)};
-      if (!destination.has_value()) {
-        continue;
-      }
+    return frame.any_reference_into(
+        pointer,
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const sourcemeta::core::WeakPointer &source_pointer,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) -> bool {
+          if (source_pointer.empty()) {
+            return true;
+          }
 
-      if (!destination->get().pointer.starts_with(pointer)) {
-        continue;
-      }
-
-      const auto &source_pointer{reference.first.second};
-      if (source_pointer.empty()) {
-        return true;
-      }
-
-      const auto source_location{frame.traverse(
-          source_pointer.initial(),
-          sourcemeta::blaze::SchemaFrame::LocationType::Subschema)};
-      if (source_location.has_value() &&
-          frame.is_reachable(base, source_location->get(), walker, resolver)) {
-        return true;
-      }
-    }
-
-    return false;
+          const auto source_location{frame.traverse(
+              source_pointer.initial(),
+              sourcemeta::blaze::SchemaFrame::LocationType::Subschema)};
+          return source_location.has_value() &&
+                 frame.is_reachable(base, source_location->get(), walker,
+                                    resolver);
+        });
   }
 
   static auto

--- a/src/canonicalizer/rules/type_with_applicator_to_allof.h
+++ b/src/canonicalizer/rules/type_with_applicator_to_allof.h
@@ -114,7 +114,7 @@ public:
         location.pointer,
         [&](const sourcemeta::blaze::SchemaReferenceType,
             const sourcemeta::core::WeakPointer &source_pointer,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            const sourcemeta::blaze::SchemaFrame::Reference &reference)
             -> void {
           const auto relative{source_pointer.resolve_from(location.pointer)};
           if (relative.empty() || !relative.at(0).is_property()) {
@@ -159,7 +159,7 @@ public:
           location.pointer,
           [&](const sourcemeta::blaze::SchemaReferenceType,
               const sourcemeta::core::WeakPointer &source_pointer,
-              const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+              const sourcemeta::blaze::SchemaFrame::Reference &reference)
               -> bool {
             const auto relative_src{
                 source_pointer.resolve_from(location.pointer)};

--- a/src/canonicalizer/rules/type_with_applicator_to_allof.h
+++ b/src/canonicalizer/rules/type_with_applicator_to_allof.h
@@ -110,22 +110,30 @@ public:
 
     this->strategy_ = Strategy::FullRestructure;
     this->applicators_with_refs_ = 0;
-    for (const auto &reference : frame.references()) {
-      const auto &source_pointer{reference.first.second};
-      if (!source_pointer.starts_with(location.pointer)) {
-        continue;
-      }
-      const auto relative{source_pointer.resolve_from(location.pointer)};
-      if (relative.empty() || !relative.at(0).is_property()) {
-        continue;
-      }
-      const auto &first_keyword{relative.at(0).to_property()};
-      const auto bit{applicator_bit(first_keyword)};
-      if (bit != 0) {
-        const auto destination{frame.traverse(reference.second.destination)};
-        if (destination.has_value()) {
-          const auto &dest_pointer{destination->get().pointer};
-          if (dest_pointer.starts_with(location.pointer)) {
+    frame.for_each_reference_from(
+        location.pointer,
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const sourcemeta::core::WeakPointer &source_pointer,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            -> void {
+          const auto relative{source_pointer.resolve_from(location.pointer)};
+          if (relative.empty() || !relative.at(0).is_property()) {
+            return;
+          }
+
+          const auto &first_keyword{relative.at(0).to_property()};
+          const auto bit{applicator_bit(first_keyword)};
+          if (bit == 0) {
+            return;
+          }
+
+          const auto destination{frame.traverse(reference.destination)};
+          if (destination.has_value()) {
+            const auto &dest_pointer{destination->get().pointer};
+            if (!dest_pointer.starts_with(location.pointer)) {
+              return;
+            }
+
             const auto relative_dest{
                 dest_pointer.resolve_from(location.pointer)};
             if (!relative_dest.empty() && relative_dest.at(0).is_property() &&
@@ -133,16 +141,13 @@ public:
                  relative_dest.at(0).to_property() == "$defs" ||
                  relative_dest.at(0).to_property() == "dependencies" ||
                  relative_dest.at(0).to_property() == "dependentSchemas")) {
-              continue;
+              return;
             }
-          } else {
-            continue;
           }
-        }
-        this->strategy_ = Strategy::SafeExtract;
-        this->applicators_with_refs_ |= bit;
-      }
-    }
+
+          this->strategy_ = Strategy::SafeExtract;
+          this->applicators_with_refs_ |= bit;
+        });
 
     if (this->strategy_ == Strategy::SafeExtract && !has_structural) {
       if (!has_allof) {
@@ -150,39 +155,38 @@ public:
         return true;
       }
 
-      bool all_refs_fixed{true};
-      for (const auto &reference : frame.references()) {
-        const auto &source_pointer{reference.first.second};
-        if (!source_pointer.starts_with(location.pointer)) {
-          continue;
-        }
-        const auto relative_src{source_pointer.resolve_from(location.pointer)};
-        if (relative_src.empty() || !relative_src.at(0).is_property()) {
-          continue;
-        }
-        const auto &src_keyword{relative_src.at(0).to_property()};
-        if (src_keyword != "not" && src_keyword != "anyOf" &&
-            src_keyword != "oneOf" &&
-            !(this->has_if_then_else_ &&
-              (src_keyword == "if" || src_keyword == "then" ||
-               src_keyword == "else"))) {
-          continue;
-        }
+      const auto all_refs_fixed{!frame.any_reference_from(
+          location.pointer,
+          [&](const sourcemeta::blaze::SchemaReferenceType,
+              const sourcemeta::core::WeakPointer &source_pointer,
+              const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+              -> bool {
+            const auto relative_src{
+                source_pointer.resolve_from(location.pointer)};
+            if (relative_src.empty() || !relative_src.at(0).is_property()) {
+              return false;
+            }
 
-        const auto destination{frame.traverse(reference.second.destination)};
-        if (!destination.has_value()) {
-          all_refs_fixed = false;
-          break;
-        }
+            const auto &src_keyword{relative_src.at(0).to_property()};
+            if (src_keyword != "not" && src_keyword != "anyOf" &&
+                src_keyword != "oneOf" &&
+                !(this->has_if_then_else_ &&
+                  (src_keyword == "if" || src_keyword == "then" ||
+                   src_keyword == "else"))) {
+              return false;
+            }
 
-        const auto relative_dest{
-            destination->get().pointer.resolve_from(location.pointer)};
-        if (relative_dest.empty() || !relative_dest.at(0).is_property() ||
-            relative_dest.at(0).to_property() != "allOf") {
-          all_refs_fixed = false;
-          break;
-        }
-      }
+            const auto destination{frame.traverse(reference.destination)};
+            if (!destination.has_value()) {
+              return true;
+            }
+
+            const auto relative_dest{
+                destination->get().pointer.resolve_from(location.pointer)};
+            return relative_dest.empty() ||
+                   !relative_dest.at(0).is_property() ||
+                   relative_dest.at(0).to_property() != "allOf";
+          })};
 
       if (all_refs_fixed) {
         this->strategy_ = Strategy::MergeIntoAllOf;

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -94,30 +94,26 @@ auto compile(const sourcemeta::core::JSON &input,
                      sourcemeta::core::WeakPointer::Comparator>
       visited;
   CodegenIRResult result;
-  for (const auto &[key, location] : frame.locations()) {
-    if (location.type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-        location.type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-      continue;
-    }
+  frame.for_each_subschema(
+      [&](const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
+        // Framing may report resource twice or more given default identifiers
+        // and nested resources
+        const auto [visited_iterator, inserted] =
+            visited.insert(location.pointer);
+        if (!inserted) {
+          return;
+        }
 
-    // Framing may report resource twice or more given default identifiers and
-    // nested resources
-    const auto [visited_iterator, inserted] = visited.insert(location.pointer);
-    if (!inserted) {
-      continue;
-    }
+        // Skip subschemas under validation-only keywords that do not contribute
+        // to the type structure (like `contains`)
+        if (is_validation_subschema(frame, location, walker, resolver)) {
+          return;
+        }
 
-    // Skip subschemas under validation-only keywords that do not contribute
-    // to the type structure (like `contains`)
-    if (is_validation_subschema(frame, location, walker, resolver)) {
-      continue;
-    }
-
-    const auto &subschema{sourcemeta::core::get(schema, location.pointer)};
-    result.push_back(compiler(schema, frame, location, resolver, subschema));
-  }
+        const auto &subschema{sourcemeta::core::get(schema, location.pointer)};
+        result.push_back(
+            compiler(schema, frame, location, resolver, subschema));
+      });
 
   // --------------------------------------------------------------------------
   // (5) Sort entries so that dependencies come before dependents

--- a/src/codegen/codegen_default_compiler.h
+++ b/src/codegen/codegen_default_compiler.h
@@ -481,12 +481,11 @@ auto handle_ref(const sourcemeta::core::JSON &schema,
   ref_pointer.push_back("$ref");
   const auto ref_weak_pointer{sourcemeta::core::to_weak_pointer(ref_pointer)};
 
-  const auto &references{frame.references()};
-  const auto reference{references.find(
-      {sourcemeta::blaze::SchemaReferenceType::Static, ref_weak_pointer})};
-  assert(reference != references.cend());
+  const auto reference{frame.reference(
+      sourcemeta::blaze::SchemaReferenceType::Static, ref_weak_pointer)};
+  assert(reference.has_value());
 
-  const auto &destination{reference->second.destination};
+  const auto &destination{reference.value().get().destination};
   const auto target{frame.traverse(destination)};
   if (!target.has_value()) {
     throw CodegenUnexpectedSchemaError(
@@ -519,14 +518,12 @@ auto handle_dynamic_ref(
   ref_pointer.push_back("$dynamicRef");
   const auto ref_weak_pointer{sourcemeta::core::to_weak_pointer(ref_pointer)};
 
-  const auto &references{frame.references()};
-
   // Note: The frame internally converts single-target dynamic references to
   // static reference
-  const auto static_reference{references.find(
-      {sourcemeta::blaze::SchemaReferenceType::Static, ref_weak_pointer})};
-  if (static_reference != references.cend()) {
-    const auto &destination{static_reference->second.destination};
+  const auto static_reference{frame.reference(
+      sourcemeta::blaze::SchemaReferenceType::Static, ref_weak_pointer)};
+  if (static_reference.has_value()) {
+    const auto &destination{static_reference.value().get().destination};
     const auto target{frame.traverse(destination)};
     if (!target.has_value()) {
       throw CodegenUnexpectedSchemaError(
@@ -544,28 +541,29 @@ auto handle_dynamic_ref(
 
   // Multi-target dynamic reference: find all dynamic anchors with the matching
   // fragment and emit a union of all possible targets
-  const auto dynamic_reference{references.find(
-      {sourcemeta::blaze::SchemaReferenceType::Dynamic, ref_weak_pointer})};
-  assert(dynamic_reference != references.cend());
-  assert(dynamic_reference->second.fragment.has_value());
-  const auto &fragment{dynamic_reference->second.fragment.value()};
+  const auto dynamic_reference{frame.reference(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic, ref_weak_pointer)};
+  assert(dynamic_reference.has_value());
+  assert(dynamic_reference.value().get().fragment.has_value());
+  const auto &fragment{dynamic_reference.value().get().fragment.value()};
 
   std::vector<CodegenIRType> branches;
-  for (const auto &[key, entry] : frame.locations()) {
-    if (key.first != sourcemeta::blaze::SchemaReferenceType::Dynamic ||
-        entry.type != sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-      continue;
-    }
+  frame.for_each_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic,
+      [&](const std::string_view uri,
+          const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+        const sourcemeta::core::URI anchor_uri{
+            sourcemeta::core::JSON::String{uri}};
+        const auto anchor_fragment{anchor_uri.fragment()};
+        if (!anchor_fragment.has_value() ||
+            anchor_fragment.value() != fragment) {
+          return;
+        }
 
-    const sourcemeta::core::URI anchor_uri{key.second};
-    const auto anchor_fragment{anchor_uri.fragment()};
-    if (!anchor_fragment.has_value() || anchor_fragment.value() != fragment) {
-      continue;
-    }
-
-    branches.push_back({.pointer = sourcemeta::core::to_pointer(entry.pointer),
-                        .symbol = symbol(frame, entry)});
-  }
+        branches.push_back(
+            {.pointer = sourcemeta::core::to_pointer(entry.pointer),
+             .symbol = symbol(frame, entry)});
+      });
 
   assert(!branches.empty());
   return CodegenIRUnion{

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -21,6 +21,14 @@
 
 namespace {
 
+// A `$schema` reference points at a meta-schema rather than into the schema
+// itself, so reference planning ignores it
+auto is_metaschema_reference(const sourcemeta::core::WeakPointer &origin)
+    -> bool {
+  return !origin.empty() && origin.back().is_property() &&
+         origin.back().to_property() == "$schema";
+}
+
 auto compile_subschema(const sourcemeta::blaze::Context &context,
                        const sourcemeta::blaze::SchemaContext &schema_context,
                        const sourcemeta::blaze::DynamicContext &dynamic_context)
@@ -66,9 +74,10 @@ auto compile_subschema(const sourcemeta::blaze::Context &context,
               .base_instance_location = dynamic_context.base_instance_location},
              steps)) {
       // Just a sanity check to ensure every keyword location is indeed valid
-      assert(context.frame.locations().contains(
-          {sourcemeta::blaze::SchemaReferenceType::Static,
-           context.extra[step.extra_index].keyword_location}));
+      assert(context.frame
+                 .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                           context.extra[step.extra_index].keyword_location)
+                 .has_value());
       steps.push_back(std::move(step));
     }
   }
@@ -93,34 +102,25 @@ auto defines_any_whitelisted_keyword(
                                  sourcemeta::core::JSON::Object::hash(keyword));
   }
 
-  for (const auto &entry : frame.locations()) {
-    if (entry.second.type ==
-            sourcemeta::blaze::SchemaFrame::LocationType::Pointer ||
-        entry.second.type ==
-            sourcemeta::blaze::SchemaFrame::LocationType::Anchor) {
-      continue;
-    }
+  return frame.any_subschema(
+      [&](const sourcemeta::blaze::SchemaFrame::Location &location) -> bool {
+        const auto &subschema{sourcemeta::core::get(schema, location.pointer)};
+        if (!subschema.is_object()) {
+          return false;
+        }
 
-    const auto &subschema{sourcemeta::core::get(schema, entry.second.pointer)};
-    if (!subschema.is_object()) {
-      continue;
-    }
+        bool defines_keyword{false};
+        for (const auto &[keyword, keyword_hash] : hashed_keywords) {
+          if (subschema.defines(keyword, keyword_hash)) {
+            defines_keyword = true;
+            break;
+          }
+        }
 
-    bool defines_keyword{false};
-    for (const auto &[keyword, keyword_hash] : hashed_keywords) {
-      if (subschema.defines(keyword, keyword_hash)) {
-        defines_keyword = true;
-        break;
-      }
-    }
-
-    if (defines_keyword && frame.is_reachable(entrypoint_location, entry.second,
-                                              walker, resolver)) {
-      return true;
-    }
-  }
-
-  return false;
+        return defines_keyword &&
+               frame.is_reachable(entrypoint_location, location, walker,
+                                  resolver);
+      });
 }
 
 // TODO: Somehow move this logic up to `SchemaFrame`
@@ -128,22 +128,24 @@ auto schema_frame_populate_target_types(
     const sourcemeta::blaze::SchemaFrame &frame,
     std::unordered_map<std::string_view, std::pair<bool, bool>> &target_types)
     -> void {
-  for (const auto &reference : frame.references()) {
-    if (!reference.first.second.empty() &&
-        reference.first.second.back().is_property() &&
-        reference.first.second.back().to_property() == "$schema") {
-      continue;
-    }
+  frame.for_each_reference(
+      [&](const sourcemeta::blaze::SchemaReferenceType,
+          const sourcemeta::core::WeakPointer &origin,
+          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+          -> void {
+        if (is_metaschema_reference(origin)) {
+          return;
+        }
 
-    const auto reference_location{frame.traverse(reference.first.second)};
-    assert(reference_location.has_value());
-    auto &context{target_types[reference.second.destination]};
-    if (reference_location->get().property_name) {
-      context.first = true;
-    } else {
-      context.second = true;
-    }
-  }
+        const auto reference_location{frame.traverse(origin)};
+        assert(reference_location.has_value());
+        auto &context{target_types[reference.destination]};
+        if (reference_location->get().property_name) {
+          context.first = true;
+        } else {
+          context.second = true;
+        }
+      });
 
   std::unordered_map<std::string_view, const sourcemeta::core::WeakPointer *>
       destination_pointers;
@@ -157,21 +159,23 @@ auto schema_frame_populate_target_types(
 
   std::unordered_map<std::string_view, std::vector<std::string_view>>
       references_within;
-  for (const auto &reference : frame.references()) {
-    if (!reference.first.second.empty() &&
-        reference.first.second.back().is_property() &&
-        reference.first.second.back().to_property() == "$schema") {
-      continue;
-    }
+  frame.for_each_reference(
+      [&](const sourcemeta::blaze::SchemaReferenceType,
+          const sourcemeta::core::WeakPointer &origin,
+          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+          -> void {
+        if (is_metaschema_reference(origin)) {
+          return;
+        }
 
-    for (const auto &[destination, destination_pointer] :
-         destination_pointers) {
-      if (reference.first.second.starts_with(*destination_pointer) &&
-          reference.first.second.size() > destination_pointer->size()) {
-        references_within[destination].push_back(reference.second.destination);
-      }
-    }
-  }
+        for (const auto &[destination, destination_pointer] :
+             destination_pointers) {
+          if (origin.starts_with(*destination_pointer) &&
+              origin.size() > destination_pointer->size()) {
+            references_within[destination].push_back(reference.destination);
+          }
+        }
+      });
 
   bool changed{true};
   while (changed) {
@@ -237,12 +241,11 @@ auto compile(const sourcemeta::core::JSON &schema,
   ///////////////////////////////////////////////////////////////////
 
   std::vector<std::string> resources;
-  for (const auto &entry : frame.locations()) {
-    if (entry.second.type ==
-        sourcemeta::blaze::SchemaFrame::LocationType::Resource) {
-      resources.push_back(entry.first.second);
-    }
-  }
+  frame.for_each_resource(
+      [&resources](const std::string_view uri,
+                   const sourcemeta::blaze::SchemaFrame::Location &) -> void {
+        resources.emplace_back(uri);
+      });
 
   // Rule out any duplicates as we will use this list as the
   // source for a perfect hash function on schema resources.
@@ -256,16 +259,9 @@ auto compile(const sourcemeta::core::JSON &schema,
   // (2) Check if the schema relies on dynamic scopes
   ///////////////////////////////////////////////////////////////////
 
-  bool uses_dynamic_scopes{false};
-  for (const auto &reference : frame.references()) {
-    // Check whether dynamic referencing takes places in this schema. If not,
-    // we can avoid the overhead of keeping track of dynamics scopes, etc
-    if (reference.first.first ==
-        sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-      uses_dynamic_scopes = true;
-      break;
-    }
-  }
+  // If dynamic referencing does not take place in this schema, we can avoid
+  // the overhead of keeping track of dynamic scopes, etc
+  const auto uses_dynamic_scopes{frame.has_dynamic_references()};
 
   ///////////////////////////////////////////////////////////////////
   // (3) Plan which static references we will precompile
@@ -283,71 +279,69 @@ auto compile(const sourcemeta::core::JSON &schema,
                       entrypoint, false),
       std::make_pair(0, nullptr));
 
-  for (const auto &reference : frame.references()) {
-    // Ignore meta-schema references
-    if (!reference.first.second.empty() &&
-        reference.first.second.back().is_property() &&
-        reference.first.second.back().to_property() == "$schema") {
-      continue;
-    }
+  frame.for_each_reference(
+      [&](const sourcemeta::blaze::SchemaReferenceType type,
+          const sourcemeta::core::WeakPointer &origin,
+          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+          -> void {
+        if (is_metaschema_reference(origin)) {
+          return;
+        }
 
-    auto reference_origin{frame.traverse(reference.first.second)};
-    assert(reference_origin.has_value());
-    while (reference_origin->get().type ==
-               sourcemeta::blaze::SchemaFrame::LocationType::Pointer &&
-           reference_origin->get().parent.has_value()) {
-      reference_origin = frame.traverse(reference_origin->get().parent.value());
-      assert(reference_origin.has_value());
-    }
+        auto reference_origin{frame.traverse(origin)};
+        assert(reference_origin.has_value());
+        while (reference_origin->get().type ==
+                   sourcemeta::blaze::SchemaFrame::LocationType::Pointer &&
+               reference_origin->get().parent.has_value()) {
+          reference_origin =
+              frame.traverse(reference_origin->get().parent.value());
+          assert(reference_origin.has_value());
+        }
 
-    // Skip unreachable targets
-    if (reference_origin->get().type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Pointer &&
-        !frame.is_reachable(entrypoint_location, reference_origin->get(),
-                            walker, resolver)) {
-      continue;
-    }
+        // Skip unreachable targets
+        if (reference_origin->get().type !=
+                sourcemeta::blaze::SchemaFrame::LocationType::Pointer &&
+            !frame.is_reachable(entrypoint_location, reference_origin->get(),
+                                walker, resolver)) {
+          return;
+        }
 
-    assert(target_types.contains(reference.second.destination));
-    const auto &[needs_name,
-                 needs_instance]{target_types.at(reference.second.destination)};
+        assert(target_types.contains(reference.destination));
+        const auto &[needs_name,
+                     needs_instance]{target_types.at(reference.destination)};
 
-    if (needs_name) {
-      targets_map.emplace(
-          std::make_tuple(reference.first.first,
-                          std::string_view{reference.second.destination}, true),
-          std::make_pair(targets_map.size(), &reference.first.second));
-    }
+        if (needs_name) {
+          targets_map.emplace(
+              std::make_tuple(type, std::string_view{reference.destination},
+                              true),
+              std::make_pair(targets_map.size(), &origin));
+        }
 
-    if (needs_instance) {
-      targets_map.emplace(
-          std::make_tuple(reference.first.first,
-                          std::string_view{reference.second.destination},
-                          false),
-          std::make_pair(targets_map.size(), &reference.first.second));
-    }
-  }
+        if (needs_instance) {
+          targets_map.emplace(
+              std::make_tuple(type, std::string_view{reference.destination},
+                              false),
+              std::make_pair(targets_map.size(), &origin));
+        }
+      });
 
   // Also add dynamic anchors that may not be directly referenced
   // but could be used as override targets during dynamic resolution
-  for (const auto &entry : frame.locations()) {
-    if (entry.second.type !=
-            sourcemeta::blaze::SchemaFrame::LocationType::Anchor ||
-        entry.first.first != sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-      continue;
-    }
+  frame.for_each_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic,
+      [&](const std::string_view uri,
+          const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
+        // Skip unreachable dynamic anchors
+        if (!frame.is_reachable(entrypoint_location, location, walker,
+                                resolver)) {
+          return;
+        }
 
-    // Skip unreachable dynamic anchors
-    if (!frame.is_reachable(entrypoint_location, entry.second, walker,
-                            resolver)) {
-      continue;
-    }
-
-    targets_map.emplace(std::make_tuple(entry.first.first,
-                                        std::string_view{entry.first.second},
-                                        false),
-                        std::make_pair(targets_map.size(), nullptr));
-  }
+        targets_map.emplace(
+            std::make_tuple(sourcemeta::blaze::SchemaReferenceType::Dynamic,
+                            uri, false),
+            std::make_pair(targets_map.size(), nullptr));
+      });
 
   ///////////////////////////////////////////////////////////////////
   // (4) Build the global compilation context
@@ -379,39 +373,34 @@ auto compile(const sourcemeta::core::JSON &schema,
 
   std::vector<std::pair<std::size_t, std::size_t>> labels_map;
   if (uses_dynamic_scopes) {
-    for (const auto &entry : context.frame.locations()) {
-      // We are only trying to find dynamic anchors
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Anchor ||
-          entry.first.first !=
-              sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-        continue;
-      }
+    context.frame.for_each_anchor(
+        sourcemeta::blaze::SchemaReferenceType::Dynamic,
+        [&](const std::string_view uri,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          // Skip unreachable dynamic anchors
+          if (!context.frame.is_reachable(entrypoint_location, entry,
+                                          context.walker, context.resolver)) {
+            return;
+          }
 
-      // Skip unreachable dynamic anchors
-      if (!context.frame.is_reachable(entrypoint_location, entry.second,
-                                      context.walker, context.resolver)) {
-        continue;
-      }
+          // Compute the hash for this dynamic anchor
+          const sourcemeta::core::URI anchor_uri{uri};
+          const auto label{Evaluator::hash(
+              schema_resource_id(
+                  context.resources,
+                  anchor_uri.recompose_without_fragment().value_or("")),
+              anchor_uri.fragment().value_or(""))};
 
-      // Compute the hash for this dynamic anchor
-      const sourcemeta::core::URI anchor_uri{entry.first.second};
-      const auto label{Evaluator::hash(
-          schema_resource_id(
-              context.resources,
-              anchor_uri.recompose_without_fragment().value_or("")),
-          anchor_uri.fragment().value_or(""))};
+          // Find the index in targets for this dynamic anchor
+          const auto key{
+              std::make_tuple(sourcemeta::blaze::SchemaReferenceType::Dynamic,
+                              std::string_view{uri}, false)};
+          assert(context.targets.contains(key));
+          const auto index{context.targets.at(key).first};
+          assert(index < context.targets.size());
 
-      // Find the index in targets for this dynamic anchor
-      const auto key{
-          std::make_tuple(sourcemeta::blaze::SchemaReferenceType::Dynamic,
-                          std::string_view{entry.first.second}, false)};
-      assert(context.targets.contains(key));
-      const auto index{context.targets.at(key).first};
-      assert(index < context.targets.size());
-
-      labels_map.emplace_back(label, index);
-    }
+          labels_map.emplace_back(label, index);
+        });
   }
 
   ///////////////////////////////////////////////////////////////////
@@ -546,16 +535,20 @@ auto compile(const Context &context, const SchemaContext &schema_context,
                 .recompose()};
 
   // Otherwise the recursion attempt is non-sense
-  if (!context.frame.locations().contains(
-          {sourcemeta::blaze::SchemaReferenceType::Static, destination}))
-      [[unlikely]] {
+  if (!context.frame
+           .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                     destination)
+           .has_value()) [[unlikely]] {
     throw sourcemeta::blaze::SchemaReferenceError(
         destination, to_pointer(schema_context.relative_pointer),
         "The target of the reference does not exist in the schema");
   }
 
-  const auto &entry{context.frame.locations().at(
-      {sourcemeta::blaze::SchemaReferenceType::Static, destination})};
+  const auto &entry{
+      context.frame
+          .location(sourcemeta::blaze::SchemaReferenceType::Static, destination)
+          .value()
+          .get()};
   const auto &new_schema{get(context.root, entry.pointer)};
   assert((new_schema.is_object() || new_schema.is_boolean()));
 

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -131,8 +131,7 @@ auto schema_frame_populate_target_types(
   frame.for_each_reference(
       [&](const sourcemeta::blaze::SchemaReferenceType,
           const sourcemeta::core::WeakPointer &origin,
-          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
-          -> void {
+          const sourcemeta::blaze::SchemaFrame::Reference &reference) -> void {
         if (is_metaschema_reference(origin)) {
           return;
         }
@@ -162,8 +161,7 @@ auto schema_frame_populate_target_types(
   frame.for_each_reference(
       [&](const sourcemeta::blaze::SchemaReferenceType,
           const sourcemeta::core::WeakPointer &origin,
-          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
-          -> void {
+          const sourcemeta::blaze::SchemaFrame::Reference &reference) -> void {
         if (is_metaschema_reference(origin)) {
           return;
         }
@@ -282,8 +280,7 @@ auto compile(const sourcemeta::core::JSON &schema,
   frame.for_each_reference(
       [&](const sourcemeta::blaze::SchemaReferenceType type,
           const sourcemeta::core::WeakPointer &origin,
-          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
-          -> void {
+          const sourcemeta::blaze::SchemaFrame::Reference &reference) -> void {
         if (is_metaschema_reference(origin)) {
           return;
         }

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -329,8 +329,8 @@ inline auto static_frame_entry(const Context &context,
   const auto current{
       to_uri(schema_context.relative_pointer, schema_context.base).recompose()};
   const auto type{sourcemeta::blaze::SchemaReferenceType::Static};
-  assert(context.frame.locations().contains({type, current}));
-  return context.frame.locations().at({type, current});
+  assert(context.frame.location(type, current).has_value());
+  return context.frame.location(type, current).value().get();
 }
 
 // Whether the current keyword value, as a schema, contains any nested
@@ -342,18 +342,11 @@ inline auto defines_nested_subschemas(const Context &context,
                                       const SchemaContext &schema_context)
     -> bool {
   const auto &entry{static_frame_entry(context, schema_context)};
-  for (const auto &location : context.frame.locations()) {
-    if ((location.second.type ==
-             sourcemeta::blaze::SchemaFrame::LocationType::Subschema ||
-         location.second.type ==
-             sourcemeta::blaze::SchemaFrame::LocationType::Resource) &&
-        location.second.pointer.starts_with(entry.pointer) &&
-        location.second.pointer.size() > entry.pointer.size()) {
-      return true;
-    }
-  }
-
-  return false;
+  return context.frame.any_subschema_under(
+      entry.pointer,
+      [](const sourcemeta::blaze::SchemaFrame::Location &) -> bool {
+        return true;
+      });
 }
 
 // TODO: Get rid of this given the new Core regex optimisations
@@ -391,14 +384,15 @@ inline auto find_adjacent(const Context &context,
                    make_weak_pointer(ref_keyword)),
                schema_context.base)
             .recompose()};
-    assert(
-        context.frame.locations().contains({reference_type, destination_uri}));
+    assert(context.frame.location(reference_type, destination_uri).has_value());
     const auto &destination{
-        context.frame.locations().at({reference_type, destination_uri})};
-    assert(context.frame.references().contains(
-        {reference_type, destination.pointer}));
+        context.frame.location(reference_type, destination_uri).value().get()};
+    assert(context.frame.reference(reference_type, destination.pointer)
+               .has_value());
     const auto &reference{
-        context.frame.references().at({reference_type, destination.pointer})};
+        context.frame.reference(reference_type, destination.pointer)
+            .value()
+            .get()};
     const auto keyword_uri{
         sourcemeta::core::to_uri(
             sourcemeta::core::to_pointer(
@@ -416,15 +410,19 @@ inline auto find_adjacent(const Context &context,
   std::vector<std::reference_wrapper<const sourcemeta::core::JSON>> result;
 
   for (const auto &possible_keyword_uri : possible_keyword_uris) {
-    if (!context.frame.locations().contains(
-            {sourcemeta::blaze::SchemaReferenceType::Static,
-             possible_keyword_uri})) {
+    if (!context.frame
+             .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                       possible_keyword_uri)
+             .has_value()) {
       continue;
     }
 
-    const auto &frame_entry{context.frame.locations().at(
-        {sourcemeta::blaze::SchemaReferenceType::Static,
-         possible_keyword_uri})};
+    const auto &frame_entry{
+        context.frame
+            .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                      possible_keyword_uri)
+            .value()
+            .get()};
     const auto &subschema{
         sourcemeta::core::get(context.root, frame_entry.pointer)};
     const auto subschema_vocabularies{
@@ -514,17 +512,15 @@ is_circular(const sourcemeta::blaze::SchemaFrame &frame,
     return true;
   }
 
-  for (const auto &ref_entry : frame.references()) {
-    if (ref_entry.first.first ==
-            sourcemeta::blaze::SchemaReferenceType::Static &&
-        ref_entry.first.second.starts_with(destination_pointer)) {
-      if (is_circular(frame, reference_origin, ref_entry.second, visited)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  return frame.any_reference_from(
+      destination_pointer,
+      [&](const sourcemeta::blaze::SchemaReferenceType type,
+          const sourcemeta::core::WeakPointer &,
+          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &entry)
+          -> bool {
+        return type == sourcemeta::blaze::SchemaReferenceType::Static &&
+               is_circular(frame, reference_origin, entry, visited);
+      });
 }
 
 // The set of property names that this schema declares as required at this

--- a/src/compiler/compile_helpers.h
+++ b/src/compiler/compile_helpers.h
@@ -494,7 +494,7 @@ inline auto annotations_enabled(const Context &context,
 inline auto
 is_circular(const sourcemeta::blaze::SchemaFrame &frame,
             const sourcemeta::core::WeakPointer &reference_origin,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference,
+            const sourcemeta::blaze::SchemaFrame::Reference &reference,
             std::unordered_set<std::string> &visited) -> bool {
   if (visited.contains(reference.destination)) {
     return false;
@@ -516,8 +516,7 @@ is_circular(const sourcemeta::blaze::SchemaFrame &frame,
       destination_pointer,
       [&](const sourcemeta::blaze::SchemaReferenceType type,
           const sourcemeta::core::WeakPointer &,
-          const sourcemeta::blaze::SchemaFrame::ReferencesEntry &entry)
-          -> bool {
+          const sourcemeta::blaze::SchemaFrame::Reference &entry) -> bool {
         return type == sourcemeta::blaze::SchemaReferenceType::Static &&
                is_circular(frame, reference_origin, entry, visited);
       });

--- a/src/compiler/default_compiler_2019_09.h
+++ b/src/compiler/default_compiler_2019_09.h
@@ -429,8 +429,10 @@ auto compiler_2019_09_core_recursiveref(const Context &context,
     -> Instructions {
   const auto &entry{static_frame_entry(context, schema_context)};
   // In this case, just behave as a normal static reference
-  if (!context.frame.references().contains(
-          {sourcemeta::blaze::SchemaReferenceType::Dynamic, entry.pointer})) {
+  if (!context.frame
+           .reference(sourcemeta::blaze::SchemaReferenceType::Dynamic,
+                      entry.pointer)
+           .has_value()) {
     return compiler_draft3_core_ref(context, schema_context, dynamic_context,
                                     current);
   }

--- a/src/compiler/default_compiler_2020_12.h
+++ b/src/compiler/default_compiler_2020_12.h
@@ -72,8 +72,10 @@ auto compiler_2020_12_core_dynamicref(const Context &context,
     -> Instructions {
   const auto &entry{static_frame_entry(context, schema_context)};
   // In this case, just behave as a normal static reference
-  if (!context.frame.references().contains(
-          {sourcemeta::blaze::SchemaReferenceType::Dynamic, entry.pointer})) {
+  if (!context.frame
+           .reference(sourcemeta::blaze::SchemaReferenceType::Dynamic,
+                      entry.pointer)
+           .has_value()) {
     return compiler_draft3_core_ref(context, schema_context, dynamic_context,
                                     current);
   }

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -357,22 +357,22 @@ auto properties_as_loop(const Context &context,
   const auto inside_disjunctor{
       is_inside_disjunctor(schema_context.relative_pointer) ||
       // Check if any reference from `anyOf` or `oneOf` points to us
-      std::ranges::any_of(
-          context.frame.references(),
-          [&context, &current_entry](const auto &reference) -> auto {
-            if (!context.frame.locations().contains(
-                    {sourcemeta::blaze::SchemaReferenceType::Static,
-                     reference.second.destination})) {
+      context.frame.any_reference(
+          [&context, &current_entry](
+              const sourcemeta::blaze::SchemaReferenceType,
+              const sourcemeta::core::WeakPointer &origin,
+              const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+              -> bool {
+            const auto destination{context.frame.location(
+                sourcemeta::blaze::SchemaReferenceType::Static,
+                reference.destination)};
+            if (!destination.has_value()) {
               return false;
             }
 
-            const auto &target{
-                context.frame.locations()
-                    .at({sourcemeta::blaze::SchemaReferenceType::Static,
-                         reference.second.destination})
-                    .pointer};
-            return is_inside_disjunctor(reference.first.second) &&
-                   current_entry.pointer.initial() == target;
+            return is_inside_disjunctor(origin) &&
+                   current_entry.pointer.initial() ==
+                       destination.value().get().pointer;
           })};
 
   if (!inside_disjunctor &&

--- a/src/compiler/default_compiler_draft3.h
+++ b/src/compiler/default_compiler_draft3.h
@@ -361,7 +361,7 @@ auto properties_as_loop(const Context &context,
           [&context, &current_entry](
               const sourcemeta::blaze::SchemaReferenceType,
               const sourcemeta::core::WeakPointer &origin,
-              const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+              const sourcemeta::blaze::SchemaFrame::Reference &reference)
               -> bool {
             const auto destination{context.frame.location(
                 sourcemeta::blaze::SchemaReferenceType::Static,

--- a/src/compiler/default_compiler_draft7.h
+++ b/src/compiler/default_compiler_draft7.h
@@ -27,8 +27,10 @@ auto compiler_draft7_applicator_if(const Context &context,
                    make_weak_pointer(KEYWORD_THEN)),
                schema_context.base)
             .recompose()};
-    assert(context.frame.locations().contains(
-        {sourcemeta::blaze::SchemaReferenceType::Static, destination}));
+    assert(context.frame
+               .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                         destination)
+               .has_value());
 
     // If `if` compiled to nothing, the `then` children will be hoisted to the
     // current level without the `LogicalCondition` wrapper. When the schema
@@ -100,8 +102,10 @@ auto compiler_draft7_applicator_if(const Context &context,
                    make_weak_pointer(KEYWORD_ELSE)),
                schema_context.base)
             .recompose()};
-    assert(context.frame.locations().contains(
-        {sourcemeta::blaze::SchemaReferenceType::Static, destination}));
+    assert(context.frame
+               .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                         destination)
+               .has_value());
     DynamicContext new_dynamic_context{
         .keyword = KEYWORD_ELSE,
         .base_schema_location = dynamic_context.base_schema_location,

--- a/src/compiler/unevaluated.cc
+++ b/src/compiler/unevaluated.cc
@@ -167,19 +167,21 @@ auto register_under_all_bases(SchemaUnevaluatedEntries &result,
                               const JSON::String &keyword,
                               const SchemaUnevaluatedEntry &value) -> void {
   result.emplace(frame.uri(location, make_weak_pointer(keyword)), value);
-  for (const auto &alternate : frame.locations()) {
-    if (alternate.second.pointer != location.pointer ||
-        alternate.second.base == location.base) {
-      continue;
+  frame.for_each_location([&](const SchemaReferenceType, const std::string_view,
+                              const SchemaFrame::Location &alternate) -> void {
+    if (alternate.pointer != location.pointer ||
+        alternate.base == location.base) {
+      return;
     }
-    if (alternate.second.type != SchemaFrame::LocationType::Subschema &&
-        alternate.second.type != SchemaFrame::LocationType::Resource &&
-        alternate.second.type != SchemaFrame::LocationType::Anchor) {
-      continue;
+
+    if (alternate.type != SchemaFrame::LocationType::Subschema &&
+        alternate.type != SchemaFrame::LocationType::Resource &&
+        alternate.type != SchemaFrame::LocationType::Anchor) {
+      return;
     }
-    result.emplace(frame.uri(alternate.second, make_weak_pointer(keyword)),
-                   value);
-  }
+
+    result.emplace(frame.uri(alternate, make_weak_pointer(keyword)), value);
+  });
 }
 
 } // namespace
@@ -197,27 +199,21 @@ auto unevaluated(const JSON &schema, const SchemaFrame &frame,
     -> SchemaUnevaluatedEntries {
   SchemaUnevaluatedEntries result;
 
-  for (const auto &entry : frame.locations()) {
-    if (entry.second.type != SchemaFrame::LocationType::Subschema &&
-        entry.second.type != SchemaFrame::LocationType::Resource) {
-      continue;
-    }
-
-    const auto &subschema{get(schema, entry.second.pointer)};
+  frame.for_each_subschema([&](const SchemaFrame::Location &location) -> void {
+    const auto &subschema{get(schema, location.pointer)};
     assert((subschema.is_object() || subschema.is_boolean()));
     if (!subschema.is_object()) {
-      continue;
+      return;
     }
 
     const bool has_unevaluated_properties{
         subschema.defines("unevaluatedProperties")};
     const bool has_unevaluated_items{subschema.defines("unevaluatedItems")};
     if (!has_unevaluated_properties && !has_unevaluated_items) {
-      continue;
+      return;
     }
 
-    const auto &subschema_vocabularies{
-        frame.vocabularies(entry.second, resolver)};
+    const auto &subschema_vocabularies{frame.vocabularies(location, resolver)};
 
     // The same pointer may be reachable through alternate identifiers whose
     // dynamic anchors carry a different base, so we register the entry under
@@ -234,8 +230,8 @@ auto unevaluated(const JSON &schema, const SchemaFrame &frame,
             "unevaluatedProperties", schema, frame, walker, resolver,
             {"properties", "patternProperties", "additionalProperties",
              "unevaluatedProperties"},
-            entry.second, entry.second, true, unevaluated);
-        register_under_all_bases(result, frame, entry.second,
+            location, location, true, unevaluated);
+        register_under_all_bases(result, frame, location,
                                  UNEVALUATED_PROPERTIES, unevaluated);
       }
     }
@@ -248,21 +244,21 @@ auto unevaluated(const JSON &schema, const SchemaFrame &frame,
               Known::JSON_Schema_2020_12_Applicator)) {
         find_adjacent_dependencies(
             "unevaluatedItems", schema, frame, walker, resolver,
-            {"prefixItems", "items", "contains", "unevaluatedItems"},
-            entry.second, entry.second, true, unevaluated);
-        register_under_all_bases(result, frame, entry.second, UNEVALUATED_ITEMS,
+            {"prefixItems", "items", "contains", "unevaluatedItems"}, location,
+            location, true, unevaluated);
+        register_under_all_bases(result, frame, location, UNEVALUATED_ITEMS,
                                  unevaluated);
       } else if (subschema_vocabularies.contains(
                      Known::JSON_Schema_2019_09_Applicator)) {
         find_adjacent_dependencies(
             "unevaluatedItems", schema, frame, walker, resolver,
-            {"items", "additionalItems", "unevaluatedItems"}, entry.second,
-            entry.second, true, unevaluated);
-        register_under_all_bases(result, frame, entry.second, UNEVALUATED_ITEMS,
+            {"items", "additionalItems", "unevaluatedItems"}, location,
+            location, true, unevaluated);
+        register_under_all_bases(result, frame, location, UNEVALUATED_ITEMS,
                                  unevaluated);
       }
     }
-  }
+  });
 
   return result;
 }

--- a/src/editor/editor.cc
+++ b/src/editor/editor.cc
@@ -108,7 +108,7 @@ auto for_editor(sourcemeta::core::JSON &schema,
     frame.for_each_reference(
         [&](const sourcemeta::blaze::SchemaReferenceType type,
             const sourcemeta::core::WeakPointer &origin,
-            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            const sourcemeta::blaze::SchemaFrame::Reference &reference)
             -> void {
           assert(!origin.empty());
           assert(origin.back().is_property());

--- a/src/editor/editor.cc
+++ b/src/editor/editor.cc
@@ -95,109 +95,110 @@ auto for_editor(sourcemeta::core::JSON &schema,
 
     // Note that `std::unordered_map` is slower here due to high collision rates
     // from the simple pointer hashes
-    std::map<sourcemeta::core::WeakPointer,
-             std::reference_wrapper<const sourcemeta::core::JSON::String>>
-        pointer_to_uri;
-    for (const auto &entry : frame.locations()) {
-      pointer_to_uri.emplace(entry.second.pointer,
-                             std::cref(entry.first.second));
-    }
+    std::map<sourcemeta::core::WeakPointer, std::string_view> pointer_to_uri;
+    frame.for_each_location(
+        [&pointer_to_uri](
+            const sourcemeta::blaze::SchemaReferenceType,
+            const std::string_view uri,
+            const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
+          pointer_to_uri.emplace(location.pointer, uri);
+        });
 
     // Collect reference changes
-    for (const auto &[key, reference] : frame.references()) {
-      assert(!key.second.empty());
-      assert(key.second.back().is_property());
-      const auto &keyword{key.second.back().to_property()};
+    frame.for_each_reference(
+        [&](const sourcemeta::blaze::SchemaReferenceType type,
+            const sourcemeta::core::WeakPointer &origin,
+            const sourcemeta::blaze::SchemaFrame::ReferencesEntry &reference)
+            -> void {
+          assert(!origin.empty());
+          assert(origin.back().is_property());
+          const auto &keyword{origin.back().to_property()};
 
-      if (key.first == sourcemeta::blaze::SchemaReferenceType::Dynamic) {
-        if (reference.fragment.has_value()) {
-          const auto destination{top_dynamic_anchor_location(
-              frame, key.second, reference.fragment.value(),
-              reference.destination)};
-          if (!destination.has_value()) {
-            continue;
+          if (type == sourcemeta::blaze::SchemaReferenceType::Dynamic) {
+            if (reference.fragment.has_value()) {
+              const auto destination{top_dynamic_anchor_location(
+                  frame, origin, reference.fragment.value(),
+                  reference.destination)};
+              if (!destination.has_value()) {
+                return;
+              }
+
+              reference_changes.push_back(
+                  {.pointer = sourcemeta::core::to_pointer(origin),
+                   .new_value =
+                       sourcemeta::core::to_uri(destination.value().get())
+                           .recompose(),
+                   .keyword = keyword,
+                   .rename_to_ref = true});
+            } else {
+              reference_changes.push_back(
+                  {.pointer = sourcemeta::core::to_pointer(origin),
+                   .new_value = "",
+                   .keyword = keyword,
+                   .rename_to_ref = true});
+            }
+          } else {
+            if (keyword == "$schema") {
+              // Use pre-built index instead of O(n) frame.uri() scan
+              const auto uri_it{pointer_to_uri.find(origin)};
+              assert(uri_it != pointer_to_uri.end());
+              const auto location{frame.traverse(uri_it->second)};
+              assert(location.has_value());
+              reference_changes.push_back(
+                  {.pointer = sourcemeta::core::to_pointer(origin),
+                   .new_value =
+                       std::format("{}", location.value().get().base_dialect),
+                   .keyword = keyword,
+                   .rename_to_ref = false});
+              return;
+            }
+
+            const auto result{frame.traverse(reference.destination)};
+            if (result.has_value()) {
+              const bool should_rename =
+                  keyword == "$dynamicRef" || keyword == "$recursiveRef";
+              reference_changes.push_back(
+                  {.pointer = sourcemeta::core::to_pointer(origin),
+                   .new_value =
+                       sourcemeta::core::to_uri(result.value().get().pointer)
+                           .recompose(),
+                   .keyword = keyword,
+                   .rename_to_ref = should_rename});
+            } else {
+              reference_changes.push_back(
+                  {.pointer = sourcemeta::core::to_pointer(origin),
+                   .new_value = reference.destination,
+                   .keyword = keyword,
+                   .rename_to_ref = false});
+            }
           }
-
-          reference_changes.push_back(
-              {.pointer = sourcemeta::core::to_pointer(key.second),
-               .new_value = sourcemeta::core::to_uri(destination.value().get())
-                                .recompose(),
-               .keyword = keyword,
-               .rename_to_ref = true});
-        } else {
-          reference_changes.push_back(
-              {.pointer = sourcemeta::core::to_pointer(key.second),
-               .new_value = "",
-               .keyword = keyword,
-               .rename_to_ref = true});
-        }
-      } else {
-        if (keyword == "$schema") {
-          // Use pre-built index instead of O(n) frame.uri() scan
-          const auto uri_it{pointer_to_uri.find(key.second)};
-          assert(uri_it != pointer_to_uri.end());
-          const auto origin{frame.traverse(uri_it->second.get())};
-          assert(origin.has_value());
-          reference_changes.push_back(
-              {.pointer = sourcemeta::core::to_pointer(key.second),
-               .new_value =
-                   std::format("{}", origin.value().get().base_dialect),
-               .keyword = keyword,
-               .rename_to_ref = false});
-          continue;
-        }
-
-        const auto result{frame.traverse(reference.destination)};
-        if (result.has_value()) {
-          const bool should_rename =
-              keyword == "$dynamicRef" || keyword == "$recursiveRef";
-          reference_changes.push_back(
-              {.pointer = sourcemeta::core::to_pointer(key.second),
-               .new_value =
-                   sourcemeta::core::to_uri(result.value().get().pointer)
-                       .recompose(),
-               .keyword = keyword,
-               .rename_to_ref = should_rename});
-        } else {
-          reference_changes.push_back(
-              {.pointer = sourcemeta::core::to_pointer(key.second),
-               .new_value = reference.destination,
-               .keyword = keyword,
-               .rename_to_ref = false});
-        }
-      }
-    }
+        });
 
     // Collect subschema changes
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Resource &&
-          entry.second.type !=
-              sourcemeta::blaze::SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
+    frame.for_each_subschema(
 
-      const auto &subschema{
-          sourcemeta::core::get(schema, entry.second.pointer)};
-      if (subschema.is_boolean()) {
-        continue;
-      }
+        [&](const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
+          const auto &subschema{
+              sourcemeta::core::get(schema, location.pointer)};
+          if (subschema.is_boolean()) {
+            return;
+          }
 
-      const bool add_schema =
-          entry.second.pointer.empty() && !subschema.defines("$schema");
-      const auto &vocabularies{frame.vocabularies(entry.second, resolver)};
+          const bool add_schema =
+              location.pointer.empty() && !subschema.defines("$schema");
+          const auto &vocabularies{frame.vocabularies(location, resolver)};
 
-      subschema_changes.push_back(
-          {.pointer = sourcemeta::core::to_pointer(entry.second.pointer),
-           .base_dialect = entry.second.base_dialect,
-           .add_schema_declaration = add_schema,
-           .erase_2020_12_keywords =
-               vocabularies.contains(sourcemeta::blaze::SchemaVocabularies::
-                                         Known::JSON_Schema_2020_12_Core),
-           .erase_2019_09_keywords =
-               vocabularies.contains(sourcemeta::blaze::SchemaVocabularies::
-                                         Known::JSON_Schema_2019_09_Core)});
-    }
+          subschema_changes.push_back(
+              {.pointer = sourcemeta::core::to_pointer(location.pointer),
+               .base_dialect = location.base_dialect,
+               .add_schema_declaration = add_schema,
+               .erase_2020_12_keywords =
+                   vocabularies.contains(sourcemeta::blaze::SchemaVocabularies::
+                                             Known::JSON_Schema_2020_12_Core),
+               .erase_2019_09_keywords =
+                   vocabularies.contains(sourcemeta::blaze::SchemaVocabularies::
+                                             Known::JSON_Schema_2019_09_Core)});
+        });
   }
 
   // (2) Apply reference changes

--- a/src/format/format.cc
+++ b/src/format/format.cc
@@ -148,14 +148,10 @@ auto format(sourcemeta::core::JSON &schema, const SchemaWalker &walker,
     SchemaFrame frame{SchemaFrame::Mode::Locations, schema, walker, resolver,
                       default_dialect};
 
-    for (const auto &entry : frame.locations()) {
-      if (entry.second.type != SchemaFrame::LocationType::Resource &&
-          entry.second.type != SchemaFrame::LocationType::Subschema) {
-        continue;
-      }
-
-      subschemas.push_back(sourcemeta::core::to_pointer(entry.second.pointer));
-    }
+    frame.for_each_subschema(
+        [&subschemas](const SchemaFrame::Location &location) -> void {
+          subschemas.push_back(sourcemeta::core::to_pointer(location.pointer));
+        });
   }
 
   for (const auto &pointer : subschemas) {

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -355,8 +355,8 @@ auto canonicalize_pointer_fragment(sourcemeta::core::URI &uri) -> void {
   }
 }
 
-auto set_base_and_fragment(
-    sourcemeta::blaze::SchemaFrame::ReferencesEntry &entry) -> void {
+auto set_base_and_fragment(sourcemeta::blaze::SchemaFrame::Reference &entry)
+    -> void {
   const std::string_view destination_view{entry.destination};
   if (destination_view.empty()) {
     entry.base = std::string_view{};
@@ -1078,11 +1078,10 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
           schema_pointer.push_back(std::cref(KEYWORD_SCHEMA));
           const auto [it, inserted] = this->references_.insert_or_assign(
               {SchemaReferenceType::Static, std::move(schema_pointer)},
-              SchemaFrame::ReferencesEntry{.original = maybe_metaschema,
-                                           .destination =
-                                               metaschema.recompose(),
-                                           .base = std::string_view{},
-                                           .fragment = std::nullopt});
+              SchemaFrame::Reference{.original = maybe_metaschema,
+                                     .destination = metaschema.recompose(),
+                                     .base = std::string_view{},
+                                     .fragment = std::nullopt});
           set_base_and_fragment(it->second);
         }
       }
@@ -1361,10 +1360,10 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
         ref_pointer.push_back(std::cref(KEYWORD_REF));
         const auto [it, inserted] = this->references_.insert_or_assign(
             {SchemaReferenceType::Static, std::move(ref_pointer)},
-            SchemaFrame::ReferencesEntry{.original = original,
-                                         .destination = ref.recompose(),
-                                         .base = std::string_view{},
-                                         .fragment = std::nullopt});
+            SchemaFrame::Reference{.original = original,
+                                   .destination = ref.recompose(),
+                                   .base = std::string_view{},
+                                   .fragment = std::nullopt});
         set_base_and_fragment(it->second);
       }
 
@@ -1407,10 +1406,10 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
         recursive_ref_pointer.push_back(std::cref(KEYWORD_RECURSIVE_REF));
         const auto [it, inserted] = this->references_.insert_or_assign(
             {reference_type, std::move(recursive_ref_pointer)},
-            SchemaFrame::ReferencesEntry{.original = ref,
-                                         .destination = anchor_uri.recompose(),
-                                         .base = std::string_view{},
-                                         .fragment = std::nullopt});
+            SchemaFrame::Reference{.original = ref,
+                                   .destination = anchor_uri.recompose(),
+                                   .base = std::string_view{},
+                                   .fragment = std::nullopt});
         set_base_and_fragment(it->second);
       }
 
@@ -1464,10 +1463,10 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
             {behaves_as_static ? SchemaReferenceType::Static
                                : SchemaReferenceType::Dynamic,
              std::move(dynamic_ref_pointer)},
-            SchemaFrame::ReferencesEntry{.original = original,
-                                         .destination = std::move(ref_string),
-                                         .base = std::string_view{},
-                                         .fragment = std::nullopt});
+            SchemaFrame::Reference{.original = original,
+                                   .destination = std::move(ref_string),
+                                   .base = std::string_view{},
+                                   .fragment = std::nullopt});
         set_base_and_fragment(it->second);
       }
     }
@@ -1600,25 +1599,13 @@ auto SchemaFrame::metaschema(const SchemaResolver &resolver) const
 
 auto SchemaFrame::reference(const SchemaReferenceType type,
                             const sourcemeta::core::WeakPointer &pointer) const
-    -> std::optional<std::reference_wrapper<const ReferencesEntry>> {
+    -> std::optional<std::reference_wrapper<const Reference>> {
   const auto result{this->references_.find({type, pointer})};
   if (result != this->references_.cend()) {
     return result->second;
   }
 
   return std::nullopt;
-}
-
-auto SchemaFrame::is_subschema(const Location &location) noexcept -> bool {
-  return location.type == LocationType::Resource ||
-         location.type == LocationType::Subschema;
-}
-
-auto SchemaFrame::is_strictly_under(
-    const Location &location,
-    const sourcemeta::core::WeakPointer &pointer) noexcept -> bool {
-  return location.pointer.size() > pointer.size() &&
-         location.pointer.starts_with(pointer);
 }
 
 auto SchemaFrame::location(const SchemaReferenceType type,

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -387,8 +387,8 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
                                             "Schema identifier already exists");
 }
 
-auto store(sourcemeta::blaze::SchemaFrame::Locations &frame,
-           const sourcemeta::blaze::SchemaReferenceType type,
+template <typename Locations>
+auto store(Locations &frame, const sourcemeta::blaze::SchemaReferenceType type,
            const sourcemeta::blaze::SchemaFrame::LocationType entry_type,
            sourcemeta::core::JSON::String uri, const std::string_view base,
            const sourcemeta::core::WeakPointer &pointer_from_root,
@@ -443,9 +443,9 @@ struct CacheSubschema {
 
 // The location pointers that references resolve to, computed once so that
 // serialising every location does not re-scan the entire reference list
-auto reference_destinations(
-    const sourcemeta::blaze::SchemaFrame::References &references,
-    const sourcemeta::blaze::SchemaFrame::Locations &locations)
+template <typename References, typename Locations>
+auto reference_destinations(const References &references,
+                            const Locations &locations)
     -> std::vector<sourcemeta::core::WeakPointer> {
   std::vector<sourcemeta::core::WeakPointer> result;
   for (const auto &reference : references) {
@@ -721,6 +721,7 @@ struct SchemaFrame::Cache {
   std::unordered_map<const Location *, const sourcemeta::core::WeakPointer *>
       location_to_canonical_;
   bool standalone_{false};
+  bool has_dynamic_references_{false};
 
   auto populate_pointer_to_location(const SchemaFrame &frame) -> void;
   auto populate_reference_graph(const SchemaFrame &frame) -> void;
@@ -1547,6 +1548,13 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
       set_base_and_fragment(it->second);
     }
   }
+
+  // Only meaningful once the rewrite above has settled, as that is what
+  // decides whether a dynamic reference stays dynamic at all
+  this->cache_->has_dynamic_references_ =
+      std::ranges::any_of(this->references_, [](const auto &reference) -> bool {
+        return reference.first.first == SchemaReferenceType::Dynamic;
+      });
 }
 
 auto SchemaFrame::root_location() const
@@ -1590,14 +1598,6 @@ auto SchemaFrame::metaschema(const SchemaResolver &resolver) const
       .first->second;
 }
 
-auto SchemaFrame::locations() const noexcept -> const Locations & {
-  return this->locations_;
-}
-
-auto SchemaFrame::references() const noexcept -> const References & {
-  return this->references_;
-}
-
 auto SchemaFrame::reference(const SchemaReferenceType type,
                             const sourcemeta::core::WeakPointer &pointer) const
     -> std::optional<std::reference_wrapper<const ReferencesEntry>> {
@@ -1607,6 +1607,42 @@ auto SchemaFrame::reference(const SchemaReferenceType type,
   }
 
   return std::nullopt;
+}
+
+auto SchemaFrame::is_subschema(const Location &location) noexcept -> bool {
+  return location.type == LocationType::Resource ||
+         location.type == LocationType::Subschema;
+}
+
+auto SchemaFrame::is_strictly_under(
+    const Location &location,
+    const sourcemeta::core::WeakPointer &pointer) noexcept -> bool {
+  return location.pointer.size() > pointer.size() &&
+         location.pointer.starts_with(pointer);
+}
+
+auto SchemaFrame::location(const SchemaReferenceType type,
+                           const std::string_view uri) const
+    -> std::optional<std::reference_wrapper<const Location>> {
+  const sourcemeta::core::JSON::String uri_string{uri};
+  const auto result{this->locations_.find({type, uri_string})};
+  if (result != this->locations_.cend()) {
+    return result->second;
+  }
+
+  return std::nullopt;
+}
+
+auto SchemaFrame::location_count() const noexcept -> std::size_t {
+  return this->locations_.size();
+}
+
+auto SchemaFrame::reference_count() const noexcept -> std::size_t {
+  return this->references_.size();
+}
+
+auto SchemaFrame::has_dynamic_references() const noexcept -> bool {
+  return this->cache_->has_dynamic_references_;
 }
 
 auto SchemaFrame::standalone() const noexcept -> bool {

--- a/src/foundation/include/sourcemeta/blaze/foundation_frame.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_frame.h
@@ -91,17 +91,6 @@ public:
     std::optional<std::string_view> fragment;
   };
 
-  /// A JSON Schema reference map is a mapping of a JSON Pointer
-  /// of a subschema to a destination static reference URI.
-  /// For convenience, the value consists of the URI on its entirety,
-  /// but also broken down by its potential fragment component.
-  /// The reference type is part of the key as it is possible to
-  /// have a static and a dynamic reference to the same location
-  /// on the same schema object.
-  using References =
-      std::map<std::pair<SchemaReferenceType, sourcemeta::core::WeakPointer>,
-               ReferencesEntry>;
-
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 // GCC believes that a member of an enum class (which is namespaced by
@@ -133,20 +122,6 @@ public:
     bool orphan;
   };
 
-  /// A JSON Schema reference frame is a mapping of URIs to schema identifiers,
-  /// JSON Pointers within the schema, and subschemas dialects. We call it
-  /// reference frame as this mapping is essential for resolving references.
-  // TODO: Consider replacing std::map with std::flat_map once libc++
-  // supports it (__cpp_lib_flat_map) for better cache locality
-  using Locations =
-      // While it might seem weird that we namespace the location URIs with a
-      // reference type, it is essential for distinguishing schema resource URIs
-      // from `$recursiveRef: true` on another place of the schema schema
-      // resource, as otherwise they would both have the exact same URI, but
-      // point to different places.
-      std::map<std::pair<SchemaReferenceType, sourcemeta::core::JSON::String>,
-               Location>;
-
   /// A list of paths to frame within a schema wrapper
   using Paths = std::vector<sourcemeta::core::WeakPointer>;
 
@@ -173,17 +148,25 @@ public:
               IdentifierMode identifier_mode = IdentifierMode::Additional,
               const Paths &paths = {sourcemeta::core::EMPTY_WEAK_POINTER});
 
-  /// Access the analysed schema locations
-  [[nodiscard]] auto locations() const noexcept -> const Locations &;
-
-  /// Access the analysed schema references
-  [[nodiscard]] auto references() const noexcept -> const References &;
-
   /// Get a specific reference entry by type and pointer
   [[nodiscard]] auto
   reference(const SchemaReferenceType type,
             const sourcemeta::core::WeakPointer &pointer) const
       -> std::optional<std::reference_wrapper<const ReferencesEntry>>;
+
+  /// Get a specific location entry by reference type and URI
+  [[nodiscard]] auto location(const SchemaReferenceType type,
+                              const std::string_view uri) const
+      -> std::optional<std::reference_wrapper<const Location>>;
+
+  /// The number of locations in the frame
+  [[nodiscard]] auto location_count() const noexcept -> std::size_t;
+
+  /// The number of references in the frame
+  [[nodiscard]] auto reference_count() const noexcept -> std::size_t;
+
+  /// Check whether the analysed schema makes use of dynamic referencing at all
+  [[nodiscard]] auto has_dynamic_references() const noexcept -> bool;
 
   /// Check whether the analysed schema has no external references
   [[nodiscard]] auto standalone() const noexcept -> bool;
@@ -251,6 +234,216 @@ public:
       -> std::pair<SchemaReferenceType,
                    std::optional<std::reference_wrapper<const Location>>>;
 
+  /// Iterate over every schema resource and subschema, skipping the pointer
+  /// and anchor entries that do not stand for a schema of their own
+  template <std::invocable<const Location &> F>
+  auto for_each_subschema(const F &callback) const -> void {
+    for (const auto &entry : this->locations_) {
+      if (is_subschema(entry.second)) {
+        callback(entry.second);
+      }
+    }
+  }
+
+  /// Iterate over every schema resource and subschema strictly below the given
+  /// pointer
+  template <std::invocable<const Location &> F>
+  auto for_each_subschema_under(const sourcemeta::core::WeakPointer &pointer,
+                                const F &callback) const -> void {
+    for (const auto &entry : this->locations_) {
+      if (is_subschema(entry.second) &&
+          is_strictly_under(entry.second, pointer)) {
+        callback(entry.second);
+      }
+    }
+  }
+
+  /// Check whether any schema resource or subschema satisfies the predicate
+  template <std::predicate<const Location &> F>
+  [[nodiscard]] auto any_subschema(const F &predicate) const -> bool {
+    for (const auto &entry : this->locations_) {
+      if (is_subschema(entry.second) && predicate(entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Check whether any schema resource or subschema strictly below the given
+  /// pointer satisfies the predicate
+  template <std::predicate<const Location &> F>
+  [[nodiscard]] auto
+  any_subschema_under(const sourcemeta::core::WeakPointer &pointer,
+                      const F &predicate) const -> bool {
+    for (const auto &entry : this->locations_) {
+      if (is_subschema(entry.second) &&
+          is_strictly_under(entry.second, pointer) && predicate(entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Iterate over every anchor of the given kind, along with its URI
+  template <std::invocable<std::string_view, const Location &> F>
+  auto for_each_anchor(const SchemaReferenceType type, const F &callback) const
+      -> void {
+    for (const auto &entry : this->locations_) {
+      if (entry.first.first == type &&
+          entry.second.type == LocationType::Anchor) {
+        callback(entry.first.second, entry.second);
+      }
+    }
+  }
+
+  /// Check whether any anchor of the given kind satisfies the predicate
+  template <std::predicate<std::string_view, const Location &> F>
+  [[nodiscard]] auto any_anchor(const SchemaReferenceType type,
+                                const F &predicate) const -> bool {
+    for (const auto &entry : this->locations_) {
+      if (entry.first.first == type &&
+          entry.second.type == LocationType::Anchor &&
+          predicate(entry.first.second, entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Iterate over every schema resource, along with its URI
+  template <std::invocable<std::string_view, const Location &> F>
+  auto for_each_resource(const F &callback) const -> void {
+    for (const auto &entry : this->locations_) {
+      if (entry.second.type == LocationType::Resource) {
+        callback(entry.first.second, entry.second);
+      }
+    }
+  }
+
+  /// Iterate over every location, whatever kind it is
+  template <
+      std::invocable<SchemaReferenceType, std::string_view, const Location &> F>
+  auto for_each_location(const F &callback) const -> void {
+    for (const auto &entry : this->locations_) {
+      callback(entry.first.first, entry.first.second, entry.second);
+    }
+  }
+
+  /// Check whether any location satisfies the predicate
+  template <
+      std::predicate<SchemaReferenceType, std::string_view, const Location &> F>
+  [[nodiscard]] auto any_location(const F &predicate) const -> bool {
+    for (const auto &entry : this->locations_) {
+      if (predicate(entry.first.first, entry.first.second, entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Iterate over every reference, along with the pointer it originates from
+  template <
+      std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  auto for_each_reference(const F &callback) const -> void {
+    for (const auto &entry : this->references_) {
+      callback(entry.first.first, entry.first.second, entry.second);
+    }
+  }
+
+  /// Check whether any reference satisfies the predicate
+  template <
+      std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  [[nodiscard]] auto any_reference(const F &predicate) const -> bool {
+    for (const auto &entry : this->references_) {
+      if (predicate(entry.first.first, entry.first.second, entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Iterate over every reference that originates at or below the given pointer
+  template <
+      std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  auto for_each_reference_from(const sourcemeta::core::WeakPointer &pointer,
+                               const F &callback) const -> void {
+    for (const auto &entry : this->references_) {
+      if (entry.first.second.starts_with(pointer)) {
+        callback(entry.first.first, entry.first.second, entry.second);
+      }
+    }
+  }
+
+  /// Check whether any reference originating at or below the given pointer
+  /// satisfies the predicate
+  template <
+      std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  [[nodiscard]] auto
+  any_reference_from(const sourcemeta::core::WeakPointer &pointer,
+                     const F &predicate) const -> bool {
+    for (const auto &entry : this->references_) {
+      if (entry.first.second.starts_with(pointer) &&
+          predicate(entry.first.first, entry.first.second, entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Iterate over every reference whose destination resolves at or below the
+  /// given pointer. Note that unlike
+  /// sourcemeta::blaze::SchemaFrame::has_references_to, which matches a
+  /// destination exactly, this covers the entire subtree
+  template <
+      std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  auto for_each_reference_into(const sourcemeta::core::WeakPointer &pointer,
+                               const F &callback) const -> void {
+    for (const auto &entry : this->references_) {
+      const auto destination{this->traverse(entry.second.destination)};
+      if (destination.has_value() &&
+          destination.value().get().pointer.starts_with(pointer)) {
+        callback(entry.first.first, entry.first.second, entry.second);
+      }
+    }
+  }
+
+  /// Check whether any reference whose destination resolves at or below the
+  /// given pointer satisfies the predicate
+  template <
+      std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
+                     const ReferencesEntry &>
+          F>
+  [[nodiscard]] auto
+  any_reference_into(const sourcemeta::core::WeakPointer &pointer,
+                     const F &predicate) const -> bool {
+    for (const auto &entry : this->references_) {
+      const auto destination{this->traverse(entry.second.destination)};
+      if (destination.has_value() &&
+          destination.value().get().pointer.starts_with(pointer) &&
+          predicate(entry.first.first, entry.first.second, entry.second)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /// Iterate over all resource URIs in the frame
   template <std::invocable<std::string_view> F>
   auto for_each_resource_uri(const F &callback) const -> void {
@@ -300,6 +493,34 @@ public:
                                   const SchemaResolver &resolver) const -> bool;
 
 private:
+  /// A JSON Schema reference map is a mapping of a JSON Pointer
+  /// of a subschema to a destination static reference URI.
+  /// For convenience, the value consists of the URI on its entirety,
+  /// but also broken down by its potential fragment component.
+  /// The reference type is part of the key as it is possible to
+  /// have a static and a dynamic reference to the same location
+  /// on the same schema object.
+  using References =
+      std::map<std::pair<SchemaReferenceType, sourcemeta::core::WeakPointer>,
+               ReferencesEntry>;
+
+  using Locations =
+      // While it might seem weird that we namespace the location URIs with a
+      // reference type, it is essential for distinguishing schema resource URIs
+      // from `$recursiveRef: true` on another place of the schema schema
+      // resource, as otherwise they would both have the exact same URI, but
+      // point to different places.
+      std::map<std::pair<SchemaReferenceType, sourcemeta::core::JSON::String>,
+               Location>;
+
+  [[nodiscard]] static auto is_subschema(const Location &location) noexcept
+      -> bool;
+
+  [[nodiscard]] static auto
+  is_strictly_under(const Location &location,
+                    const sourcemeta::core::WeakPointer &pointer) noexcept
+      -> bool;
+
   Mode mode_;
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.

--- a/src/foundation/include/sourcemeta/blaze/foundation_frame.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_frame.h
@@ -80,8 +80,8 @@ public:
   // Query the current mode that the schema frame was configured with
   [[nodiscard]] auto mode() const noexcept -> Mode { return this->mode_; }
 
-  /// A single entry in a JSON Schema reference map
-  struct ReferencesEntry {
+  /// A reference that the schema declares, as found by framing
+  struct Reference {
     std::string_view original;
     // TODO: This one is tricky to turn into a view, as there is no
     // location entry to point to if it is an external unresolved reference
@@ -152,7 +152,7 @@ public:
   [[nodiscard]] auto
   reference(const SchemaReferenceType type,
             const sourcemeta::core::WeakPointer &pointer) const
-      -> std::optional<std::reference_wrapper<const ReferencesEntry>>;
+      -> std::optional<std::reference_wrapper<const Reference>>;
 
   /// Get a specific location entry by reference type and URI
   [[nodiscard]] auto location(const SchemaReferenceType type,
@@ -239,7 +239,8 @@ public:
   template <std::invocable<const Location &> F>
   auto for_each_subschema(const F &callback) const -> void {
     for (const auto &entry : this->locations_) {
-      if (is_subschema(entry.second)) {
+      if (entry.second.type == LocationType::Resource ||
+          entry.second.type == LocationType::Subschema) {
         callback(entry.second);
       }
     }
@@ -251,8 +252,10 @@ public:
   auto for_each_subschema_under(const sourcemeta::core::WeakPointer &pointer,
                                 const F &callback) const -> void {
     for (const auto &entry : this->locations_) {
-      if (is_subschema(entry.second) &&
-          is_strictly_under(entry.second, pointer)) {
+      if ((entry.second.type == LocationType::Resource ||
+           entry.second.type == LocationType::Subschema) &&
+          entry.second.pointer.size() > pointer.size() &&
+          entry.second.pointer.starts_with(pointer)) {
         callback(entry.second);
       }
     }
@@ -262,7 +265,9 @@ public:
   template <std::predicate<const Location &> F>
   [[nodiscard]] auto any_subschema(const F &predicate) const -> bool {
     for (const auto &entry : this->locations_) {
-      if (is_subschema(entry.second) && predicate(entry.second)) {
+      if ((entry.second.type == LocationType::Resource ||
+           entry.second.type == LocationType::Subschema) &&
+          predicate(entry.second)) {
         return true;
       }
     }
@@ -277,8 +282,11 @@ public:
   any_subschema_under(const sourcemeta::core::WeakPointer &pointer,
                       const F &predicate) const -> bool {
     for (const auto &entry : this->locations_) {
-      if (is_subschema(entry.second) &&
-          is_strictly_under(entry.second, pointer) && predicate(entry.second)) {
+      if ((entry.second.type == LocationType::Resource ||
+           entry.second.type == LocationType::Subschema) &&
+          entry.second.pointer.size() > pointer.size() &&
+          entry.second.pointer.starts_with(pointer) &&
+          predicate(entry.second)) {
         return true;
       }
     }
@@ -348,7 +356,7 @@ public:
   /// Iterate over every reference, along with the pointer it originates from
   template <
       std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   auto for_each_reference(const F &callback) const -> void {
     for (const auto &entry : this->references_) {
@@ -359,7 +367,7 @@ public:
   /// Check whether any reference satisfies the predicate
   template <
       std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   [[nodiscard]] auto any_reference(const F &predicate) const -> bool {
     for (const auto &entry : this->references_) {
@@ -374,7 +382,7 @@ public:
   /// Iterate over every reference that originates at or below the given pointer
   template <
       std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   auto for_each_reference_from(const sourcemeta::core::WeakPointer &pointer,
                                const F &callback) const -> void {
@@ -389,7 +397,7 @@ public:
   /// satisfies the predicate
   template <
       std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   [[nodiscard]] auto
   any_reference_from(const sourcemeta::core::WeakPointer &pointer,
@@ -410,7 +418,7 @@ public:
   /// destination exactly, this covers the entire subtree
   template <
       std::invocable<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   auto for_each_reference_into(const sourcemeta::core::WeakPointer &pointer,
                                const F &callback) const -> void {
@@ -427,7 +435,7 @@ public:
   /// given pointer satisfies the predicate
   template <
       std::predicate<SchemaReferenceType, const sourcemeta::core::WeakPointer &,
-                     const ReferencesEntry &>
+                     const Reference &>
           F>
   [[nodiscard]] auto
   any_reference_into(const sourcemeta::core::WeakPointer &pointer,
@@ -456,9 +464,9 @@ public:
 
   /// Iterate over all unresolved references (where destination cannot be
   /// traversed)
-  template <std::invocable<const sourcemeta::core::WeakPointer &,
-                           const ReferencesEntry &>
-                F>
+  template <
+      std::invocable<const sourcemeta::core::WeakPointer &, const Reference &>
+          F>
   auto for_each_unresolved_reference(const F &callback) const -> void {
     for (const auto &[key, reference] : this->references_) {
       if (!this->traverse(reference.destination).has_value()) {
@@ -502,7 +510,7 @@ private:
   /// on the same schema object.
   using References =
       std::map<std::pair<SchemaReferenceType, sourcemeta::core::WeakPointer>,
-               ReferencesEntry>;
+               Reference>;
 
   using Locations =
       // While it might seem weird that we namespace the location URIs with a
@@ -512,14 +520,6 @@ private:
       // point to different places.
       std::map<std::pair<SchemaReferenceType, sourcemeta::core::JSON::String>,
                Location>;
-
-  [[nodiscard]] static auto is_subschema(const Location &location) noexcept
-      -> bool;
-
-  [[nodiscard]] static auto
-  is_strictly_under(const Location &location,
-                    const sourcemeta::core::WeakPointer &pointer) noexcept
-      -> bool;
 
   Mode mode_;
 // Exporting symbols that depends on the standard C++ library is considered

--- a/test/foundation/foundation_frame_test.cc
+++ b/test/foundation/foundation_frame_test.cc
@@ -1158,7 +1158,7 @@ TEST(accessors_has_dynamic_references) {
   EXPECT_TRUE(frame.any_reference(
       [](const sourcemeta::blaze::SchemaReferenceType type,
          const sourcemeta::core::WeakPointer &,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+         const sourcemeta::blaze::SchemaFrame::Reference &) {
         return type == sourcemeta::blaze::SchemaReferenceType::Dynamic;
       }));
 }
@@ -1703,10 +1703,9 @@ TEST(accessors_for_each_reference) {
   std::vector<std::string> origins;
   std::vector<sourcemeta::blaze::SchemaReferenceType> types;
   frame.for_each_reference(
-      [&origins,
-       &types](const sourcemeta::blaze::SchemaReferenceType type,
-               const sourcemeta::core::WeakPointer &origin,
-               const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+      [&origins, &types](const sourcemeta::blaze::SchemaReferenceType type,
+                         const sourcemeta::core::WeakPointer &origin,
+                         const sourcemeta::blaze::SchemaFrame::Reference &) {
         origins.push_back(sourcemeta::core::to_string(origin));
         types.push_back(type);
       });
@@ -1755,13 +1754,13 @@ TEST(accessors_any_reference) {
   EXPECT_TRUE(frame.any_reference(
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &origin,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+         const sourcemeta::blaze::SchemaFrame::Reference &) {
         return sourcemeta::core::to_string(origin) == "/properties/one/$ref";
       }));
   EXPECT_FALSE(frame.any_reference(
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &entry) {
+         const sourcemeta::blaze::SchemaFrame::Reference &entry) {
         return entry.destination == "https://example.com/nowhere";
       }));
 }
@@ -1796,7 +1795,7 @@ TEST(accessors_for_each_reference_from) {
       sourcemeta::core::to_weak_pointer(properties),
       [&origins](const sourcemeta::blaze::SchemaReferenceType,
                  const sourcemeta::core::WeakPointer &origin,
-                 const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+                 const sourcemeta::blaze::SchemaFrame::Reference &) {
         origins.push_back(sourcemeta::core::to_string(origin));
       });
 
@@ -1835,16 +1834,12 @@ TEST(accessors_any_reference_from) {
       sourcemeta::core::to_weak_pointer(definitions),
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
-        return true;
-      }));
+         const sourcemeta::blaze::SchemaFrame::Reference &) { return true; }));
   EXPECT_FALSE(frame.any_reference_from(
       sourcemeta::core::to_weak_pointer(nowhere),
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
-        return true;
-      }));
+         const sourcemeta::blaze::SchemaFrame::Reference &) { return true; }));
 }
 
 TEST(accessors_for_each_reference_into) {
@@ -1877,7 +1872,7 @@ TEST(accessors_for_each_reference_into) {
       sourcemeta::core::to_weak_pointer(target),
       [&origins](const sourcemeta::blaze::SchemaReferenceType,
                  const sourcemeta::core::WeakPointer &origin,
-                 const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+                 const sourcemeta::blaze::SchemaFrame::Reference &) {
         origins.push_back(sourcemeta::core::to_string(origin));
       });
 
@@ -1916,7 +1911,7 @@ TEST(accessors_any_reference_into) {
       sourcemeta::core::to_weak_pointer(bar),
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &origin,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+         const sourcemeta::blaze::SchemaFrame::Reference &) {
         return sourcemeta::core::to_string(origin) ==
                "/properties/two/$dynamicRef";
       }));
@@ -1924,7 +1919,5 @@ TEST(accessors_any_reference_into) {
       sourcemeta::core::to_weak_pointer(one),
       [](const sourcemeta::blaze::SchemaReferenceType,
          const sourcemeta::core::WeakPointer &,
-         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
-        return true;
-      }));
+         const sourcemeta::blaze::SchemaFrame::Reference &) { return true; }));
 }

--- a/test/foundation/foundation_frame_test.cc
+++ b/test/foundation/foundation_frame_test.cc
@@ -9,6 +9,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, expected_known)               \
   EXPECT_TRUE(                                                                 \
@@ -37,35 +38,49 @@
                      expected_base_dialect, expected_base,                     \
                      expected_relative_pointer, expected_parent,               \
                      expected_property_name, expected_orphan)                  \
-  EXPECT_TRUE((frame).locations().contains({(expected_type), (reference)}));   \
+  EXPECT_TRUE((frame).location((expected_type), (reference)).has_value());     \
   EXPECT_EQ((frame).root(), (root_id));                                        \
   EXPECT_EQ(                                                                   \
-      sourcemeta::core::to_string(                                             \
-          (frame).locations().at({(expected_type), (reference)}).pointer),     \
+      sourcemeta::core::to_string((frame)                                      \
+                                      .location((expected_type), (reference))  \
+                                      .value()                                 \
+                                      .get()                                   \
+                                      .pointer),                               \
       (expected_pointer));                                                     \
-  EXPECT_EQ((frame).locations().at({(expected_type), (reference)}).dialect,    \
-            (expected_dialect));                                               \
-  EXPECT_EQ((frame).locations().at({(expected_type), (reference)}).base,       \
+  EXPECT_EQ(                                                                   \
+      (frame).location((expected_type), (reference)).value().get().dialect,    \
+      (expected_dialect));                                                     \
+  EXPECT_EQ((frame).location((expected_type), (reference)).value().get().base, \
             (expected_base));                                                  \
-  EXPECT_TRUE(                                                                 \
-      (frame)                                                                  \
-          .traverse(                                                           \
-              (frame).locations().at({(expected_type), (reference)}).base)     \
-          .has_value());                                                       \
+  EXPECT_TRUE((frame)                                                          \
+                  .traverse((frame)                                            \
+                                .location((expected_type), (reference))        \
+                                .value()                                       \
+                                .get()                                         \
+                                .base)                                         \
+                  .has_value());                                               \
+  EXPECT_EQ((frame)                                                            \
+                .location((expected_type), (reference))                        \
+                .value()                                                       \
+                .get()                                                         \
+                .base_dialect,                                                 \
+            sourcemeta::blaze::SchemaBaseDialect::expected_base_dialect);      \
   EXPECT_EQ(                                                                   \
-      (frame).locations().at({(expected_type), (reference)}).base_dialect,     \
-      sourcemeta::blaze::SchemaBaseDialect::expected_base_dialect);            \
-  EXPECT_EQ(sourcemeta::core::to_string((frame).relative_instance_location(    \
-                (frame).locations().at({(expected_type), (reference)}))),      \
-            (expected_relative_pointer));                                      \
+      sourcemeta::core::to_string((frame).relative_instance_location(          \
+          (frame).location((expected_type), (reference)).value().get())),      \
+      (expected_relative_pointer));                                            \
   EXPECT_OPTIONAL_POINTER(                                                     \
-      (frame).locations().at({(expected_type), (reference)}).parent,           \
+      (frame).location((expected_type), (reference)).value().get().parent,     \
       expected_parent);                                                        \
+  EXPECT_EQ((frame)                                                            \
+                .location((expected_type), (reference))                        \
+                .value()                                                       \
+                .get()                                                         \
+                .property_name,                                                \
+            (expected_property_name));                                         \
   EXPECT_EQ(                                                                   \
-      (frame).locations().at({(expected_type), (reference)}).property_name,    \
-      (expected_property_name));                                               \
-  EXPECT_EQ((frame).locations().at({(expected_type), (reference)}).orphan,     \
-            (expected_orphan));
+      (frame).location((expected_type), (reference)).value().get().orphan,     \
+      (expected_orphan));
 
 #define EXPECT_FRAME_STATIC(                                                   \
     frame, reference, root_id, expected_pointer, expected_dialect,             \
@@ -85,12 +100,13 @@
                       expected_dialect, expected_base_dialect, expected_base,  \
                       expected_relative_pointer, expected_parent,              \
                       expected_property_name, expected_orphan)                 \
-  EXPECT_EQ(                                                                   \
-      (frame)                                                                  \
-          .locations()                                                         \
-          .at({sourcemeta::blaze::SchemaReferenceType::Static, (reference)})   \
-          .type,                                                               \
-      sourcemeta::blaze::SchemaFrame::LocationType::Resource);
+  EXPECT_EQ((frame)                                                            \
+                .location(sourcemeta::blaze::SchemaReferenceType::Static,      \
+                          (reference))                                         \
+                .value()                                                       \
+                .get()                                                         \
+                .type,                                                         \
+            sourcemeta::blaze::SchemaFrame::LocationType::Resource);
 
 #define EXPECT_FRAME_STATIC_POINTER(                                           \
     frame, reference, root_id, expected_pointer, expected_dialect,             \
@@ -100,12 +116,13 @@
                       expected_dialect, expected_base_dialect, expected_base,  \
                       expected_relative_pointer, expected_parent,              \
                       expected_property_name, expected_orphan)                 \
-  EXPECT_EQ(                                                                   \
-      (frame)                                                                  \
-          .locations()                                                         \
-          .at({sourcemeta::blaze::SchemaReferenceType::Static, (reference)})   \
-          .type,                                                               \
-      sourcemeta::blaze::SchemaFrame::LocationType::Pointer);
+  EXPECT_EQ((frame)                                                            \
+                .location(sourcemeta::blaze::SchemaReferenceType::Static,      \
+                          (reference))                                         \
+                .value()                                                       \
+                .get()                                                         \
+                .type,                                                         \
+            sourcemeta::blaze::SchemaFrame::LocationType::Pointer);
 
 #define EXPECT_FRAME_STATIC_SUBSCHEMA(                                         \
     frame, reference, root_id, expected_pointer, expected_dialect,             \
@@ -115,12 +132,13 @@
                       expected_dialect, expected_base_dialect, expected_base,  \
                       expected_relative_pointer, expected_parent,              \
                       expected_property_name, expected_orphan)                 \
-  EXPECT_EQ(                                                                   \
-      (frame)                                                                  \
-          .locations()                                                         \
-          .at({sourcemeta::blaze::SchemaReferenceType::Static, (reference)})   \
-          .type,                                                               \
-      sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
+  EXPECT_EQ((frame)                                                            \
+                .location(sourcemeta::blaze::SchemaReferenceType::Static,      \
+                          (reference))                                         \
+                .value()                                                       \
+                .get()                                                         \
+                .type,                                                         \
+            sourcemeta::blaze::SchemaFrame::LocationType::Subschema);
 
 #define EXPECT_REFERENCE(frame, expected_type, expected_pointer, expected_uri, \
                          expected_base, expected_fragment, expected_original)  \
@@ -898,7 +916,7 @@ TEST(embedded_custom_metaschema_across_two_frames) {
       sourcemeta::blaze::SchemaFrame::Mode::References, document_b,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
 
-  EXPECT_EQ(frame.locations().size(), 19);
+  EXPECT_EQ(frame.location_count(), 19);
 
   // Resources
 
@@ -1042,7 +1060,7 @@ TEST(embedded_custom_metaschema_across_two_frames) {
 
   // References
 
-  EXPECT_EQ(frame.references().size(), 2);
+  EXPECT_EQ(frame.reference_count(), 2);
 
   EXPECT_STATIC_REFERENCE(frame, "/$schema", "https://example.com/meta",
                           "https://example.com/meta", std::nullopt,
@@ -1065,4 +1083,848 @@ TEST(embedded_custom_metaschema_across_two_frames) {
   EXPECT_FALSE(
       root_vocabularies.contains(sourcemeta::blaze::SchemaVocabularies::Known::
                                      JSON_Schema_2020_12_Validation));
+}
+
+TEST(accessors_location_count) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_EQ(frame.location_count(), 28);
+}
+
+TEST(accessors_reference_count) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_EQ(frame.reference_count(), 4);
+}
+
+TEST(accessors_has_dynamic_references) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "a": { "$id": "one", "$dynamicAnchor": "shared" },
+      "b": { "$id": "two", "$dynamicAnchor": "shared" }
+    },
+    "properties": { "value": { "$dynamicRef": "#shared" } }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_TRUE(frame.has_dynamic_references());
+  EXPECT_TRUE(frame.any_reference(
+      [](const sourcemeta::blaze::SchemaReferenceType type,
+         const sourcemeta::core::WeakPointer &,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return type == sourcemeta::blaze::SchemaReferenceType::Dynamic;
+      }));
+}
+
+TEST(accessors_has_dynamic_references_after_static_rewrite) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": { "a": { "$dynamicAnchor": "only" } },
+    "properties": { "value": { "$dynamicRef": "#only" } }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_FALSE(frame.has_dynamic_references());
+}
+
+TEST(accessors_has_dynamic_references_without_any) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": { "one": { "$ref": "#" } }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_FALSE(frame.has_dynamic_references());
+}
+
+TEST(accessors_location_by_uri) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const auto result{
+      frame.location(sourcemeta::blaze::SchemaReferenceType::Static,
+                     "https://example.com/schema#static-anchor")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(sourcemeta::core::to_string(result.value().get().pointer),
+            "/$defs/foo");
+  EXPECT_EQ(result.value().get().type,
+            sourcemeta::blaze::SchemaFrame::LocationType::Anchor);
+}
+
+TEST(accessors_location_by_uri_wrong_type) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_FALSE(frame
+                   .location(sourcemeta::blaze::SchemaReferenceType::Dynamic,
+                             "https://example.com/schema#static-anchor")
+                   .has_value());
+}
+
+TEST(accessors_location_by_uri_unknown) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_FALSE(frame
+                   .location(sourcemeta::blaze::SchemaReferenceType::Static,
+                             "https://example.com/nowhere")
+                   .has_value());
+}
+
+TEST(accessors_for_each_subschema) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::vector<std::string> pointers;
+  frame.for_each_subschema(
+      [&pointers](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        pointers.push_back(sourcemeta::core::to_string(location.pointer));
+      });
+
+  EXPECT_EQ(pointers.size(), 9);
+  EXPECT_EQ(pointers.at(0), "/$defs/baz");
+  EXPECT_EQ(pointers.at(1), "/$defs/baz/properties/deep");
+  EXPECT_EQ(pointers.at(2), "");
+  EXPECT_EQ(pointers.at(3), "/$defs/bar");
+  EXPECT_EQ(pointers.at(4), "/$defs/baz");
+  EXPECT_EQ(pointers.at(5), "/$defs/baz/properties/deep");
+  EXPECT_EQ(pointers.at(6), "/$defs/foo");
+  EXPECT_EQ(pointers.at(7), "/properties/one");
+  EXPECT_EQ(pointers.at(8), "/properties/two");
+}
+
+TEST(accessors_for_each_subschema_under) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer base{"$defs"};
+  std::vector<std::string> pointers;
+  frame.for_each_subschema_under(
+      sourcemeta::core::to_weak_pointer(base),
+      [&pointers](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        pointers.push_back(sourcemeta::core::to_string(location.pointer));
+      });
+
+  EXPECT_EQ(pointers.size(), 6);
+  EXPECT_EQ(pointers.at(0), "/$defs/baz");
+  EXPECT_EQ(pointers.at(1), "/$defs/baz/properties/deep");
+  EXPECT_EQ(pointers.at(2), "/$defs/bar");
+  EXPECT_EQ(pointers.at(3), "/$defs/baz");
+  EXPECT_EQ(pointers.at(4), "/$defs/baz/properties/deep");
+  EXPECT_EQ(pointers.at(5), "/$defs/foo");
+}
+
+TEST(accessors_any_subschema) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_TRUE(frame.any_subschema(
+      [](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        return sourcemeta::core::to_string(location.pointer) ==
+               "/properties/two";
+      }));
+  EXPECT_FALSE(frame.any_subschema(
+      [](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        return sourcemeta::core::to_string(location.pointer) == "/nowhere";
+      }));
+}
+
+TEST(accessors_any_subschema_under) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer properties{"properties"};
+  const sourcemeta::core::Pointer definitions{"$defs"};
+  EXPECT_TRUE(frame.any_subschema_under(
+      sourcemeta::core::to_weak_pointer(properties),
+      [](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        return sourcemeta::core::to_string(location.pointer) ==
+               "/properties/one";
+      }));
+  EXPECT_FALSE(frame.any_subschema_under(
+      sourcemeta::core::to_weak_pointer(definitions),
+      [](const sourcemeta::blaze::SchemaFrame::Location &location) {
+        return sourcemeta::core::to_string(location.pointer) ==
+               "/properties/one";
+      }));
+}
+
+TEST(accessors_for_each_anchor_static) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::vector<std::string> uris;
+  frame.for_each_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Static,
+      [&uris](const std::string_view uri,
+              const sourcemeta::blaze::SchemaFrame::Location &) {
+        uris.emplace_back(uri);
+      });
+
+  EXPECT_EQ(uris.size(), 2);
+  EXPECT_EQ(uris.at(0), "https://example.com/schema#dynamic-anchor");
+  EXPECT_EQ(uris.at(1), "https://example.com/schema#static-anchor");
+}
+
+TEST(accessors_for_each_anchor_dynamic) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::vector<std::string> uris;
+  std::vector<std::string> pointers;
+  frame.for_each_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic,
+      [&uris,
+       &pointers](const std::string_view uri,
+                  const sourcemeta::blaze::SchemaFrame::Location &location) {
+        uris.emplace_back(uri);
+        pointers.push_back(sourcemeta::core::to_string(location.pointer));
+      });
+
+  EXPECT_EQ(uris.size(), 1);
+  EXPECT_EQ(uris.at(0), "https://example.com/schema#dynamic-anchor");
+  EXPECT_EQ(pointers.size(), 1);
+  EXPECT_EQ(pointers.at(0), "/$defs/bar");
+}
+
+TEST(accessors_any_anchor) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_TRUE(frame.any_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic,
+      [](const std::string_view uri,
+         const sourcemeta::blaze::SchemaFrame::Location &) {
+        return uri == "https://example.com/schema#dynamic-anchor";
+      }));
+  EXPECT_FALSE(frame.any_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Dynamic,
+      [](const std::string_view uri,
+         const sourcemeta::blaze::SchemaFrame::Location &) {
+        return uri == "https://example.com/schema#static-anchor";
+      }));
+  EXPECT_TRUE(frame.any_anchor(
+      sourcemeta::blaze::SchemaReferenceType::Static,
+      [](const std::string_view uri,
+         const sourcemeta::blaze::SchemaFrame::Location &) {
+        return uri == "https://example.com/schema#static-anchor";
+      }));
+}
+
+TEST(accessors_for_each_resource) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::vector<std::string> uris;
+  std::vector<std::string> pointers;
+  frame.for_each_resource(
+      [&uris,
+       &pointers](const std::string_view uri,
+                  const sourcemeta::blaze::SchemaFrame::Location &location) {
+        uris.emplace_back(uri);
+        pointers.push_back(sourcemeta::core::to_string(location.pointer));
+      });
+
+  EXPECT_EQ(uris.size(), 2);
+  EXPECT_EQ(uris.at(0), "https://example.com/nested");
+  EXPECT_EQ(pointers.at(0), "/$defs/baz");
+  EXPECT_EQ(uris.at(1), "https://example.com/schema");
+  EXPECT_EQ(pointers.at(1), "");
+}
+
+TEST(accessors_for_each_location) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::size_t visited{0};
+  std::size_t dynamic{0};
+  frame.for_each_location(
+      [&visited, &dynamic](const sourcemeta::blaze::SchemaReferenceType type,
+                           const std::string_view,
+                           const sourcemeta::blaze::SchemaFrame::Location &) {
+        visited += 1;
+        if (type == sourcemeta::blaze::SchemaReferenceType::Dynamic) {
+          dynamic += 1;
+        }
+      });
+
+  EXPECT_EQ(visited, frame.location_count());
+  EXPECT_EQ(visited, 28);
+  EXPECT_EQ(dynamic, 1);
+}
+
+TEST(accessors_any_location) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_TRUE(
+      frame.any_location([](const sourcemeta::blaze::SchemaReferenceType,
+                            const std::string_view uri,
+                            const sourcemeta::blaze::SchemaFrame::Location &) {
+        return uri == "https://example.com/nested#/properties/deep";
+      }));
+  EXPECT_FALSE(
+      frame.any_location([](const sourcemeta::blaze::SchemaReferenceType,
+                            const std::string_view uri,
+                            const sourcemeta::blaze::SchemaFrame::Location &) {
+        return uri == "https://example.com/nowhere";
+      }));
+}
+
+TEST(accessors_for_each_reference) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  std::vector<std::string> origins;
+  std::vector<sourcemeta::blaze::SchemaReferenceType> types;
+  frame.for_each_reference(
+      [&origins,
+       &types](const sourcemeta::blaze::SchemaReferenceType type,
+               const sourcemeta::core::WeakPointer &origin,
+               const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        origins.push_back(sourcemeta::core::to_string(origin));
+        types.push_back(type);
+      });
+
+  EXPECT_EQ(origins.size(), 4);
+  EXPECT_EQ(types.size(), 4);
+  std::size_t dynamic_references{0};
+  for (const auto type : types) {
+    if (type == sourcemeta::blaze::SchemaReferenceType::Dynamic) {
+      dynamic_references += 1;
+    }
+  }
+
+  EXPECT_EQ(dynamic_references, 0);
+  EXPECT_FALSE(frame.has_dynamic_references());
+  EXPECT_EQ(origins.at(0), "/$defs/baz/properties/deep/$ref");
+  EXPECT_EQ(origins.at(1), "/$schema");
+  EXPECT_EQ(origins.at(2), "/properties/one/$ref");
+  EXPECT_EQ(origins.at(3), "/properties/two/$dynamicRef");
+}
+
+TEST(accessors_any_reference) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  EXPECT_TRUE(frame.any_reference(
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &origin,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return sourcemeta::core::to_string(origin) == "/properties/one/$ref";
+      }));
+  EXPECT_FALSE(frame.any_reference(
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &entry) {
+        return entry.destination == "https://example.com/nowhere";
+      }));
+}
+
+TEST(accessors_for_each_reference_from) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer properties{"properties"};
+  std::vector<std::string> origins;
+  frame.for_each_reference_from(
+      sourcemeta::core::to_weak_pointer(properties),
+      [&origins](const sourcemeta::blaze::SchemaReferenceType,
+                 const sourcemeta::core::WeakPointer &origin,
+                 const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        origins.push_back(sourcemeta::core::to_string(origin));
+      });
+
+  EXPECT_EQ(origins.size(), 2);
+  EXPECT_EQ(origins.at(0), "/properties/one/$ref");
+  EXPECT_EQ(origins.at(1), "/properties/two/$dynamicRef");
+}
+
+TEST(accessors_any_reference_from) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer definitions{"$defs"};
+  const sourcemeta::core::Pointer nowhere{"nowhere"};
+  EXPECT_TRUE(frame.any_reference_from(
+      sourcemeta::core::to_weak_pointer(definitions),
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return true;
+      }));
+  EXPECT_FALSE(frame.any_reference_from(
+      sourcemeta::core::to_weak_pointer(nowhere),
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return true;
+      }));
+}
+
+TEST(accessors_for_each_reference_into) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer target{"$defs", "foo"};
+  std::vector<std::string> origins;
+  frame.for_each_reference_into(
+      sourcemeta::core::to_weak_pointer(target),
+      [&origins](const sourcemeta::blaze::SchemaReferenceType,
+                 const sourcemeta::core::WeakPointer &origin,
+                 const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        origins.push_back(sourcemeta::core::to_string(origin));
+      });
+
+  EXPECT_EQ(origins.size(), 2);
+  EXPECT_EQ(origins.at(0), "/$defs/baz/properties/deep/$ref");
+  EXPECT_EQ(origins.at(1), "/properties/one/$ref");
+}
+
+TEST(accessors_any_reference_into) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": { "$anchor": "static-anchor", "type": "string" },
+      "bar": { "$dynamicAnchor": "dynamic-anchor", "type": "number" },
+      "baz": {
+        "$id": "nested",
+        "properties": {
+          "deep": { "$ref": "https://example.com/schema#/$defs/foo" }
+        }
+      }
+    },
+    "properties": {
+      "one": { "$ref": "#/$defs/foo" },
+      "two": { "$dynamicRef": "#dynamic-anchor" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  const sourcemeta::core::Pointer bar{"$defs", "bar"};
+  const sourcemeta::core::Pointer one{"properties", "one"};
+  EXPECT_TRUE(frame.any_reference_into(
+      sourcemeta::core::to_weak_pointer(bar),
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &origin,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return sourcemeta::core::to_string(origin) ==
+               "/properties/two/$dynamicRef";
+      }));
+  EXPECT_FALSE(frame.any_reference_into(
+      sourcemeta::core::to_weak_pointer(one),
+      [](const sourcemeta::blaze::SchemaReferenceType,
+         const sourcemeta::core::WeakPointer &,
+         const sourcemeta::blaze::SchemaFrame::ReferencesEntry &) {
+        return true;
+      }));
 }

--- a/test/foundation/framesuite.cc
+++ b/test/foundation/framesuite.cc
@@ -103,11 +103,11 @@ auto check_reachability(const sourcemeta::blaze::SchemaFrame &frame,
                           check.at("type").to_string() == "dynamic"
                       ? sourcemeta::blaze::SchemaReferenceType::Dynamic
                       : sourcemeta::blaze::SchemaReferenceType::Static};
-  const auto target{frame.locations().find({type, check.at("to").to_string()})};
-  EXPECT_TRUE(target != frame.locations().cend());
+  const auto target{frame.location(type, check.at("to").to_string())};
+  EXPECT_TRUE(target.has_value());
   const auto origin{frame.traverse(check.at("from").to_string())};
   EXPECT_TRUE(origin.has_value());
-  EXPECT_EQ(frame.is_reachable(origin.value().get(), target->second,
+  EXPECT_EQ(frame.is_reachable(origin.value().get(), target.value().get(),
                                sourcemeta::blaze::schema_walker, resolver),
             check.at("reachable").to_boolean());
 }

--- a/test/foundation/referencingsuite.cc
+++ b/test/foundation/referencingsuite.cc
@@ -94,11 +94,15 @@ auto run_referencing_test(const sourcemeta::core::JSON &suite,
         sourcemeta::blaze::schema_resolver,
         dialect,
         uri};
-    for (const auto &[key, entry] : frame.locations()) {
-      new_entries.insert({key.second,
-                          {sourcemeta::core::get(schema.first, entry.pointer),
-                           std::string{entry.base}}});
-    }
+    frame.for_each_location(
+        [&](const sourcemeta::blaze::SchemaReferenceType,
+            const std::string_view location_uri,
+            const sourcemeta::blaze::SchemaFrame::Location &entry) -> void {
+          new_entries.insert(
+              {sourcemeta::core::JSON::String{location_uri},
+               {sourcemeta::core::get(schema.first, entry.pointer),
+                std::string{entry.base}}});
+        });
   }
 
   // We don't insert into the main registry on the above loop,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

