### PR TITLE
Stop depending on frame pointer locations in the editor

### DIFF
--- a/src/editor/editor.cc
+++ b/src/editor/editor.cc
@@ -6,7 +6,6 @@
 
 #include <cassert> // assert
 #include <format>  // std::format
-#include <map>     // std::map
 
 namespace {
 
@@ -22,9 +21,7 @@ auto top_dynamic_anchor_location(
     -> std::optional<
         std::reference_wrapper<const sourcemeta::core::WeakPointer>> {
   // Get the location object of where we are at the moment
-  const auto uri{frame.uri(current)};
-  assert(uri.has_value());
-  const auto match{frame.traverse(uri.value().get())};
+  const auto match{frame.traverse(current)};
   assert(match.has_value());
   const auto &location{match.value().get()};
 
@@ -93,17 +90,6 @@ auto for_editor(sourcemeta::core::JSON &schema,
     // Otherwise the input is not bundled
     assert(frame.standalone());
 
-    // Note that `std::unordered_map` is slower here due to high collision rates
-    // from the simple pointer hashes
-    std::map<sourcemeta::core::WeakPointer, std::string_view> pointer_to_uri;
-    frame.for_each_location(
-        [&pointer_to_uri](
-            const sourcemeta::blaze::SchemaReferenceType,
-            const std::string_view uri,
-            const sourcemeta::blaze::SchemaFrame::Location &location) -> void {
-          pointer_to_uri.emplace(location.pointer, uri);
-        });
-
     // Collect reference changes
     frame.for_each_reference(
         [&](const sourcemeta::blaze::SchemaReferenceType type,
@@ -116,8 +102,10 @@ auto for_editor(sourcemeta::core::JSON &schema,
 
           if (type == sourcemeta::blaze::SchemaReferenceType::Dynamic) {
             if (reference.fragment.has_value()) {
+              // A reference is a keyword of the subschema that declares it,
+              // which is the resource scope the search has to start from
               const auto destination{top_dynamic_anchor_location(
-                  frame, origin, reference.fragment.value(),
+                  frame, origin.initial(), reference.fragment.value(),
                   reference.destination)};
               if (!destination.has_value()) {
                 return;
@@ -139,10 +127,10 @@ auto for_editor(sourcemeta::core::JSON &schema,
             }
           } else {
             if (keyword == "$schema") {
-              // Use pre-built index instead of O(n) frame.uri() scan
-              const auto uri_it{pointer_to_uri.find(origin)};
-              assert(uri_it != pointer_to_uri.end());
-              const auto location{frame.traverse(uri_it->second)};
+              // A meta-schema reference is a keyword of the subschema that
+              // declares it, so the base dialect to report is the one in force
+              // at that subschema
+              const auto location{frame.traverse(origin.initial())};
               assert(location.has_value());
               reference_changes.push_back(
                   {.pointer = sourcemeta::core::to_pointer(origin),


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

