### PR TITLE
Break the `References` framing mode into `References` vs `Pointers`

### DIFF
--- a/benchmark/frame.cc
+++ b/benchmark/frame.cc
@@ -36,6 +36,19 @@ static void Schema_Frame_OMC_References(benchmark::State &state) {
   }
 }
 
+static void Schema_Frame_OMC_Pointers(benchmark::State &state) {
+  const auto schema{
+      sourcemeta::core::read_json(std::filesystem::path{CURRENT_DIRECTORY} /
+                                  "files" / "2019_09_omc_json_v2.json")};
+
+  for (auto _ : state) {
+    sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::Pointers, schema,
+        sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+    benchmark::DoNotOptimize(frame);
+  }
+}
+
 static void Schema_Frame_OMC_Locations(benchmark::State &state) {
   const auto schema{
       sourcemeta::core::read_json(std::filesystem::path{CURRENT_DIRECTORY} /
@@ -175,6 +188,7 @@ static void Schema_Frame_Deeply_Nested_References(benchmark::State &state) {
 
 BENCHMARK(Schema_Frame_WoT_References);
 BENCHMARK(Schema_Frame_OMC_References);
+BENCHMARK(Schema_Frame_OMC_Pointers);
 BENCHMARK(Schema_Frame_OMC_Locations);
 BENCHMARK(Schema_Frame_ISO_Language_Locations);
 BENCHMARK(Schema_Frame_ISO_Language_Root);

--- a/contrib/frame.cc
+++ b/contrib/frame.cc
@@ -17,7 +17,7 @@ auto main(int argc, char *argv[]) -> int {
                                 : sourcemeta::core::parse_json(std::cin)};
 
     sourcemeta::blaze::SchemaFrame frame{
-        sourcemeta::blaze::SchemaFrame::Mode::References, schema,
+        sourcemeta::blaze::SchemaFrame::Mode::Pointers, schema,
         sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
 
     sourcemeta::core::prettify(

--- a/src/alterschema/linter/invalid_external_ref.h
+++ b/src/alterschema/linter/invalid_external_ref.h
@@ -106,8 +106,10 @@ private:
                       const SchemaFrame::Location &location) const -> bool {
     auto frame_iterator{this->frame_cache_.find(base_key)};
     if (frame_iterator == this->frame_cache_.end()) {
+      // A reference may name any place of the remote rather than only the
+      // schemas of it, so this needs framing to address every pointer
       auto remote_frame{std::make_unique<SchemaFrame>(
-          SchemaFrame::Mode::Locations, remote.value(), walker, resolver,
+          SchemaFrame::Mode::Pointers, remote.value(), walker, resolver,
           location.dialect, base_key)};
       frame_iterator =
           this->frame_cache_.emplace(base_key, std::move(remote_frame)).first;

--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -422,8 +422,11 @@ auto bundle_schema(sourcemeta::core::JSON &root,
     if (reference.fragment.has_value()) {
       // TODO: The fact that we have to re-frame on each loop pass to check
       // for this is probably insanely slow
+      // A fragment may name any place of the remote rather than only the
+      // schemas of it, so this is one of the few callers that needs framing
+      // to address every pointer
       sourcemeta::blaze::SchemaFrame remote_frame{
-          sourcemeta::blaze::SchemaFrame::Mode::Locations,
+          sourcemeta::blaze::SchemaFrame::Mode::Pointers,
           remote,
           walker,
           resolver,

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -428,6 +428,35 @@ auto schema_frame_populate_target_types(
 
 namespace sourcemeta::blaze {
 
+// Whether an entry point that the frame could not locate nonetheless names a
+// place that the document has, which means it is a keyword rather than a
+// schema. Only reachable when the entry point carries a pointer fragment, as
+// anything else can only ever name a schema
+auto entrypoint_names_non_schema(const sourcemeta::core::JSON &schema,
+                                 const sourcemeta::blaze::SchemaFrame &frame,
+                                 const std::string_view entrypoint) -> bool {
+  sourcemeta::core::URI uri{sourcemeta::core::JSON::String{entrypoint}};
+  const auto fragment{uri.fragment()};
+  if (!fragment.has_value() || !fragment.value().starts_with('/')) {
+    return false;
+  }
+
+  const sourcemeta::core::Pointer relative{
+      sourcemeta::core::to_pointer(sourcemeta::core::JSON::String{
+          fragment.value()})};
+  const auto base{
+      uri.recompose_without_fragment().value_or(sourcemeta::core::JSON::String{})};
+  const auto base_location{frame.traverse(base)};
+  if (!base_location.has_value()) {
+    return sourcemeta::core::try_get(schema, relative) != nullptr;
+  }
+
+  return sourcemeta::core::try_get(
+             schema, sourcemeta::core::to_pointer(
+                         base_location.value().get().pointer)
+                         .concat(relative)) != nullptr;
+}
+
 auto compile(const sourcemeta::core::JSON &schema,
              const sourcemeta::blaze::SchemaWalker &walker,
              const sourcemeta::blaze::SchemaResolver &resolver,
@@ -440,8 +469,14 @@ auto compile(const sourcemeta::core::JSON &schema,
 
   const auto maybe_entrypoint_location{frame.traverse(entrypoint)};
   if (!maybe_entrypoint_location.has_value()) [[unlikely]] {
+    // A frame that only locates schemas has nothing to say about an entry
+    // point that names a plain keyword, so tell the two apart by asking the
+    // document rather than reporting a place that does exist as missing
     throw CompilerInvalidEntryPoint{
-        entrypoint, "The given entry point URI does not exist in the schema"};
+        entrypoint,
+        entrypoint_names_non_schema(schema, frame, entrypoint)
+            ? "The given entry point URI is not a valid subschema"
+            : "The given entry point URI does not exist in the schema"};
   }
 
   const auto &entrypoint_location{maybe_entrypoint_location->get()};

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -435,25 +435,34 @@ namespace sourcemeta::blaze {
 auto entrypoint_names_non_schema(const sourcemeta::core::JSON &schema,
                                  const sourcemeta::blaze::SchemaFrame &frame,
                                  const std::string_view entrypoint) -> bool {
-  sourcemeta::core::URI uri{sourcemeta::core::JSON::String{entrypoint}};
-  const auto fragment{uri.fragment()};
-  if (!fragment.has_value() || !fragment.value().starts_with('/')) {
+  std::optional<sourcemeta::core::URI> uri;
+  try {
+    uri.emplace(sourcemeta::core::JSON::String{entrypoint});
+  } catch (const sourcemeta::core::URIParseError &) {
+    // A URI that does not even parse names nothing at all, so leave the
+    // caller to report it as the invalid entry point that it is
     return false;
   }
 
-  const sourcemeta::core::Pointer relative{sourcemeta::core::to_pointer(
-      sourcemeta::core::JSON::String{fragment.value()})};
-  const auto base{uri.recompose_without_fragment().value_or(
+  const auto relative{sourcemeta::core::fragment_to_pointer(uri.value())};
+  if (!relative.has_value()) {
+    return false;
+  }
+
+  const auto base{uri.value().recompose_without_fragment().value_or(
       sourcemeta::core::JSON::String{})};
   const auto base_location{frame.traverse(base)};
   if (!base_location.has_value()) {
-    return sourcemeta::core::try_get(schema, relative) != nullptr;
+    // A base that framing does not know names some other document, which this
+    // one has nothing to say about
+    return base.empty() &&
+           sourcemeta::core::try_get(schema, relative.value()) != nullptr;
   }
 
   return sourcemeta::core::try_get(
              schema,
              sourcemeta::core::to_pointer(base_location.value().get().pointer)
-                 .concat(relative)) != nullptr;
+                 .concat(relative.value())) != nullptr;
 }
 
 auto compile(const sourcemeta::core::JSON &schema,

--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -441,20 +441,19 @@ auto entrypoint_names_non_schema(const sourcemeta::core::JSON &schema,
     return false;
   }
 
-  const sourcemeta::core::Pointer relative{
-      sourcemeta::core::to_pointer(sourcemeta::core::JSON::String{
-          fragment.value()})};
-  const auto base{
-      uri.recompose_without_fragment().value_or(sourcemeta::core::JSON::String{})};
+  const sourcemeta::core::Pointer relative{sourcemeta::core::to_pointer(
+      sourcemeta::core::JSON::String{fragment.value()})};
+  const auto base{uri.recompose_without_fragment().value_or(
+      sourcemeta::core::JSON::String{})};
   const auto base_location{frame.traverse(base)};
   if (!base_location.has_value()) {
     return sourcemeta::core::try_get(schema, relative) != nullptr;
   }
 
   return sourcemeta::core::try_get(
-             schema, sourcemeta::core::to_pointer(
-                         base_location.value().get().pointer)
-                         .concat(relative)) != nullptr;
+             schema,
+             sourcemeta::core::to_pointer(base_location.value().get().pointer)
+                 .concat(relative)) != nullptr;
 }
 
 auto compile(const sourcemeta::core::JSON &schema,

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -1505,9 +1505,17 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
         continue;
       }
 
+      // The fragment of a reference is URI-encoded, so it has to be decoded
+      // rather than read as-is, else an escape like `a%20b` would stand for a
+      // property of that literal name
+      const auto relative{sourcemeta::core::fragment_to_pointer(
+          sourcemeta::core::URI{reference.second.destination})};
+      if (!relative.has_value()) {
+        continue;
+      }
+
       auto absolute{sourcemeta::core::to_pointer(base_entry->second.pointer)
-                        .concat(sourcemeta::core::to_pointer(
-                            sourcemeta::core::JSON::String{fragment.value()}))};
+                        .concat(relative.value())};
       if (sourcemeta::core::try_get(root, absolute) == nullptr) {
         continue;
       }

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -520,6 +520,9 @@ auto SchemaFrame::to_json(
     case SchemaFrame::Mode::References:
       root.assign_assume_new("mode", sourcemeta::core::JSON{"references"});
       break;
+    case SchemaFrame::Mode::Pointers:
+      root.assign_assume_new("mode", sourcemeta::core::JSON{"pointers"});
+      break;
   }
 
   const auto destinations{
@@ -1049,7 +1052,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
         }
       }
 
-      if (this->mode_ == SchemaFrame::Mode::References) {
+      if (this->mode_ >= SchemaFrame::Mode::References) {
         // Handle metaschema references
         const auto maybe_metaschema{sourcemeta::blaze::dialect(
             entry.common.subschema.get(), {}, false)};
@@ -1201,6 +1204,11 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
     for (const auto &relative_pointer : pointers) {
       const auto pointer_weak{path.concat(relative_pointer)};
 
+      if (this->mode_ != SchemaFrame::Mode::Pointers &&
+          !subschemas.contains(pointer_weak)) {
+        continue;
+      }
+
       const auto combined{
           find_dialect_and_all_bases(base_dialects, base_uris, pointer_weak)};
       const auto &dialect_for_pointer{
@@ -1319,7 +1327,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
     }
   }
 
-  if (this->mode_ != SchemaFrame::Mode::References) {
+  if (this->mode_ < SchemaFrame::Mode::References) {
     return;
   }
 
@@ -1469,6 +1477,85 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
                                    .fragment = std::nullopt});
         set_base_and_fragment(it->second);
       }
+    }
+  }
+
+  // A reference may target a place that the walker never descends into, like
+  // a keyword value or a container that a top-level `$ref` overrides. Those
+  // have no location of their own outside of
+  // sourcemeta::blaze::SchemaFrame::Mode::Pointers, so materialise one for
+  // each, which costs an entry per reference rather than one per pointer of
+  // the analysed document
+  if (this->mode_ < SchemaFrame::Mode::Pointers) {
+    for (const auto &reference : this->references_) {
+      const auto &fragment{reference.second.fragment};
+      if (!fragment.has_value() || !fragment.value().starts_with('/')) {
+        continue;
+      }
+
+      if (this->locations_.contains(
+              {SchemaReferenceType::Static, reference.second.destination})) {
+        continue;
+      }
+
+      const auto base_entry{this->locations_.find(
+          {SchemaReferenceType::Static,
+           sourcemeta::core::JSON::String{reference.second.base}})};
+      if (base_entry == this->locations_.cend()) {
+        continue;
+      }
+
+      auto absolute{sourcemeta::core::to_pointer(base_entry->second.pointer)
+                        .concat(sourcemeta::core::to_pointer(
+                            sourcemeta::core::JSON::String{fragment.value()}))};
+      if (sourcemeta::core::try_get(root, absolute) == nullptr) {
+        continue;
+      }
+
+      this->reference_pointers_.push_back(std::move(absolute));
+      const auto pointer_weak{
+          sourcemeta::core::to_weak_pointer(this->reference_pointers_.back())};
+      const auto combined{
+          find_dialect_and_all_bases(base_dialects, base_uris, pointer_weak)};
+
+      std::size_t nearest_base_depth{base_entry->second.pointer.size()};
+      std::string_view nearest_base_view{base_entry->first.second};
+      for (const auto &candidate : combined.every_base) {
+        if (candidate.first.empty()) {
+          continue;
+        }
+
+        nearest_base_depth = candidate.second.size();
+        const auto candidate_entry{this->locations_.find(
+            {SchemaReferenceType::Static,
+             sourcemeta::core::JSON::String{candidate.first}})};
+        if (candidate_entry != this->locations_.cend()) {
+          nearest_base_view = candidate_entry->first.second;
+        }
+
+        break;
+      }
+
+      const auto parent{combined.dialect_match.has_value()
+                            ? combined.dialect_match->second
+                            : base_entry->second.pointer};
+      const auto parent_subschema{subschemas.find(parent)};
+      store(this->locations_, SchemaReferenceType::Static,
+            SchemaFrame::LocationType::Pointer,
+            sourcemeta::core::JSON::String{reference.second.destination},
+            nearest_base_view, pointer_weak, nearest_base_depth,
+            combined.dialect_match.has_value()
+                ? combined.dialect_match->first.get().dialects.front()
+                : base_entry->second.dialect,
+            combined.dialect_match.has_value()
+                ? combined.dialect_match->first.get().base_dialect
+                : base_entry->second.base_dialect,
+            parent,
+            parent_subschema != subschemas.cend() &&
+                parent_subschema->second.property_name,
+            parent_subschema != subschemas.cend() &&
+                parent_subschema->second.orphan,
+            true);
     }
   }
 

--- a/src/foundation/include/sourcemeta/blaze/foundation_frame.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_frame.h
@@ -15,6 +15,7 @@
 
 #include <concepts>   // std::invocable
 #include <cstdint>    // std::uint8_t
+#include <deque>      // std::deque
 #include <functional> // std::reference_wrapper
 #include <map>        // std::map
 #include <memory>     // std::unique_ptr
@@ -58,7 +59,14 @@ public:
   /// intensive. Each mode is a superset of the previous one. Note that
   /// sourcemeta::blaze::SchemaFrame::Mode::Root reports on a single schema,
   /// so framing a wrapper that holds more than one yields no locations
-  enum class Mode : std::uint8_t { Root, Locations, References };
+  ///
+  /// Every mode below sourcemeta::blaze::SchemaFrame::Mode::Pointers locates
+  /// the schemas of the document rather than each of its JSON Pointers, plus
+  /// whatever place a reference happens to name. Reach for
+  /// sourcemeta::blaze::SchemaFrame::Mode::Pointers only to address a keyword
+  /// or a value of the document by URI, as computing those locations tends to
+  /// dominate the cost of framing
+  enum class Mode : std::uint8_t { Root, Locations, References, Pointers };
 
   /// How a caller-provided default identifier relates to the one that the
   /// schema declares, if any
@@ -529,6 +537,11 @@ private:
 #pragma warning(disable : 4251 4275)
 #endif
   sourcemeta::core::JSON::String root_;
+  // A reference may target a place that no schema location covers, in which
+  // case framing materialises one for it. Unlike every other location, the
+  // tokens of those pointers are not borrowed from the analysed document, so
+  // they have to be declared here to outlive the locations that borrow them
+  std::deque<sourcemeta::core::Pointer> reference_pointers_;
   Locations locations_;
   References references_;
   // What the frame derives rather than is, kept out of line so that this

--- a/src/foundation/include/sourcemeta/blaze/foundation_frame.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_frame.h
@@ -60,9 +60,10 @@ public:
   /// sourcemeta::blaze::SchemaFrame::Mode::Root reports on a single schema,
   /// so framing a wrapper that holds more than one yields no locations
   ///
-  /// Every mode below sourcemeta::blaze::SchemaFrame::Mode::Pointers locates
-  /// the schemas of the document rather than each of its JSON Pointers, plus
-  /// whatever place a reference happens to name. Reach for
+  /// sourcemeta::blaze::SchemaFrame::Mode::Locations and
+  /// sourcemeta::blaze::SchemaFrame::Mode::References locate the schemas of
+  /// the document rather than each of its JSON Pointers, and the latter also
+  /// locates whatever place a reference names. Reach for
   /// sourcemeta::blaze::SchemaFrame::Mode::Pointers only to address a keyword
   /// or a value of the document by URI, as computing those locations tends to
   /// dominate the cost of framing

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -409,6 +409,29 @@ TEST(instruction_move_assignable) {
   EXPECT_TRUE(std::is_move_assignable_v<sourcemeta::blaze::Instruction>);
 }
 
+TEST(invalid_entrypoint_that_is_not_a_uri) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string"
+  })JSON")};
+
+  sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, schema,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_schema_compiler,
+                               frame, "http://[");
+    FAIL();
+  } catch (const sourcemeta::blaze::CompilerInvalidEntryPoint &error) {
+    EXPECT_EQ(error.identifier(), "http://[");
+    EXPECT_STREQ(error.what(),
+                 "The given entry point URI does not exist in the schema");
+  }
+}
+
 TEST(invalid_entrypoint_does_not_exist) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/foundation/foundation_frame_test.cc
+++ b/test/foundation/foundation_frame_test.cc
@@ -208,60 +208,6 @@ TEST(to_json_mode_references_with_tracking) {
             "http://json-schema.org/draft-04/schema#": true
           }
         },
-        "https://www.sourcemeta.com/bar#/$schema": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/$schema",
-          "position": [ 10, 9, 10, 60 ],
-          "relativePointer": "/$schema",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/bar#/id": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/id",
-          "position": [ 9, 9, 9, 19 ],
-          "relativePointer": "/id",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/bar#/type": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/type",
-          "position": [ 11, 9, 11, 24 ],
-          "relativePointer": "/type",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
         "https://www.sourcemeta.com/test": {
           "parent": null,
           "type": "resource",
@@ -270,78 +216,6 @@ TEST(to_json_mode_references_with_tracking) {
           "pointer": "",
           "position": [ 1, 1, 14, 3 ],
           "relativePointer": "",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": true,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/$id": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/$id",
-          "position": [ 2, 5, 2, 44 ],
-          "relativePointer": "/$id",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/$schema": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/$schema",
-          "position": [ 3, 5, 3, 61 ],
-          "relativePointer": "/$schema",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/properties",
-          "position": [ 4, 5, 13, 5 ],
-          "relativePointer": "/properties",
           "dialect": "https://json-schema.org/draft/2020-12/schema",
           "baseDialect": "https://json-schema.org/draft/2020-12/schema",
           "propertyName": false,
@@ -376,60 +250,6 @@ TEST(to_json_mode_references_with_tracking) {
             "http://json-schema.org/draft-04/schema#": true
           }
         },
-        "https://www.sourcemeta.com/test#/properties/bar/$schema": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/$schema",
-          "position": [ 10, 9, 10, 60 ],
-          "relativePointer": "/$schema",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/bar/id": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/id",
-          "position": [ 9, 9, 9, 19 ],
-          "relativePointer": "/id",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/bar/type": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/type",
-          "position": [ 11, 9, 11, 24 ],
-          "relativePointer": "/type",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
         "https://www.sourcemeta.com/test#/properties/foo": {
           "parent": "",
           "type": "subschema",
@@ -438,30 +258,6 @@ TEST(to_json_mode_references_with_tracking) {
           "pointer": "/properties/foo",
           "position": [ 5, 7, 7, 7 ],
           "relativePointer": "/properties/foo",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/foo/$ref": {
-          "parent": "/properties/foo",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/properties/foo/$ref",
-          "position": [ 6, 9, 6, 21 ],
-          "relativePointer": "/properties/foo/$ref",
           "dialect": "https://json-schema.org/draft/2020-12/schema",
           "baseDialect": "https://json-schema.org/draft/2020-12/schema",
           "propertyName": false,
@@ -564,60 +360,6 @@ TEST(to_json_mode_references_with_tracking_empty) {
             "http://json-schema.org/draft-04/schema#": true
           }
         },
-        "https://www.sourcemeta.com/bar#/$schema": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/$schema",
-          "position": null,
-          "relativePointer": "/$schema",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/bar#/id": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/id",
-          "position": null,
-          "relativePointer": "/id",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/bar#/type": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/type",
-          "position": null,
-          "relativePointer": "/type",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
         "https://www.sourcemeta.com/test": {
           "parent": null,
           "type": "resource",
@@ -626,78 +368,6 @@ TEST(to_json_mode_references_with_tracking_empty) {
           "pointer": "",
           "position": null,
           "relativePointer": "",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": true,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/$id": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/$id",
-          "position": null,
-          "relativePointer": "/$id",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/$schema": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/$schema",
-          "position": null,
-          "relativePointer": "/$schema",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties": {
-          "parent": "",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/properties",
-          "position": null,
-          "relativePointer": "/properties",
           "dialect": "https://json-schema.org/draft/2020-12/schema",
           "baseDialect": "https://json-schema.org/draft/2020-12/schema",
           "propertyName": false,
@@ -732,60 +402,6 @@ TEST(to_json_mode_references_with_tracking_empty) {
             "http://json-schema.org/draft-04/schema#": true
           }
         },
-        "https://www.sourcemeta.com/test#/properties/bar/$schema": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/$schema",
-          "position": null,
-          "relativePointer": "/$schema",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/bar/id": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/id",
-          "position": null,
-          "relativePointer": "/id",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/bar/type": {
-          "parent": "/properties/bar",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/bar",
-          "pointer": "/properties/bar/type",
-          "position": null,
-          "relativePointer": "/type",
-          "dialect": "http://json-schema.org/draft-04/schema#",
-          "baseDialect": "http://json-schema.org/draft-04/schema#",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "http://json-schema.org/draft-04/schema#": true
-          }
-        },
         "https://www.sourcemeta.com/test#/properties/foo": {
           "parent": "",
           "type": "subschema",
@@ -794,30 +410,6 @@ TEST(to_json_mode_references_with_tracking_empty) {
           "pointer": "/properties/foo",
           "position": null,
           "relativePointer": "/properties/foo",
-          "dialect": "https://json-schema.org/draft/2020-12/schema",
-          "baseDialect": "https://json-schema.org/draft/2020-12/schema",
-          "propertyName": false,
-          "orphan": false,
-          "hasReferencesTo": false,
-          "hasReferencesThrough": false,
-          "vocabularies": {
-            "https://json-schema.org/draft/2020-12/vocab/core": true,
-            "https://json-schema.org/draft/2020-12/vocab/applicator": true,
-            "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
-            "https://json-schema.org/draft/2020-12/vocab/validation": true,
-            "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
-            "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
-            "https://json-schema.org/draft/2020-12/vocab/content": true
-          }
-        },
-        "https://www.sourcemeta.com/test#/properties/foo/$ref": {
-          "parent": "/properties/foo",
-          "type": "pointer",
-          "root": "https://www.sourcemeta.com/test",
-          "base": "https://www.sourcemeta.com/test",
-          "pointer": "/properties/foo/$ref",
-          "position": null,
-          "relativePointer": "/properties/foo/$ref",
           "dialect": "https://json-schema.org/draft/2020-12/schema",
           "baseDialect": "https://json-schema.org/draft/2020-12/schema",
           "propertyName": false,
@@ -912,8 +504,9 @@ TEST(embedded_custom_metaschema_across_two_frames) {
   [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame_a{
       sourcemeta::blaze::SchemaFrame::Mode::References, document_a,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+  // This one takes a full inventory of the locations, pointers included
   const sourcemeta::blaze::SchemaFrame frame{
-      sourcemeta::blaze::SchemaFrame::Mode::References, document_b,
+      sourcemeta::blaze::SchemaFrame::Mode::Pointers, document_b,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
 
   EXPECT_EQ(frame.location_count(), 19);
@@ -1109,7 +702,7 @@ TEST(accessors_location_count) {
       sourcemeta::blaze::SchemaFrame::Mode::References, document,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
 
-  EXPECT_EQ(frame.location_count(), 28);
+  EXPECT_EQ(frame.location_count(), 12);
 }
 
 TEST(accessors_reference_count) {
@@ -1634,7 +1227,7 @@ TEST(accessors_for_each_location) {
       });
 
   EXPECT_EQ(visited, frame.location_count());
-  EXPECT_EQ(visited, 28);
+  EXPECT_EQ(visited, 12);
   EXPECT_EQ(dynamic, 1);
 }
 

--- a/test/foundation/foundation_frame_test.cc
+++ b/test/foundation/foundation_frame_test.cc
@@ -732,6 +732,30 @@ TEST(accessors_reference_count) {
   EXPECT_EQ(frame.reference_count(), 4);
 }
 
+TEST(materialised_reference_target_with_percent_encoded_token) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "a b": { "type": "string" },
+      "other": { "$ref": "#/properties/a%20b/type" }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, document,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+
+  // The target is a keyword value rather than a schema, so only materialising
+  // it puts it on the frame, and its fragment has to be decoded to get there
+  const auto target{frame.location(
+      sourcemeta::blaze::SchemaReferenceType::Static,
+      "https://example.com/schema#/properties/a%20b/type")};
+  EXPECT_TRUE(target.has_value());
+  EXPECT_EQ(sourcemeta::core::to_string(target.value().get().pointer),
+            "/properties/a b/type");
+}
+
 TEST(accessors_has_dynamic_references) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/schema",

--- a/test/foundation/foundation_frame_test.cc
+++ b/test/foundation/foundation_frame_test.cc
@@ -748,9 +748,9 @@ TEST(materialised_reference_target_with_percent_encoded_token) {
 
   // The target is a keyword value rather than a schema, so only materialising
   // it puts it on the frame, and its fragment has to be decoded to get there
-  const auto target{frame.location(
-      sourcemeta::blaze::SchemaReferenceType::Static,
-      "https://example.com/schema#/properties/a%20b/type")};
+  const auto target{
+      frame.location(sourcemeta::blaze::SchemaReferenceType::Static,
+                     "https://example.com/schema#/properties/a%20b/type")};
   EXPECT_TRUE(target.has_value());
   EXPECT_EQ(sourcemeta::core::to_string(target.value().get().pointer),
             "/properties/a b/type");

--- a/test/foundation/frame/2019-09/anchor_top_level.json
+++ b/test/foundation/frame/2019-09/anchor_top_level.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/anchor_with_valid_colon.json
+++ b/test/foundation/frame/2019-09/anchor_with_valid_colon.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/2019-09/anonymous_with_nested_schema_resource.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/custom_vocabularies.json
+++ b/test/foundation/frame/2019-09/custom_vocabularies.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/embedded_custom_metaschema.json
+++ b/test/foundation/frame/2019-09/embedded_custom_metaschema.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2019-09/empty_schema.json
+++ b/test/foundation/frame/2019-09/empty_schema.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/2019-09/empty_schema_trailing_hash.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/explicit_argument_id_different.json
+++ b/test/foundation/frame/2019-09/explicit_argument_id_different.json
@@ -71,8 +71,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/2019-09/explicit_argument_id_same.json
+++ b/test/foundation/frame/2019-09/explicit_argument_id_same.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/has_references_to_2019_09.json
+++ b/test/foundation/frame/2019-09/has_references_to_2019_09.json
@@ -63,8 +63,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2019-09/hyper.json
+++ b/test/foundation/frame/2019-09/hyper.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/nested_id_empty_fragment_only.json
+++ b/test/foundation/frame/2019-09/nested_id_empty_fragment_only.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/nested_id_empty_string.json
+++ b/test/foundation/frame/2019-09/nested_id_empty_string.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/nested_schemas.json
+++ b/test/foundation/frame/2019-09/nested_schemas.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/bar": {

--- a/test/foundation/frame/2019-09/no_dynamic_ref_on_old_drafts.json
+++ b/test/foundation/frame/2019-09/no_dynamic_ref_on_old_drafts.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/no_vocabularies.json
+++ b/test/foundation/frame/2019-09/no_vocabularies.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/no_vocabularies_hyper.json
+++ b/test/foundation/frame/2019-09/no_vocabularies_hyper.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/2019-09/one_level_applicators_with_identifiers.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/2019-09/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/2019-09/one_level_applicators_without_identifiers.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/propertyNames_with_nested_applicators.json
+++ b/test/foundation/frame/2019-09/propertyNames_with_nested_applicators.json
@@ -57,8 +57,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_anchor_false_with_id.json
+++ b/test/foundation/frame/2019-09/recursive_anchor_false_with_id.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_anchor_false_without_id.json
+++ b/test/foundation/frame/2019-09/recursive_anchor_false_without_id.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_anchor_on_relative_id.json
+++ b/test/foundation/frame/2019-09/recursive_anchor_on_relative_id.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_anchor_true_with_id.json
+++ b/test/foundation/frame/2019-09/recursive_anchor_true_with_id.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_anchor_true_without_id.json
+++ b/test/foundation/frame/2019-09/recursive_anchor_true_without_id.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_ref_multiple_recursive_anchor_true.json
+++ b/test/foundation/frame/2019-09/recursive_ref_multiple_recursive_anchor_true.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/nested": {

--- a/test/foundation/frame/2019-09/recursive_ref_nested_recursive_anchor_true.json
+++ b/test/foundation/frame/2019-09/recursive_ref_nested_recursive_anchor_true.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_ref_no_recursive_anchor.json
+++ b/test/foundation/frame/2019-09/recursive_ref_no_recursive_anchor.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_ref_no_recursive_anchor_anonymous.json
+++ b/test/foundation/frame/2019-09/recursive_ref_no_recursive_anchor_anonymous.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false_anonymous.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false_anonymous.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false_anonymous_nested.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_false_anonymous_nested.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true_anonymous.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true_anonymous.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true_anonymous_nested.json
+++ b/test/foundation/frame/2019-09/recursive_ref_recursive_anchor_true_anonymous_nested.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/ref_does_not_invalidate_sibling_subschemas_and_refs.json
+++ b/test/foundation/frame/2019-09/ref_does_not_invalidate_sibling_subschemas_and_refs.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/ref_from_def_to_sibling_def.json
+++ b/test/foundation/frame/2019-09/ref_from_def_to_sibling_def.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/ref_from_definitions.json
+++ b/test/foundation/frame/2019-09/ref_from_definitions.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/ref_metaschema.json
+++ b/test/foundation/frame/2019-09/ref_metaschema.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/ref_with_id.json
+++ b/test/foundation/frame/2019-09/ref_with_id.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2019-09/relative_base_uri_with_ref.json
+++ b/test/foundation/frame/2019-09/relative_base_uri_with_ref.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/2019-09/relative_base_uri_without_ref.json
+++ b/test/foundation/frame/2019-09/relative_base_uri_without_ref.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/2019-09/relative_id_leading_slash.json
+++ b/test/foundation/frame/2019-09/relative_id_leading_slash.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "/base": {

--- a/test/foundation/frame/2019-09/subschema_absolute_identifier.json
+++ b/test/foundation/frame/2019-09/subschema_absolute_identifier.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/2019-09/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/2019-09/top_level_id_empty_fragment_only.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2019-09/top_level_id_empty_string.json
+++ b/test/foundation/frame/2019-09/top_level_id_empty_string.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/allof_refs.json
+++ b/test/foundation/frame/2020-12/allof_refs.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/anchor_on_absolute_subid.json
+++ b/test/foundation/frame/2020-12/anchor_on_absolute_subid.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/2020-12/anchor_top_level.json
+++ b/test/foundation/frame/2020-12/anchor_top_level.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/anchor_with_invalid_type.json
+++ b/test/foundation/frame/2020-12/anchor_with_invalid_type.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/anchor_with_valid_leading_underscore.json
+++ b/test/foundation/frame/2020-12/anchor_with_valid_leading_underscore.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/2020-12/anonymous_with_nested_schema_resource.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/boolean_false_with_default_id.json
+++ b/test/foundation/frame/2020-12/boolean_false_with_default_id.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com/schema": {

--- a/test/foundation/frame/2020-12/boolean_true_with_default_id.json
+++ b/test/foundation/frame/2020-12/boolean_true_with_default_id.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com/schema": {

--- a/test/foundation/frame/2020-12/circular_orphan_refs.json
+++ b/test/foundation/frame/2020-12/circular_orphan_refs.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/circular_ref_through_defs.json
+++ b/test/foundation/frame/2020-12/circular_ref_through_defs.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/core_vocabularies_boolean_with_default.json
+++ b/test/foundation/frame/2020-12/core_vocabularies_boolean_with_default.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/cross_id_anonymous_nested.json
+++ b/test/foundation/frame/2020-12/cross_id_anonymous_nested.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/different_dynamic_and_refs_in_same_object.json
+++ b/test/foundation/frame/2020-12/different_dynamic_and_refs_in_same_object.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/dynamic_anchor_with_id.json
+++ b/test/foundation/frame/2020-12/dynamic_anchor_with_id.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/bar": {

--- a/test/foundation/frame/2020-12/dynamic_anchor_with_invalid_type.json
+++ b/test/foundation/frame/2020-12/dynamic_anchor_with_invalid_type.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_anchor_with_valid_leading_underscore.json
+++ b/test/foundation/frame/2020-12/dynamic_anchor_with_valid_leading_underscore.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/dynamic_anchor_without_id.json
+++ b/test/foundation/frame/2020-12/dynamic_anchor_without_id.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_multiple_targets.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_multiple_targets.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/2020-12/dynamic_ref_to_dynamic_anchor.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_to_dynamic_anchor.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_to_pointer.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_to_pointer.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_to_single_dynamic_anchor_external.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_to_single_dynamic_anchor_external.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_to_single_dynamic_anchor_standalone.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_to_single_dynamic_anchor_standalone.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_to_static_anchor.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_to_static_anchor.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/dynamic_ref_with_unreferenced_dynamic_anchor_target.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_with_unreferenced_dynamic_anchor_target.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/root": {

--- a/test/foundation/frame/2020-12/dynamic_ref_with_unreferenced_static_anchor_target.json
+++ b/test/foundation/frame/2020-12/dynamic_ref_with_unreferenced_static_anchor_target.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/root": {

--- a/test/foundation/frame/2020-12/dynamic_refs_with_id.json
+++ b/test/foundation/frame/2020-12/dynamic_refs_with_id.json
@@ -63,8 +63,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/dynamic_refs_with_no_id.json
+++ b/test/foundation/frame/2020-12/dynamic_refs_with_no_id.json
@@ -62,8 +62,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_anonymous.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_anonymous.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_arbitrary_container_key.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_arbitrary_container_key.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_chain.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_chain.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta-a": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_precedence.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_precedence.json
@@ -50,8 +50,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta-a": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_precedence_with_vocabularies.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_precedence_with_vocabularies.json
@@ -55,8 +55,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta-a": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_with_vocabularies.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_chain_with_vocabularies.json
@@ -49,8 +49,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta-a": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_default_dialect.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_default_dialect.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_definitions.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_definitions.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_definitions.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_definitions.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/foo": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_in_applicator.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_in_applicator.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/foo": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_non_canonical_dialect.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_non_canonical_dialect.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/foo": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_uses_root_metaschema.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_nested_uses_root_metaschema.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/foo": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_non_canonical_dialect_uri.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_non_canonical_dialect_uri.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_sibling_resource.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_sibling_resource.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_triple_nested.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_triple_nested.json
@@ -83,8 +83,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/a": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_with_id.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_with_id.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_without_vocabulary.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_without_vocabulary.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/embedded_custom_metaschema_without_vocabulary_core_only.json
+++ b/test/foundation/frame/2020-12/embedded_custom_metaschema_without_vocabulary_core_only.json
@@ -53,8 +53,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/foo": {

--- a/test/foundation/frame/2020-12/empty_schema.json
+++ b/test/foundation/frame/2020-12/empty_schema.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/2020-12/empty_schema_trailing_hash.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/explicit_argument_id_different.json
+++ b/test/foundation/frame/2020-12/explicit_argument_id_different.json
@@ -73,8 +73,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/2020-12/explicit_argument_id_same.json
+++ b/test/foundation/frame/2020-12/explicit_argument_id_same.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/has_references_through.json
+++ b/test/foundation/frame/2020-12/has_references_through.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/has_references_through_without_id.json
+++ b/test/foundation/frame/2020-12/has_references_through_without_id.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/has_references_to_2020_12.json
+++ b/test/foundation/frame/2020-12/has_references_to_2020_12.json
@@ -63,8 +63,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/hyper.json
+++ b/test/foundation/frame/2020-12/hyper.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/id_with_default_id.json
+++ b/test/foundation/frame/2020-12/id_with_default_id.json
@@ -62,8 +62,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/id_with_default_id_fallback_mode.json
+++ b/test/foundation/frame/2020-12/id_with_default_id_fallback_mode.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/idempotent_with_refs.json
+++ b/test/foundation/frame/2020-12/idempotent_with_refs.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/mode_references.json
+++ b/test/foundation/frame/2020-12/mode_references.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/2020-12/multiple_nested_cross_ref.json
+++ b/test/foundation/frame/2020-12/multiple_nested_cross_ref.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/common/test": {

--- a/test/foundation/frame/2020-12/multiple_nested_cross_ref_missing_target.json
+++ b/test/foundation/frame/2020-12/multiple_nested_cross_ref_missing_target.json
@@ -28,8 +28,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/common/test": {

--- a/test/foundation/frame/2020-12/multiple_nested_with_default_id.json
+++ b/test/foundation/frame/2020-12/multiple_nested_with_default_id.json
@@ -28,8 +28,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/common/test": {

--- a/test/foundation/frame/2020-12/nested_defs_unreferenced.json
+++ b/test/foundation/frame/2020-12/nested_defs_unreferenced.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/nested_id_empty_fragment_only.json
+++ b/test/foundation/frame/2020-12/nested_id_empty_fragment_only.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/nested_id_empty_string.json
+++ b/test/foundation/frame/2020-12/nested_id_empty_string.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/nested_schema_with_dynamic_anchor_and_refs.json
+++ b/test/foundation/frame/2020-12/nested_schema_with_dynamic_anchor_and_refs.json
@@ -51,8 +51,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/nested_schemas.json
+++ b/test/foundation/frame/2020-12/nested_schemas.json
@@ -53,8 +53,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/bar": {

--- a/test/foundation/frame/2020-12/no_id.json
+++ b/test/foundation/frame/2020-12/no_id.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/no_id_recursive_empty_pointer.json
+++ b/test/foundation/frame/2020-12/no_id_recursive_empty_pointer.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/no_id_with_default.json
+++ b/test/foundation/frame/2020-12/no_id_with_default.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/no_id_with_default_id_fallback_mode.json
+++ b/test/foundation/frame/2020-12/no_id_with_default_id_fallback_mode.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://other.com": {

--- a/test/foundation/frame/2020-12/no_refs.json
+++ b/test/foundation/frame/2020-12/no_refs.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/no_vocabularies.json
+++ b/test/foundation/frame/2020-12/no_vocabularies.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/no_vocabularies_hyper.json
+++ b/test/foundation/frame/2020-12/no_vocabularies_hyper.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/2020-12/one_level_applicators_with_identifiers.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/2020-12/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/2020-12/one_level_applicators_without_identifiers.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/orphan_chain_unreferenced.json
+++ b/test/foundation/frame/2020-12/orphan_chain_unreferenced.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/orphan_refs_reachable_target.json
+++ b/test/foundation/frame/2020-12/orphan_refs_reachable_target.json
@@ -47,8 +47,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/percent_encoded_hash_property_name_collision.json
+++ b/test/foundation/frame/2020-12/percent_encoded_hash_property_name_collision.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/percent_encoded_property_name_collision.json
+++ b/test/foundation/frame/2020-12/percent_encoded_property_name_collision.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/percent_in_property_name.json
+++ b/test/foundation/frame/2020-12/percent_in_property_name.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/properties_with_refs.json
+++ b/test/foundation/frame/2020-12/properties_with_refs.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/property_cross_ref.json
+++ b/test/foundation/frame/2020-12/property_cross_ref.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/property_named_defs.json
+++ b/test/foundation/frame/2020-12/property_named_defs.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/schema": {

--- a/test/foundation/frame/2020-12/property_ref_defs.json
+++ b/test/foundation/frame/2020-12/property_ref_defs.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/real_metaschema_takes_precedence_over_default.json
+++ b/test/foundation/frame/2020-12/real_metaschema_takes_precedence_over_default.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/ref_does_not_invalidate_sibling_subschemas_and_refs.json
+++ b/test/foundation/frame/2020-12/ref_does_not_invalidate_sibling_subschemas_and_refs.json
@@ -47,8 +47,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/ref_from_deep_nesting.json
+++ b/test/foundation/frame/2020-12/ref_from_deep_nesting.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/ref_from_definitions.json
+++ b/test/foundation/frame/2020-12/ref_from_definitions.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/ref_metaschema.json
+++ b/test/foundation/frame/2020-12/ref_metaschema.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/ref_to_dynamic_anchor.json
+++ b/test/foundation/frame/2020-12/ref_to_dynamic_anchor.json
@@ -43,8 +43,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/ref_to_orphan_chain.json
+++ b/test/foundation/frame/2020-12/ref_to_orphan_chain.json
@@ -50,8 +50,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/ref_to_percent_encoded_property_name.json
+++ b/test/foundation/frame/2020-12/ref_to_percent_encoded_property_name.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/ref_to_ref_chain.json
+++ b/test/foundation/frame/2020-12/ref_to_ref_chain.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/ref_with_id.json
+++ b/test/foundation/frame/2020-12/ref_with_id.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/ref_with_percent_encoded_colon_in_fragment.json
+++ b/test/foundation/frame/2020-12/ref_with_percent_encoded_colon_in_fragment.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/refs_with_id.json
+++ b/test/foundation/frame/2020-12/refs_with_id.json
@@ -54,8 +54,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/refs_with_no_id.json
+++ b/test/foundation/frame/2020-12/refs_with_no_id.json
@@ -53,8 +53,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/relative_base_uri_with_ref.json
+++ b/test/foundation/frame/2020-12/relative_base_uri_with_ref.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/2020-12/relative_base_uri_without_ref.json
+++ b/test/foundation/frame/2020-12/relative_base_uri_without_ref.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/2020-12/relative_base_with_relative_path_ref.json
+++ b/test/foundation/frame/2020-12/relative_base_with_relative_path_ref.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "foo/bar/baz": {

--- a/test/foundation/frame/2020-12/relative_id_with_absolute_default_id.json
+++ b/test/foundation/frame/2020-12/relative_id_with_absolute_default_id.json
@@ -60,8 +60,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/relative": {

--- a/test/foundation/frame/2020-12/remote_refs.json
+++ b/test/foundation/frame/2020-12/remote_refs.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/root_dynamic_anchor.json
+++ b/test/foundation/frame/2020-12/root_dynamic_anchor.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/root_mode_anonymous.json
+++ b/test/foundation/frame/2020-12/root_mode_anonymous.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/root_mode_multiple_containers_yield_nothing.json
+++ b/test/foundation/frame/2020-12/root_mode_multiple_containers_yield_nothing.json
@@ -23,8 +23,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/a": {

--- a/test/foundation/frame/2020-12/root_mode_single_container_with_default_id_fallback.json
+++ b/test/foundation/frame/2020-12/root_mode_single_container_with_default_id_fallback.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/2020-12/root_mode_single_container_with_identifier.json
+++ b/test/foundation/frame/2020-12/root_mode_single_container_with_identifier.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/2020-12/root_mode_vocabularies.json
+++ b/test/foundation/frame/2020-12/root_mode_vocabularies.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/root_mode_with_default_id_fallback.json
+++ b/test/foundation/frame/2020-12/root_mode_with_default_id_fallback.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://other.com": {

--- a/test/foundation/frame/2020-12/root_mode_with_identifier.json
+++ b/test/foundation/frame/2020-12/root_mode_with_identifier.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/2020-12/root_mode_zero_containers_yield_nothing.json
+++ b/test/foundation/frame/2020-12/root_mode_zero_containers_yield_nothing.json
@@ -12,8 +12,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {},
       "dynamic": {}

--- a/test/foundation/frame/2020-12/same_dynamic_and_refs_in_same_object.json
+++ b/test/foundation/frame/2020-12/same_dynamic_and_refs_in_same_object.json
@@ -44,8 +44,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/single_nested_anonymous_with_nested_resource.json
+++ b/test/foundation/frame/2020-12/single_nested_anonymous_with_nested_resource.json
@@ -45,8 +45,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/2020-12/single_nested_path_recursive_with_identifier.json
+++ b/test/foundation/frame/2020-12/single_nested_path_recursive_with_identifier.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/2020-12/single_nested_path_recursive_without_identifiers.json
+++ b/test/foundation/frame/2020-12/single_nested_path_recursive_without_identifiers.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/2020-12/standalone_with_embedded_external_refs.json
+++ b/test/foundation/frame/2020-12/standalone_with_embedded_external_refs.json
@@ -47,8 +47,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/standalone_with_external_refs.json
+++ b/test/foundation/frame/2020-12/standalone_with_external_refs.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/standalone_with_internal_refs.json
+++ b/test/foundation/frame/2020-12/standalone_with_internal_refs.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/standalone_without_refs.json
+++ b/test/foundation/frame/2020-12/standalone_without_refs.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/static_ref_to_dynamic_anchor.json
+++ b/test/foundation/frame/2020-12/static_ref_to_dynamic_anchor.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/subschema_absolute_identifier.json
+++ b/test/foundation/frame/2020-12/subschema_absolute_identifier.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/2020-12/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/2020-12/top_level_id_empty_fragment_only.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/top_level_id_empty_string.json
+++ b/test/foundation/frame/2020-12/top_level_id_empty_string.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/trailing_percent_in_property_name.json
+++ b/test/foundation/frame/2020-12/trailing_percent_in_property_name.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/unreferenced_dynamic_anchor.json
+++ b/test/foundation/frame/2020-12/unreferenced_dynamic_anchor.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/2020-12/uri_iterators.json
+++ b/test/foundation/frame/2020-12/uri_iterators.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/2020-12/vocabularies_embedded_custom_metaschema_precedence.json
+++ b/test/foundation/frame/2020-12/vocabularies_embedded_custom_metaschema_precedence.json
@@ -51,8 +51,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/2020-12/zero_paths.json
+++ b/test/foundation/frame/2020-12/zero_paths.json
@@ -13,8 +13,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {},
       "dynamic": {}

--- a/test/foundation/frame/draft0/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft0/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft0/empty_schema.json
+++ b/test/foundation/frame/draft0/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft0/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft0/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft0/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft0/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft0/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft0/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft0/hyperschema.json
+++ b/test/foundation/frame/draft0/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft0/ignore_vocabulary.json
+++ b/test/foundation/frame/draft0/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft0/one_hop.json
+++ b/test/foundation/frame/draft0/one_hop.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft0/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft0/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft0/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft0/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft0/ref_metaschema.json
+++ b/test/foundation/frame/draft0/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft0/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft0/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft1/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft1/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft1/empty_schema.json
+++ b/test/foundation/frame/draft1/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft1/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft1/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft1/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft1/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft1/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft1/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft1/hyperschema.json
+++ b/test/foundation/frame/draft1/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft1/ignore_vocabulary.json
+++ b/test/foundation/frame/draft1/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft1/one_hop.json
+++ b/test/foundation/frame/draft1/one_hop.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft1/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft1/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft1/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft1/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft1/ref_metaschema.json
+++ b/test/foundation/frame/draft1/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft1/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft1/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft2/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft2/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft2/empty_schema.json
+++ b/test/foundation/frame/draft2/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft2/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft2/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft2/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft2/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft2/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft2/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft2/hyperschema.json
+++ b/test/foundation/frame/draft2/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft2/ignore_vocabulary.json
+++ b/test/foundation/frame/draft2/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft2/one_hop.json
+++ b/test/foundation/frame/draft2/one_hop.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft2/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft2/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft2/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft2/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft2/ref_metaschema.json
+++ b/test/foundation/frame/draft2/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft2/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft2/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft3/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft3/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/definitions_subschemas.json
+++ b/test/foundation/frame/draft3/definitions_subschemas.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/embedded_custom_metaschema.json
+++ b/test/foundation/frame/draft3/embedded_custom_metaschema.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/draft3/empty_schema.json
+++ b/test/foundation/frame/draft3/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft3/empty_schema_trailing_slash.json
+++ b/test/foundation/frame/draft3/empty_schema_trailing_slash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft3/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft3/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft3/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft3/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft3/hyperschema.json
+++ b/test/foundation/frame/draft3/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/ignore_vocabulary.json
+++ b/test/foundation/frame/draft3/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/location_independent_identifier_anonymous.json
+++ b/test/foundation/frame/draft3/location_independent_identifier_anonymous.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/nested_relative_ref_with_id.json
+++ b/test/foundation/frame/draft3/nested_relative_ref_with_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft3/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft3/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft3/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft3/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft3/ref_into_definitions.json
+++ b/test/foundation/frame/draft3/ref_into_definitions.json
@@ -38,8 +38,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/ref_metaschema.json
+++ b/test/foundation/frame/draft3/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/ref_with_id.json
+++ b/test/foundation/frame/draft3/ref_with_id.json
@@ -30,8 +30,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/standalone_with_draft3_external_ref.json
+++ b/test/foundation/frame/draft3/standalone_with_draft3_external_ref.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft3/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft3/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft3/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/draft3/top_level_id_empty_fragment_only.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/top_level_id_empty_string.json
+++ b/test/foundation/frame/draft3/top_level_id_empty_string.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft3/top_level_relative_ref_with_id.json
+++ b/test/foundation/frame/draft3/top_level_relative_ref_with_id.json
@@ -30,8 +30,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft4/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/embedded_custom_metaschema.json
+++ b/test/foundation/frame/draft4/embedded_custom_metaschema.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/draft4/empty_schema.json
+++ b/test/foundation/frame/draft4/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft4/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft4/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft4/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft4/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft4/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft4/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft4/hyperschema.json
+++ b/test/foundation/frame/draft4/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/id_with_trailing_hash_and_ref_and_same_default_id.json
+++ b/test/foundation/frame/draft4/id_with_trailing_hash_and_ref_and_same_default_id.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft4/ignore_vocabulary.json
+++ b/test/foundation/frame/draft4/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/location_independent_identifier_anonymous.json
+++ b/test/foundation/frame/draft4/location_independent_identifier_anonymous.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/nested_relative_ref_with_id.json
+++ b/test/foundation/frame/draft4/nested_relative_ref_with_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft4/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft4/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft4/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft4/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft4/ref_invalidates_sibling_subschemas_and_refs.json
+++ b/test/foundation/frame/draft4/ref_invalidates_sibling_subschemas_and_refs.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/ref_metaschema.json
+++ b/test/foundation/frame/draft4/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/ref_with_id.json
+++ b/test/foundation/frame/draft4/ref_with_id.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/relative_base_uri_with_ref.json
+++ b/test/foundation/frame/draft4/relative_base_uri_with_ref.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft4/relative_base_uri_without_ref.json
+++ b/test/foundation/frame/draft4/relative_base_uri_without_ref.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft4/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft4/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft4/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/draft4/top_level_id_empty_fragment_only.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/top_level_id_empty_string.json
+++ b/test/foundation/frame/draft4/top_level_id_empty_string.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft4/top_level_relative_ref_with_id.json
+++ b/test/foundation/frame/draft4/top_level_relative_ref_with_id.json
@@ -30,8 +30,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft6/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/embedded_custom_metaschema.json
+++ b/test/foundation/frame/draft6/embedded_custom_metaschema.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/draft6/empty_schema.json
+++ b/test/foundation/frame/draft6/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft6/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft6/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft6/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft6/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft6/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft6/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft6/hyperschema.json
+++ b/test/foundation/frame/draft6/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/ignore_vocabulary.json
+++ b/test/foundation/frame/draft6/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/location_independent_identifier_anonymous.json
+++ b/test/foundation/frame/draft6/location_independent_identifier_anonymous.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/nested_relative_ref_with_id.json
+++ b/test/foundation/frame/draft6/nested_relative_ref_with_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft6/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft6/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft6/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft6/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft6/propertyNames_with_nested_applicators.json
+++ b/test/foundation/frame/draft6/propertyNames_with_nested_applicators.json
@@ -46,8 +46,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/ref_invalidates_sibling_subschemas_and_refs.json
+++ b/test/foundation/frame/draft6/ref_invalidates_sibling_subschemas_and_refs.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/ref_metaschema.json
+++ b/test/foundation/frame/draft6/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/ref_with_id.json
+++ b/test/foundation/frame/draft6/ref_with_id.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/relative_base_uri_with_ref.json
+++ b/test/foundation/frame/draft6/relative_base_uri_with_ref.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft6/relative_base_uri_without_ref.json
+++ b/test/foundation/frame/draft6/relative_base_uri_without_ref.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft6/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft6/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft6/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/draft6/top_level_id_empty_fragment_only.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/top_level_id_empty_string.json
+++ b/test/foundation/frame/draft6/top_level_id_empty_string.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft6/top_level_relative_ref_with_id.json
+++ b/test/foundation/frame/draft6/top_level_relative_ref_with_id.json
@@ -30,8 +30,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/anonymous_with_nested_schema_resource.json
+++ b/test/foundation/frame/draft7/anonymous_with_nested_schema_resource.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/embedded_custom_metaschema.json
+++ b/test/foundation/frame/draft7/embedded_custom_metaschema.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/draft7/empty_schema.json
+++ b/test/foundation/frame/draft7/empty_schema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft7/empty_schema_trailing_hash.json
+++ b/test/foundation/frame/draft7/empty_schema_trailing_hash.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft7/explicit_argument_id_different.json
+++ b/test/foundation/frame/draft7/explicit_argument_id_different.json
@@ -56,8 +56,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.example.com": {

--- a/test/foundation/frame/draft7/explicit_argument_id_same.json
+++ b/test/foundation/frame/draft7/explicit_argument_id_same.json
@@ -31,8 +31,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft7/hyperschema.json
+++ b/test/foundation/frame/draft7/hyperschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/ignore_vocabulary.json
+++ b/test/foundation/frame/draft7/ignore_vocabulary.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/location_independent_identifier_anonymous.json
+++ b/test/foundation/frame/draft7/location_independent_identifier_anonymous.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/nested_relative_ref_with_id.json
+++ b/test/foundation/frame/draft7/nested_relative_ref_with_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft7/one_level_applicators_with_identifiers.json
+++ b/test/foundation/frame/draft7/one_level_applicators_with_identifiers.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft7/one_level_applicators_without_identifiers.json
+++ b/test/foundation/frame/draft7/one_level_applicators_without_identifiers.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft7/override_inert_under_draft7_ref_siblings.json
+++ b/test/foundation/frame/draft7/override_inert_under_draft7_ref_siblings.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/override_vocabularies_without_dialect.json
+++ b/test/foundation/frame/draft7/override_vocabularies_without_dialect.json
@@ -28,8 +28,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/percent_encoded_definition_name_collision.json
+++ b/test/foundation/frame/draft7/percent_encoded_definition_name_collision.json
@@ -37,8 +37,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/schema": {

--- a/test/foundation/frame/draft7/ref_invalidates_sibling_subschemas_and_refs.json
+++ b/test/foundation/frame/draft7/ref_invalidates_sibling_subschemas_and_refs.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/ref_metaschema.json
+++ b/test/foundation/frame/draft7/ref_metaschema.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/ref_with_definitions.json
+++ b/test/foundation/frame/draft7/ref_with_definitions.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/ref_with_id.json
+++ b/test/foundation/frame/draft7/ref_with_id.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/ref_with_properties.json
+++ b/test/foundation/frame/draft7/ref_with_properties.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/relative_base_uri_with_ref.json
+++ b/test/foundation/frame/draft7/relative_base_uri_with_ref.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft7/relative_base_uri_without_ref.json
+++ b/test/foundation/frame/draft7/relative_base_uri_without_ref.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "common": {

--- a/test/foundation/frame/draft7/root_mode_draft7.json
+++ b/test/foundation/frame/draft7/root_mode_draft7.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/frame/draft7/root_mode_single_container_anonymous.json
+++ b/test/foundation/frame/draft7/root_mode_single_container_anonymous.json
@@ -34,8 +34,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "#/wrapper": {

--- a/test/foundation/frame/draft7/subschema_absolute_identifier.json
+++ b/test/foundation/frame/draft7/subschema_absolute_identifier.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/foo": {

--- a/test/foundation/frame/draft7/top_level_id_empty_fragment_only.json
+++ b/test/foundation/frame/draft7/top_level_id_empty_fragment_only.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/top_level_id_empty_string.json
+++ b/test/foundation/frame/draft7/top_level_id_empty_string.json
@@ -29,8 +29,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/draft7/top_level_relative_ref_with_id.json
+++ b/test/foundation/frame/draft7/top_level_relative_ref_with_id.json
@@ -30,8 +30,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_2020_12_to_2019_09_without_id.json
+++ b/test/foundation/frame/mixed/cross_2020_12_to_2019_09_without_id.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_2020_12_to_draft4_without_id.json
+++ b/test/foundation/frame/mixed/cross_2020_12_to_draft4_without_id.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_2020_12_to_draft6_without_id.json
+++ b/test/foundation/frame/mixed/cross_2020_12_to_draft6_without_id.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_2020_12_to_draft7_without_id.json
+++ b/test/foundation/frame/mixed/cross_2020_12_to_draft7_without_id.json
@@ -39,8 +39,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_draft7_to_2020_12_without_id.json
+++ b/test/foundation/frame/mixed/cross_draft7_to_2020_12_without_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/cross_draft7_to_draft4_without_id.json
+++ b/test/foundation/frame/mixed/cross_draft7_to_draft4_without_id.json
@@ -33,8 +33,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/nested_schemas_mixing_dialects.json
+++ b/test/foundation/frame/mixed/nested_schemas_mixing_dialects.json
@@ -47,8 +47,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://www.sourcemeta.com/bar": {

--- a/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft4.json
+++ b/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft4.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/main": {

--- a/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft7.json
+++ b/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft7.json
@@ -48,8 +48,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/embedded": {

--- a/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft7_with_allof.json
+++ b/test/foundation/frame/mixed/nested_schemas_sibling_ref_nested_2020_12_draft7_with_allof.json
@@ -52,8 +52,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/embedded": {

--- a/test/foundation/frame/mixed/override_destroys_resource_boundary_id_discarded.json
+++ b/test/foundation/frame/mixed/override_destroys_resource_boundary_id_discarded.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/parent": {

--- a/test/foundation/frame/mixed/override_hides_anchor_under_draft7.json
+++ b/test/foundation/frame/mixed/override_hides_anchor_under_draft7.json
@@ -41,8 +41,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/child": {

--- a/test/foundation/frame/mixed/override_induces_resource_boundary.json
+++ b/test/foundation/frame/mixed/override_induces_resource_boundary.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "http://example.com/child": {

--- a/test/foundation/frame/mixed/override_picks_dollarid_under_draft6.json
+++ b/test/foundation/frame/mixed/override_picks_dollarid_under_draft6.json
@@ -36,8 +36,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "http://example.com/parent": {

--- a/test/foundation/frame/mixed/override_vocabularies_from_draft4_to_2020_12.json
+++ b/test/foundation/frame/mixed/override_vocabularies_from_draft4_to_2020_12.json
@@ -35,8 +35,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "": {

--- a/test/foundation/frame/mixed/root_mode_embedded_custom_metaschema.json
+++ b/test/foundation/frame/mixed/root_mode_embedded_custom_metaschema.json
@@ -40,8 +40,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com/meta": {

--- a/test/foundation/frame/mixed/vocabularies_reference_survives_later_dialects.json
+++ b/test/foundation/frame/mixed/vocabularies_reference_survives_later_dialects.json
@@ -42,8 +42,8 @@
     },
     "references": []
   },
-  "references": {
-    "mode": "references",
+  "pointers": {
+    "mode": "pointers",
     "locations": {
       "static": {
         "https://example.com": {

--- a/test/foundation/framesuite.cc
+++ b/test/foundation/framesuite.cc
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <iostream>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -19,7 +20,7 @@ namespace {
 // otherwise go unnoticed, as the runner would simply not read it
 const std::vector<std::string> KNOWN_KEYS{
     "schema", "resolver",       "defaultDialect", "defaultId",    "paths",
-    "root",   "identifierMode", "references",     "reachability", "standalone"};
+    "root",   "identifierMode", "pointers",       "reachability", "standalone"};
 
 auto make_resolver(const sourcemeta::core::JSON &test)
     -> sourcemeta::blaze::SchemaResolver {
@@ -112,6 +113,39 @@ auto check_reachability(const sourcemeta::blaze::SchemaFrame &frame,
             check.at("reachable").to_boolean());
 }
 
+// Every mode below sourcemeta::blaze::SchemaFrame::Mode::Pointers reports a
+// pointer location only when a reference names it, so the expectations for
+// those follow from the one fixture we store rather than from near-duplicates
+// of it
+auto drop_pointer_locations(
+    sourcemeta::core::JSON &document,
+    const std::set<sourcemeta::core::JSON::String> &keep) -> void {
+  for (const auto &kind : {"static", "dynamic"}) {
+    auto &group{document.at("locations").at(kind)};
+    std::vector<sourcemeta::core::JSON::String> doomed;
+    for (const auto &location : group.as_object()) {
+      if (location.second.at("type").to_string() == "pointer" &&
+          !keep.contains(location.first)) {
+        doomed.push_back(location.first);
+      }
+    }
+
+    for (const auto &uri : doomed) {
+      group.erase(uri);
+    }
+  }
+}
+
+auto reference_destinations(const sourcemeta::core::JSON &document)
+    -> std::set<sourcemeta::core::JSON::String> {
+  std::set<sourcemeta::core::JSON::String> result;
+  for (const auto &reference : document.at("references").as_array()) {
+    result.insert(reference.at("destination").to_string());
+  }
+
+  return result;
+}
+
 auto run_frame_test(const sourcemeta::core::JSON &test) -> void {
   for (const auto &entry : test.as_object()) {
     EXPECT_TRUE(std::ranges::find(KNOWN_KEYS, entry.first) !=
@@ -120,7 +154,7 @@ auto run_frame_test(const sourcemeta::core::JSON &test) -> void {
 
   EXPECT_TRUE(test.defines("schema"));
   EXPECT_TRUE(test.defines("root"));
-  EXPECT_TRUE(test.defines("references"));
+  EXPECT_TRUE(test.defines("pointers"));
   EXPECT_TRUE(test.defines("standalone"));
 
   const auto resolver{make_resolver(test)};
@@ -139,6 +173,23 @@ auto run_frame_test(const sourcemeta::core::JSON &test) -> void {
       paths};
   EXPECT_EQ(root.to_json(resolver), test.at("root"));
 
+  const sourcemeta::blaze::SchemaFrame pointers{
+      sourcemeta::blaze::SchemaFrame::Mode::Pointers,
+      test.at("schema"),
+      sourcemeta::blaze::schema_walker,
+      resolver,
+      inputs.default_dialect,
+      inputs.default_id,
+      identifier_mode,
+      paths};
+  EXPECT_EQ(pointers.to_json(resolver), test.at("pointers"));
+
+  // References mode locates every schema, but of the remaining pointers only
+  // the ones that a reference actually names
+  auto expected_references{test.at("pointers")};
+  expected_references.assign("mode", sourcemeta::core::JSON{"references"});
+  drop_pointer_locations(expected_references,
+                         reference_destinations(expected_references));
   const sourcemeta::blaze::SchemaFrame references{
       sourcemeta::blaze::SchemaFrame::Mode::References,
       test.at("schema"),
@@ -148,7 +199,7 @@ auto run_frame_test(const sourcemeta::core::JSON &test) -> void {
       inputs.default_id,
       identifier_mode,
       paths};
-  EXPECT_EQ(references.to_json(resolver), test.at("references"));
+  EXPECT_EQ(references.to_json(resolver), expected_references);
 
   EXPECT_EQ(references.standalone(), test.at("standalone").to_boolean());
 
@@ -158,12 +209,12 @@ auto run_frame_test(const sourcemeta::core::JSON &test) -> void {
     }
   }
 
-  // Locations mode reports the same locations as References mode, only without
-  // resolving any reference, so we assert it as a relationship rather than
-  // storing a near-duplicate of the same data
-  auto expected_locations{test.at("references")};
-  expected_locations.assign("references", sourcemeta::core::JSON::make_array());
+  // Locations mode resolves no reference at all, so it keeps no pointer that
+  // only a reference would have justified either
+  auto expected_locations{test.at("pointers")};
   expected_locations.assign("mode", sourcemeta::core::JSON{"locations"});
+  expected_locations.assign("references", sourcemeta::core::JSON::make_array());
+  drop_pointer_locations(expected_locations, {});
   for (const auto &kind : {"static", "dynamic"}) {
     auto &group{expected_locations.at("locations").at(kind)};
     std::vector<sourcemeta::core::JSON::String> uris;

--- a/test/foundation/referencingsuite.cc
+++ b/test/foundation/referencingsuite.cc
@@ -88,7 +88,7 @@ auto run_referencing_test(const sourcemeta::core::JSON &suite,
       new_entries;
   for (const auto &[uri, schema] : registry) {
     sourcemeta::blaze::SchemaFrame frame{
-        sourcemeta::blaze::SchemaFrame::Mode::References,
+        sourcemeta::blaze::SchemaFrame::Mode::Pointers,
         schema.first,
         sourcemeta::blaze::schema_walker,
         sourcemeta::blaze::schema_resolver,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

