### PR TITLE
Stop framing remote schemas to check reference fragments

### DIFF
--- a/benchmark/bundle.cc
+++ b/benchmark/bundle.cc
@@ -3,6 +3,9 @@
 #include <sourcemeta/blaze/bundle.h>
 #include <sourcemeta/blaze/foundation.h>
 
+#include <map>    // std::map
+#include <string> // std::string, std::to_string
+
 static void Schema_Bundle_Meta_2020_12(benchmark::State &state) {
   for (auto _ : state) {
     state.PauseTiming();
@@ -18,4 +21,66 @@ static void Schema_Bundle_Meta_2020_12(benchmark::State &state) {
   }
 }
 
+// Bundling checks that the fragment of a reference names something the remote
+// actually has, once per distinct remote that a fragment reaches into
+static void Schema_Bundle_Many_Remotes_With_Fragments(benchmark::State &state) {
+  static constexpr auto REMOTES{10};
+  static constexpr auto SUBSCHEMAS{200};
+
+  auto body{sourcemeta::core::JSON::make_object()};
+  for (auto index = 0; index < SUBSCHEMAS; index++) {
+    auto subschema{sourcemeta::core::JSON::make_object()};
+    subschema.assign("type", sourcemeta::core::JSON{"string"});
+    subschema.assign("minLength", sourcemeta::core::JSON{index});
+    body.assign("property-" + std::to_string(index), std::move(subschema));
+  }
+
+  std::map<std::string, sourcemeta::core::JSON> registry;
+  auto properties{sourcemeta::core::JSON::make_object()};
+  for (auto index = 0; index < REMOTES; index++) {
+    const auto identifier{"https://example.com/remote-" +
+                          std::to_string(index)};
+    auto remote{sourcemeta::core::JSON::make_object()};
+    remote.assign(
+        "$schema",
+        sourcemeta::core::JSON{"https://json-schema.org/draft/2020-12/schema"});
+    remote.assign("$id", sourcemeta::core::JSON{identifier});
+    remote.assign("properties", body);
+    registry.emplace(identifier, std::move(remote));
+
+    auto property{sourcemeta::core::JSON::make_object()};
+    property.assign(
+        "$ref", sourcemeta::core::JSON{identifier + "#/properties/property-0"});
+    properties.assign("from-" + std::to_string(index), std::move(property));
+  }
+
+  auto document{sourcemeta::core::JSON::make_object()};
+  document.assign(
+      "$schema",
+      sourcemeta::core::JSON{"https://json-schema.org/draft/2020-12/schema"});
+  document.assign("$id", sourcemeta::core::JSON{"https://example.com/main"});
+  document.assign("properties", std::move(properties));
+
+  const auto resolver{[&registry](const std::string_view identifier)
+                          -> sourcemeta::blaze::SchemaResolverResult {
+    const auto match{registry.find(std::string{identifier})};
+    if (match != registry.cend()) {
+      return match->second;
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  }};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto schema{document};
+    state.ResumeTiming();
+    sourcemeta::blaze::bundle(
+        schema, sourcemeta::blaze::schema_walker, resolver,
+        sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+    benchmark::DoNotOptimize(schema);
+  }
+}
+
 BENCHMARK(Schema_Bundle_Meta_2020_12);
+BENCHMARK(Schema_Bundle_Many_Remotes_With_Fragments);

--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -420,18 +420,19 @@ auto bundle_schema(sourcemeta::core::JSON &root,
     // If the reference has a fragment, verify it exists in the remote
     // schema
     if (reference.fragment.has_value()) {
-      bool exists{false};
+      // A pointer fragment names a place of the document, and the document can
+      // answer for that on its own without paying to frame it
       const auto fragment_pointer{sourcemeta::core::fragment_to_pointer(
           sourcemeta::core::URI{reference.destination})};
-      if (fragment_pointer.has_value()) {
-        // A pointer fragment names a place of the document, and the document
-        // can answer for that on its own without paying to frame it
-        exists = sourcemeta::core::try_get(remote, fragment_pointer.value()) !=
-                 nullptr;
-      } else {
-        // An anchor is not a place of the document, so this one does need a
-        // frame, but only for the anchors of the remote rather than for every
-        // pointer of it
+      bool exists{fragment_pointer.has_value() &&
+                  sourcemeta::core::try_get(remote, fragment_pointer.value()) !=
+                      nullptr};
+
+      // An anchor is not a place of the document, and the drafts that spell
+      // identifiers as `id` let one look just like a pointer, so a miss above
+      // still has to ask the frame. Only the anchors of the remote matter
+      // here, rather than every pointer of it
+      if (!exists) {
         const sourcemeta::blaze::SchemaFrame remote_frame{
             sourcemeta::blaze::SchemaFrame::Mode::Locations,
             remote,

--- a/src/bundle/bundle.cc
+++ b/src/bundle/bundle.cc
@@ -420,19 +420,29 @@ auto bundle_schema(sourcemeta::core::JSON &root,
     // If the reference has a fragment, verify it exists in the remote
     // schema
     if (reference.fragment.has_value()) {
-      // TODO: The fact that we have to re-frame on each loop pass to check
-      // for this is probably insanely slow
-      // A fragment may name any place of the remote rather than only the
-      // schemas of it, so this is one of the few callers that needs framing
-      // to address every pointer
-      sourcemeta::blaze::SchemaFrame remote_frame{
-          sourcemeta::blaze::SchemaFrame::Mode::Pointers,
-          remote,
-          walker,
-          resolver,
-          default_dialect,
-          identifier};
-      if (!remote_frame.traverse(reference.destination).has_value()) {
+      bool exists{false};
+      const auto fragment_pointer{sourcemeta::core::fragment_to_pointer(
+          sourcemeta::core::URI{reference.destination})};
+      if (fragment_pointer.has_value()) {
+        // A pointer fragment names a place of the document, and the document
+        // can answer for that on its own without paying to frame it
+        exists = sourcemeta::core::try_get(remote, fragment_pointer.value()) !=
+                 nullptr;
+      } else {
+        // An anchor is not a place of the document, so this one does need a
+        // frame, but only for the anchors of the remote rather than for every
+        // pointer of it
+        const sourcemeta::blaze::SchemaFrame remote_frame{
+            sourcemeta::blaze::SchemaFrame::Mode::Locations,
+            remote,
+            walker,
+            resolver,
+            default_dialect,
+            identifier};
+        exists = remote_frame.traverse(reference.destination).has_value();
+      }
+
+      if (!exists) {
         throw sourcemeta::blaze::SchemaReferenceError(
             reference.destination, sourcemeta::core::to_pointer(pointer),
             "Could not resolve schema reference");

--- a/test/bundle/bundle_2020_12_test.cc
+++ b/test/bundle/bundle_2020_12_test.cc
@@ -430,6 +430,61 @@ TEST(schema_not_found) {
   }
 }
 
+TEST(pointer_fragment_found) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "https://example.com/baz-anchor#/$defs/baz" }
+    }
+  })JSON");
+
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "https://example.com/baz-anchor#/$defs/baz" }
+    },
+    "$defs": {
+      "https://example.com/baz-anchor": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.com/baz-anchor",
+        "$defs": {
+          "baz": {
+            "$anchor": "baz",
+            "type": "string"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(pointer_fragment_not_found) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": { "$ref": "https://example.com/baz-anchor#/$defs/qux" }
+    }
+  })JSON");
+
+  try {
+    sourcemeta::blaze::bundle(
+        document, sourcemeta::blaze::schema_walker, test_resolver,
+        sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
+    EXPECT_STREQ(error.what(), "Could not resolve schema reference");
+  }
+}
+
 TEST(anchor_not_found) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com",

--- a/test/bundle/bundle_draft4_test.cc
+++ b/test/bundle/bundle_draft4_test.cc
@@ -28,6 +28,14 @@ static auto test_resolver(std::string_view identifier)
       "id": "https://www.sourcemeta.com/test-3",
       "allOf": [ { "$ref": "test-1" } ]
     })JSON");
+  } else if (identifier == "https://www.sourcemeta.com/pointer-shaped-id") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://www.sourcemeta.com/pointer-shaped-id",
+      "definitions": {
+        "bar": { "id": "#/foo", "type": "string" }
+      }
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
     return sourcemeta::core::parse_json(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -742,6 +750,42 @@ TEST(metaschema_offline_idempotent) {
       "https://example.com/meta/2.json": {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "id": "https://example.com/meta/2.json"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(reference_to_pointer_shaped_legacy_identifier) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://www.sourcemeta.com/main",
+    "properties": {
+      "foo": { "$ref": "https://www.sourcemeta.com/pointer-shaped-id#/foo" }
+    }
+  })JSON");
+
+  // The remote has no `/foo` property. What the fragment names is the
+  // location independent identifier that `/definitions/bar` declares, which
+  // the drafts that spell identifiers as `id` let look just like a pointer
+  sourcemeta::blaze::bundle(
+      document, sourcemeta::blaze::schema_walker, test_resolver,
+      sourcemeta::blaze::BundleMode::NonOfficialMetaschemas);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://www.sourcemeta.com/main",
+    "properties": {
+      "foo": { "$ref": "https://www.sourcemeta.com/pointer-shaped-id#/foo" }
+    },
+    "definitions": {
+      "https://www.sourcemeta.com/pointer-shaped-id": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/pointer-shaped-id",
+        "definitions": {
+          "bar": { "id": "#/foo", "type": "string" }
+        }
       }
     }
   })JSON");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

