### PR TITLE
Stop framing remote schemas to check reference fragments when linting

### DIFF
--- a/benchmark/alterschema.cc
+++ b/benchmark/alterschema.cc
@@ -144,6 +144,13 @@ Alterschema_Check_Resolvable_External_Refs(benchmark::State &state) {
     properties.assign("from-" + std::to_string(index), std::move(property));
   }
 
+  // One reference that cannot resolve, so that the assertion below tells
+  // "every other remote resolved" apart from "the rule never ran at all"
+  auto unresolvable{sourcemeta::core::JSON::make_object()};
+  unresolvable.assign(
+      "$ref", sourcemeta::core::JSON{"https://example.com/missing#/nowhere"});
+  properties.assign("unresolvable", std::move(unresolvable));
+
   auto schema{sourcemeta::core::JSON::make_object()};
   schema.assign("$schema", sourcemeta::core::JSON{
                                "https://json-schema.org/draft/2020-12/schema"});
@@ -164,10 +171,20 @@ Alterschema_Check_Resolvable_External_Refs(benchmark::State &state) {
   sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
 
   for (auto _ : state) {
+    std::size_t trace_count{0};
     auto result =
         bundle.check(schema, sourcemeta::blaze::schema_walker, resolver,
-                     [](const auto &, const auto &, const auto &, const auto &,
-                        const auto &) {});
+                     [&trace_count](const auto &, const auto &name,
+                                    const auto &, const auto &, const auto &) {
+                       if (name == "invalid_external_ref") {
+                         trace_count++;
+                       }
+                     });
+    // Exactly the one reference that cannot resolve. Fewer would mean the rule
+    // stopped running, more would mean a remote or a fragment stopped
+    // resolving, and either way this would quietly turn into a measurement of
+    // the invalid reference path instead
+    assert(trace_count == 1);
     benchmark::DoNotOptimize(result);
   }
 }

--- a/benchmark/alterschema.cc
+++ b/benchmark/alterschema.cc
@@ -144,13 +144,6 @@ Alterschema_Check_Resolvable_External_Refs(benchmark::State &state) {
     properties.assign("from-" + std::to_string(index), std::move(property));
   }
 
-  // One reference that cannot resolve, so that the assertion below tells
-  // "every other remote resolved" apart from "the rule never ran at all"
-  auto unresolvable{sourcemeta::core::JSON::make_object()};
-  unresolvable.assign(
-      "$ref", sourcemeta::core::JSON{"https://example.com/missing#/nowhere"});
-  properties.assign("unresolvable", std::move(unresolvable));
-
   auto schema{sourcemeta::core::JSON::make_object()};
   schema.assign("$schema", sourcemeta::core::JSON{
                                "https://json-schema.org/draft/2020-12/schema"});
@@ -180,11 +173,9 @@ Alterschema_Check_Resolvable_External_Refs(benchmark::State &state) {
                          trace_count++;
                        }
                      });
-    // Exactly the one reference that cannot resolve. Fewer would mean the rule
-    // stopped running, more would mean a remote or a fragment stopped
-    // resolving, and either way this would quietly turn into a measurement of
-    // the invalid reference path instead
-    assert(trace_count == 1);
+    // Otherwise a remote or a fragment that stops resolving would quietly turn
+    // this into a measurement of the invalid reference path instead
+    assert(trace_count == 0);
     benchmark::DoNotOptimize(result);
   }
 }

--- a/benchmark/alterschema.cc
+++ b/benchmark/alterschema.cc
@@ -3,6 +3,8 @@
 #include <cassert>    // assert
 #include <cstddef>    // std::size_t
 #include <filesystem> // std::filesystem
+#include <map>        // std::map
+#include <string>     // std::string, std::to_string
 
 #include <sourcemeta/blaze/alterschema.h>
 #include <sourcemeta/blaze/compiler.h>
@@ -109,8 +111,70 @@ static void Alterschema_Check_Invalid_External_Refs(benchmark::State &state) {
   }
 }
 
+// Every reference here resolves, so the linter reaches the check that a
+// fragment names something the remote actually has
+static void
+Alterschema_Check_Resolvable_External_Refs(benchmark::State &state) {
+  static constexpr auto REMOTES{20};
+  static constexpr auto SUBSCHEMAS{200};
+
+  auto body{sourcemeta::core::JSON::make_object()};
+  for (auto index = 0; index < SUBSCHEMAS; index++) {
+    auto subschema{sourcemeta::core::JSON::make_object()};
+    subschema.assign("type", sourcemeta::core::JSON{"string"});
+    body.assign("property-" + std::to_string(index), std::move(subschema));
+  }
+
+  std::map<std::string, sourcemeta::core::JSON> registry;
+  auto properties{sourcemeta::core::JSON::make_object()};
+  for (auto index = 0; index < REMOTES; index++) {
+    const auto identifier{"https://example.com/remote-" +
+                          std::to_string(index)};
+    auto remote{sourcemeta::core::JSON::make_object()};
+    remote.assign(
+        "$schema",
+        sourcemeta::core::JSON{"https://json-schema.org/draft/2020-12/schema"});
+    remote.assign("$id", sourcemeta::core::JSON{identifier});
+    remote.assign("properties", body);
+    registry.emplace(identifier, std::move(remote));
+
+    auto property{sourcemeta::core::JSON::make_object()};
+    property.assign(
+        "$ref", sourcemeta::core::JSON{identifier + "#/properties/property-0"});
+    properties.assign("from-" + std::to_string(index), std::move(property));
+  }
+
+  auto schema{sourcemeta::core::JSON::make_object()};
+  schema.assign("$schema", sourcemeta::core::JSON{
+                               "https://json-schema.org/draft/2020-12/schema"});
+  schema.assign("$id", sourcemeta::core::JSON{"https://example.com/main"});
+  schema.assign("properties", std::move(properties));
+
+  const auto resolver{[&registry](const std::string_view identifier)
+                          -> sourcemeta::blaze::SchemaResolverResult {
+    const auto match{registry.find(std::string{identifier})};
+    if (match != registry.cend()) {
+      return match->second;
+    }
+
+    return sourcemeta::blaze::schema_resolver(identifier);
+  }};
+
+  sourcemeta::blaze::SchemaTransformer bundle;
+  sourcemeta::blaze::add(bundle, sourcemeta::blaze::AlterSchemaMode::Linter);
+
+  for (auto _ : state) {
+    auto result =
+        bundle.check(schema, sourcemeta::blaze::schema_walker, resolver,
+                     [](const auto &, const auto &, const auto &, const auto &,
+                        const auto &) {});
+    benchmark::DoNotOptimize(result);
+  }
+}
+
 BENCHMARK(Alterschema_Check_Readibility_ISO_Language_Set_3);
 BENCHMARK(Alterschema_Check_Readibility_OMC);
 BENCHMARK(Alterschema_Check_Readibility_KrakenD);
 BENCHMARK(Alterschema_Apply_Readibility_KrakenD);
 BENCHMARK(Alterschema_Check_Invalid_External_Refs);
+BENCHMARK(Alterschema_Check_Resolvable_External_Refs);

--- a/src/alterschema/alterschema.cc
+++ b/src/alterschema/alterschema.cc
@@ -102,7 +102,7 @@ auto WALK_UP(const JSON &root, const SchemaFrame &frame,
     const auto &parent_pointer{current_parent.value()};
     const auto relative_pointer{current_pointer.resolve_from(parent_pointer)};
     assert(!relative_pointer.empty() && relative_pointer.at(0).is_property());
-    const auto parent{frame.traverse(frame.uri(parent_pointer).value().get())};
+    const auto parent{frame.traverse(parent_pointer)};
     assert(parent.has_value());
     const auto &parent_vocabularies{
         frame.vocabularies(parent.value().get(), resolver)};

--- a/src/alterschema/linter/invalid_external_ref.h
+++ b/src/alterschema/linter/invalid_external_ref.h
@@ -104,12 +104,24 @@ private:
                       const JSON::String &base_key, const SchemaWalker &walker,
                       const SchemaResolver &resolver,
                       const SchemaFrame::Location &location) const -> bool {
+    // A pointer fragment names a place of the document, and the document can
+    // answer for that on its own without paying to frame it
+    const auto fragment_pointer{sourcemeta::core::fragment_to_pointer(
+        sourcemeta::core::URI{reference_entry.destination})};
+    if (fragment_pointer.has_value() &&
+        sourcemeta::core::try_get(remote.value(), fragment_pointer.value()) !=
+            nullptr) {
+      return false;
+    }
+
+    // An anchor is not a place of the document, and the drafts that spell
+    // identifiers as `id` let one look just like a pointer, so a miss above
+    // still has to ask the frame. Only the anchors of the remote matter here,
+    // rather than every pointer of it
     auto frame_iterator{this->frame_cache_.find(base_key)};
     if (frame_iterator == this->frame_cache_.end()) {
-      // A reference may name any place of the remote rather than only the
-      // schemas of it, so this needs framing to address every pointer
       auto remote_frame{std::make_unique<SchemaFrame>(
-          SchemaFrame::Mode::Pointers, remote.value(), walker, resolver,
+          SchemaFrame::Mode::Locations, remote.value(), walker, resolver,
           location.dialect, base_key)};
       frame_iterator =
           this->frame_cache_.emplace(base_key, std::move(remote_frame)).first;

--- a/src/canonicalizer/helpers.h
+++ b/src/canonicalizer/helpers.h
@@ -117,7 +117,7 @@ auto WALK_UP(const sourcemeta::core::JSON &root, const SchemaFrame &frame,
     const auto &parent_pointer{current_parent.value()};
     const auto relative_pointer{current_pointer.resolve_from(parent_pointer)};
     assert(!relative_pointer.empty() && relative_pointer.at(0).is_property());
-    const auto parent{frame.traverse(frame.uri(parent_pointer).value().get())};
+    const auto parent{frame.traverse(parent_pointer)};
     assert(parent.has_value());
     const auto &parent_vocabularies{
         frame.vocabularies(parent.value().get(), resolver)};

--- a/src/canonicalizer/rules/type_inherit_in_place.h
+++ b/src/canonicalizer/rules/type_inherit_in_place.h
@@ -77,7 +77,7 @@ public:
       if (walk_relative.empty() || !walk_relative.at(0).is_property()) {
         break;
       }
-      const auto walk_entry{frame.traverse(frame.uri(wp).value().get())};
+      const auto walk_entry{frame.traverse(wp)};
       if (!walk_entry.has_value()) {
         break;
       }

--- a/src/canonicalizer/rules/type_union_implicit.h
+++ b/src/canonicalizer/rules/type_union_implicit.h
@@ -86,7 +86,7 @@ private:
       if (walk_relative.empty() || !walk_relative.at(0).is_property()) {
         break;
       }
-      const auto walk_entry{frame.traverse(frame.uri(wp).value().get())};
+      const auto walk_entry{frame.traverse(wp)};
       if (!walk_entry.has_value()) {
         break;
       }

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -723,6 +723,10 @@ struct SchemaFrame::Cache {
       canonical_pointer_;
   std::unordered_map<const Location *, const sourcemeta::core::WeakPointer *>
       location_to_canonical_;
+  // The key that a location is stored under, so that reporting the URI of a
+  // pointer does not have to search the locations for the entry it already has
+  std::unordered_map<const Location *, const sourcemeta::core::JSON::String *>
+      location_to_uri_;
   bool standalone_{false};
   bool has_dynamic_references_{false};
 
@@ -1867,10 +1871,9 @@ auto SchemaFrame::uri(const sourcemeta::core::WeakPointer &pointer) const
   }
 
   if (best != nullptr) {
-    for (const auto &entry : this->locations_) {
-      if (&entry.second == best) {
-        return entry.first.second;
-      }
+    const auto match{this->cache_->location_to_uri_.find(best)};
+    if (match != this->cache_->location_to_uri_.cend()) {
+      return *(match->second);
     }
   }
 
@@ -2011,9 +2014,11 @@ auto SchemaFrame::Cache::populate_pointer_to_location(const SchemaFrame &frame)
   }
 
   this->pointer_to_location_.reserve(frame.locations_.size());
+  this->location_to_uri_.reserve(frame.locations_.size());
   for (const auto &entry : frame.locations_) {
     this->pointer_to_location_[std::cref(entry.second.pointer)].push_back(
         &entry.second);
+    this->location_to_uri_.emplace(&entry.second, &entry.first.second);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

