### PR TITLE
Stop crashing and emitting invalid code on malformed and unsatisfiable schemas

### DIFF
--- a/src/canonicalizer/canonicalize.cc
+++ b/src/canonicalizer/canonicalize.cc
@@ -366,6 +366,7 @@ auto apply(const std::vector<Rule> &rules, sourcemeta::core::JSON &schema,
 #include "rules/unnecessary_allof_ref_wrapper_draft.h"
 #include "rules/unnecessary_extends_ref_wrapper.h"
 #include "rules/unsatisfiable_drop_validation.h"
+#include "rules/unsatisfiable_empty_enum.h"
 #include "rules/unsatisfiable_exclusive_equal_bounds.h"
 #include "rules/unsatisfiable_in_place_applicator_type.h"
 #include "rules/unsatisfiable_type_and_enum.h"
@@ -380,7 +381,7 @@ auto canonicalize(sourcemeta::core::JSON &schema,
                   const std::string_view default_dialect,
                   const std::string_view default_id) -> void {
   std::vector<Rule> rules;
-  rules.reserve(125);
+  rules.reserve(128);
   rules.push_back(make_rule<ExclusiveMinimumBooleanIntegerFold>());
   rules.push_back(make_rule<ExclusiveMaximumBooleanIntegerFold>());
   rules.push_back(make_rule<UnsatisfiableExclusiveEqualBounds>());
@@ -477,6 +478,7 @@ auto canonicalize(sourcemeta::core::JSON &schema,
   rules.push_back(make_rule<DropAllOfEmptySchemas>());
   rules.push_back(make_rule<DropExtendsEmptySchemas>());
   rules.push_back(make_rule<EmptyObjectAsTrue>());
+  rules.push_back(make_rule<UnsatisfiableEmptyEnum>());
   rules.push_back(make_rule<UnsatisfiableTypeAndEnum>());
   rules.push_back(make_rule<EnumFilterByType>());
   rules.push_back(make_rule<TypeUnionToSchemas>());

--- a/src/canonicalizer/helpers.h
+++ b/src/canonicalizer/helpers.h
@@ -70,6 +70,23 @@ inline auto UNSATISFIABLE_SCHEMA(const SchemaVocabularies &vocabularies)
     return result;
   }
 
+  // Draft 2 and earlier have no boolean schemas either, and their negation
+  // keyword takes type names rather than schemas, so the name to rule out is
+  // the wildcard that every instance answers to
+  if (vocabularies.contains_any(
+          {SchemaVocabularies::Known::JSON_Schema_Draft_0,
+           SchemaVocabularies::Known::JSON_Schema_Draft_0_Hyper,
+           SchemaVocabularies::Known::JSON_Schema_Draft_1,
+           SchemaVocabularies::Known::JSON_Schema_Draft_1_Hyper,
+           SchemaVocabularies::Known::JSON_Schema_Draft_2,
+           SchemaVocabularies::Known::JSON_Schema_Draft_2_Hyper})) {
+    auto types{sourcemeta::core::JSON::make_array()};
+    types.push_back(sourcemeta::core::JSON{"any"});
+    auto result{sourcemeta::core::JSON::make_object()};
+    result.assign("disallow", std::move(types));
+    return result;
+  }
+
   return sourcemeta::core::JSON{false};
 }
 

--- a/src/canonicalizer/rules/unsatisfiable_empty_enum.h
+++ b/src/canonicalizer/rules/unsatisfiable_empty_enum.h
@@ -1,0 +1,40 @@
+class UnsatisfiableEmptyEnum final : public SchemaTransformRule {
+public:
+  using reframe_after_transform = std::false_type;
+  UnsatisfiableEmptyEnum() : SchemaTransformRule{"unsatisfiable_empty_enum"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::blaze::SchemaVocabularies &vocabularies,
+            const sourcemeta::blaze::SchemaFrame &,
+            const sourcemeta::blaze::SchemaFrame::Location &,
+            const sourcemeta::blaze::SchemaWalker &,
+            const sourcemeta::blaze::SchemaResolver &) const -> bool override {
+    ONLY_CONTINUE_IF(
+        vocabularies.contains_any(
+            {SchemaVocabularies::Known::JSON_Schema_Draft_0,
+             SchemaVocabularies::Known::JSON_Schema_Draft_1,
+             SchemaVocabularies::Known::JSON_Schema_Draft_2,
+             SchemaVocabularies::Known::JSON_Schema_Draft_3,
+             SchemaVocabularies::Known::JSON_Schema_Draft_4,
+             SchemaVocabularies::Known::JSON_Schema_Draft_6,
+             SchemaVocabularies::Known::JSON_Schema_Draft_7,
+             SchemaVocabularies::Known::JSON_Schema_2019_09_Validation,
+             SchemaVocabularies::Known::JSON_Schema_2020_12_Validation}) &&
+        schema.is_object());
+
+    const auto *enum_value{schema.try_at("enum")};
+    ONLY_CONTINUE_IF(enum_value && enum_value->is_array() &&
+                     enum_value->empty());
+    this->unsatisfiable_ = UNSATISFIABLE_SCHEMA(vocabularies);
+    return true;
+  }
+
+  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+    INTO_UNSATISFIABLE(schema, this->unsatisfiable_);
+  }
+
+private:
+  mutable sourcemeta::core::JSON unsatisfiable_{false};
+};

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -48,17 +48,20 @@ auto is_validation_subschema(
                                  resolver);
 }
 
-auto effective_dialect(const sourcemeta::core::JSON &schema,
-                       const std::string_view fallback)
+// The dialect a schema declares, falling back to the given default. Unlike the
+// equivalent helper in bundling, this one hands back a copy rather than a view,
+// as canonicalisation goes on to rewrite the very document it reads from
+auto declared_dialect(const sourcemeta::core::JSON &schema,
+                      const std::string_view default_dialect)
     -> sourcemeta::core::JSON::String {
-  if (schema.is_object()) {
-    const auto *dialect{schema.try_at("$schema")};
-    if (dialect && dialect->is_string()) {
-      return dialect->to_string();
-    }
+  if (!schema.is_object()) {
+    return sourcemeta::core::JSON::String{default_dialect};
   }
 
-  return sourcemeta::core::JSON::String{fallback};
+  const auto *dialect{schema.try_at("$schema")};
+  return (dialect != nullptr && dialect->is_string())
+             ? dialect->to_string()
+             : sourcemeta::core::JSON::String{default_dialect};
 }
 
 } // anonymous namespace
@@ -86,7 +89,7 @@ auto compile(const sourcemeta::core::JSON &input,
   // Canonicalisation can collapse an unsatisfiable schema into a boolean,
   // which has no room for the dialect the document declares, so hold on to
   // that dialect for the framing that follows
-  const auto dialect{effective_dialect(schema, default_dialect)};
+  const auto dialect{declared_dialect(schema, default_dialect)};
 
   sourcemeta::blaze::canonicalize(schema, walker, resolver, dialect,
                                   default_id);

--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -48,6 +48,19 @@ auto is_validation_subschema(
                                  resolver);
 }
 
+auto effective_dialect(const sourcemeta::core::JSON &schema,
+                       const std::string_view fallback)
+    -> sourcemeta::core::JSON::String {
+  if (schema.is_object()) {
+    const auto *dialect{schema.try_at("$schema")};
+    if (dialect && dialect->is_string()) {
+      return dialect->to_string();
+    }
+  }
+
+  return sourcemeta::core::JSON::String{fallback};
+}
+
 } // anonymous namespace
 
 namespace sourcemeta::blaze {
@@ -70,7 +83,12 @@ auto compile(const sourcemeta::core::JSON &input,
   // (2) Canonicalize the schema for easier analysis
   // --------------------------------------------------------------------------
 
-  sourcemeta::blaze::canonicalize(schema, walker, resolver, default_dialect,
+  // Canonicalisation can collapse an unsatisfiable schema into a boolean,
+  // which has no room for the dialect the document declares, so hold on to
+  // that dialect for the framing that follows
+  const auto dialect{effective_dialect(schema, default_dialect)};
+
+  sourcemeta::blaze::canonicalize(schema, walker, resolver, dialect,
                                   default_id);
 
   // --------------------------------------------------------------------------
@@ -82,7 +100,7 @@ auto compile(const sourcemeta::core::JSON &input,
       schema,
       walker,
       resolver,
-      default_dialect,
+      dialect,
       default_id};
 
   // --------------------------------------------------------------------------

--- a/src/codegen/codegen_default_compiler.h
+++ b/src/codegen/codegen_default_compiler.h
@@ -129,8 +129,14 @@ auto handle_object(const sourcemeta::core::JSON &schema,
             "Expected an array of string values");
       }
 
-      // Guaranteed by canonicalisation
-      assert(properties.defines(item.to_string()));
+      // Canonicalisation adds a required property that the schema leaves
+      // unconstrained, but it cannot do so for an object that forbids it
+      if (!properties.defines(item.to_string())) {
+        throw CodegenUnexpectedSchemaError(
+            schema, location.pointer,
+            "This schema requires a property that it does not allow");
+      }
+
       required_set.insert(item.to_string());
     }
   }

--- a/src/codegen/codegen_default_compiler.h
+++ b/src/codegen/codegen_default_compiler.h
@@ -109,11 +109,26 @@ auto handle_object(const sourcemeta::core::JSON &schema,
   assert(subschema.defines("properties"));
 
   const auto &properties{subschema.at("properties")};
+  if (!properties.is_object()) {
+    throw CodegenUnsupportedKeywordValueError(
+        schema, location.pointer, "properties", "Expected an object value");
+  }
 
   std::unordered_set<std::string_view> required_set;
   if (subschema.defines("required")) {
     const auto &required{subschema.at("required")};
+    if (!required.is_array()) {
+      throw CodegenUnsupportedKeywordValueError(
+          schema, location.pointer, "required", "Expected an array value");
+    }
+
     for (const auto &item : required.as_array()) {
+      if (!item.is_string()) {
+        throw CodegenUnsupportedKeywordValueError(
+            schema, location.pointer, "required",
+            "Expected an array of string values");
+      }
+
       // Guaranteed by canonicalisation
       assert(properties.defines(item.to_string()));
       required_set.insert(item.to_string());
@@ -160,6 +175,12 @@ auto handle_object(const sourcemeta::core::JSON &schema,
   std::vector<CodegenIRObjectPatternProperty> pattern;
   if (subschema.defines("patternProperties")) {
     const auto &pattern_props{subschema.at("patternProperties")};
+    if (!pattern_props.is_object()) {
+      throw CodegenUnsupportedKeywordValueError(schema, location.pointer,
+                                                "patternProperties",
+                                                "Expected an object value");
+    }
+
     for (const auto &entry : pattern_props.as_object()) {
       auto pattern_pointer{sourcemeta::core::to_pointer(location.pointer)};
       pattern_pointer.push_back("patternProperties");
@@ -249,7 +270,10 @@ auto handle_array(const sourcemeta::core::JSON &schema,
           SchemaVocabularies::Known::JSON_Schema_2020_12_Applicator) &&
       subschema.defines("prefixItems")) {
     const auto &prefix_items{subschema.at("prefixItems")};
-    assert(prefix_items.is_array());
+    if (!prefix_items.is_array()) {
+      throw CodegenUnsupportedKeywordValueError(
+          schema, location.pointer, "prefixItems", "Expected an array value");
+    }
 
     std::vector<CodegenIRType> tuple_items;
     for (std::size_t index = 0; index < prefix_items.size(); ++index) {
@@ -364,6 +388,10 @@ auto handle_enum(const sourcemeta::core::JSON &schema,
                            "description", "default", "deprecated", "readOnly",
                            "writeOnly", "examples"});
   const auto &enum_json{subschema.at("enum")};
+  if (!enum_json.is_array()) {
+    throw CodegenUnsupportedKeywordValueError(schema, location.pointer, "enum",
+                                              "Expected an array value");
+  }
 
   // Boolean and null special cases
   if (enum_json.size() == 1 && enum_json.at(0).is_null()) {
@@ -404,7 +432,12 @@ auto handle_anyof(const sourcemeta::core::JSON &schema,
        "writeOnly", "examples", "unevaluatedProperties", "unevaluatedItems"});
 
   const auto &any_of{subschema.at("anyOf")};
-  assert(any_of.is_array());
+  if (!any_of.is_array() || any_of.empty()) {
+    throw CodegenUnsupportedKeywordValueError(
+        schema, location.pointer, "anyOf", "Expected a non-empty array value");
+  }
+
+  // Canonicalisation merges a single branch into its parent
   assert(any_of.size() >= 2);
 
   std::vector<CodegenIRType> branches;
@@ -441,7 +474,12 @@ auto handle_oneof(const sourcemeta::core::JSON &schema,
        "writeOnly", "examples", "unevaluatedProperties", "unevaluatedItems"});
 
   const auto &one_of{subschema.at("oneOf")};
-  assert(one_of.is_array());
+  if (!one_of.is_array() || one_of.empty()) {
+    throw CodegenUnsupportedKeywordValueError(
+        schema, location.pointer, "oneOf", "Expected a non-empty array value");
+  }
+
+  // Canonicalisation merges a single branch into its parent
   assert(one_of.size() >= 2);
 
   std::vector<CodegenIRType> branches;
@@ -585,7 +623,10 @@ auto handle_allof(const sourcemeta::core::JSON &schema,
        "writeOnly", "examples", "unevaluatedProperties", "unevaluatedItems"});
 
   const auto &all_of{subschema.at("allOf")};
-  assert(all_of.is_array());
+  if (!all_of.is_array() || all_of.empty()) {
+    throw CodegenUnsupportedKeywordValueError(
+        schema, location.pointer, "allOf", "Expected a non-empty array value");
+  }
 
   if (all_of.size() == 1) {
     auto target_pointer{sourcemeta::core::to_pointer(location.pointer)};

--- a/test/canonicalizer/canonicalizer_2019_09_test.cc
+++ b/test/canonicalizer/canonicalizer_2019_09_test.cc
@@ -1858,3 +1858,14 @@ TEST(type_array_drops_unknown_name) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON(false)JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_2020_12_test.cc
+++ b/test/canonicalizer/canonicalizer_2020_12_test.cc
@@ -5023,3 +5023,14 @@ TEST(enum_split_in_anyof_branch_referenced) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON(false)JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft0_test.cc
+++ b/test/canonicalizer/canonicalizer_draft0_test.cc
@@ -105,3 +105,17 @@ TEST(type_union_schema_variant) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "disallow": [ "any" ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft1_test.cc
+++ b/test/canonicalizer/canonicalizer_draft1_test.cc
@@ -413,3 +413,17 @@ TEST(type_union_schema_variant) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "disallow": [ "any" ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft2_test.cc
+++ b/test/canonicalizer/canonicalizer_draft2_test.cc
@@ -374,3 +374,17 @@ TEST(type_union_schema_variant) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "disallow": [ "any" ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft3_test.cc
+++ b/test/canonicalizer/canonicalizer_draft3_test.cc
@@ -4255,3 +4255,17 @@ TEST(enum_split_deeply_nested_referenced_d3) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "disallow": [ {} ]
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft4_test.cc
+++ b/test/canonicalizer/canonicalizer_draft4_test.cc
@@ -5156,3 +5156,17 @@ TEST(type_array_drops_unknown_name) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "not": {}
+  })JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft6_test.cc
+++ b/test/canonicalizer/canonicalizer_draft6_test.cc
@@ -4481,3 +4481,14 @@ TEST(type_array_drops_unknown_name) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON(false)JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/canonicalizer/canonicalizer_draft7_test.cc
+++ b/test/canonicalizer/canonicalizer_draft7_test.cc
@@ -6248,3 +6248,14 @@ TEST(type_array_drops_unknown_name) {
 
   CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
 }
+
+TEST(unsatisfiable_empty_enum) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "enum": []
+  })JSON");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON(false)JSON");
+
+  CANONICALIZE_AND_VALIDATE(document, expected, compiled_metaschema());
+}

--- a/test/codegen/codegen_2020_12_test.cc
+++ b/test/codegen/codegen_2020_12_test.cc
@@ -1752,3 +1752,62 @@ TEST(embedded_custom_metaschema) {
   EXPECT_IR_SCALAR(result, 1, String, "");
   EXPECT_SYMBOL(std::get<CodegenIRScalar>(result.at(1)).symbol);
 }
+
+TEST(enum_empty) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": []
+  })JSON")};
+
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  using namespace sourcemeta::blaze;
+
+  EXPECT_EQ(result.size(), 1);
+
+  EXPECT_IR_IMPOSSIBLE(result, 0, "");
+  EXPECT_SYMBOL(std::get<CodegenIRImpossible>(result.at(0)).symbol);
+}
+
+TEST(enum_empty_nested) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "enum": [] } }
+  })JSON")};
+
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  using namespace sourcemeta::blaze;
+
+  EXPECT_EQ(result.size(), 2);
+
+  EXPECT_IR_IMPOSSIBLE(result, 0, "/properties/foo");
+  EXPECT_SYMBOL(std::get<CodegenIRImpossible>(result.at(0)).symbol, "foo");
+
+  EXPECT_TRUE(std::holds_alternative<CodegenIRObject>(result.at(1)));
+  EXPECT_AS_STRING(std::get<CodegenIRObject>(result.at(1)).pointer, "");
+}
+
+TEST(unsatisfiable_type_and_enum) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "string",
+    "enum": [ 1 ]
+  })JSON")};
+
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  using namespace sourcemeta::blaze;
+
+  EXPECT_EQ(result.size(), 1);
+
+  EXPECT_IR_IMPOSSIBLE(result, 0, "");
+  EXPECT_SYMBOL(std::get<CodegenIRImpossible>(result.at(0)).symbol);
+}

--- a/test/codegen/codegen_test.cc
+++ b/test/codegen/codegen_test.cc
@@ -5,6 +5,8 @@
 
 #include <sstream> // std::ostringstream
 
+#include "codegen_test_utils.h"
+
 TEST(unsupported_dialect_draft3) {
   const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
@@ -88,4 +90,293 @@ TEST(unknown_type_value_ignored) {
                           "  Schema_3 |\n"
                           "  Schema_4 |\n"
                           "  Schema_5;\n");
+}
+
+TEST(unsupported_keyword_value_error_properties_not_object) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "properties": true
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an object value");
+    EXPECT_EQ(error.keyword(), "properties");
+    EXPECT_AS_STRING(error.pointer(), "/anyOf/2");
+  }
+}
+
+TEST(unsupported_keyword_value_error_properties_not_object_nested) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "type": "object", "properties": true } }
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an object value");
+    EXPECT_EQ(error.keyword(), "properties");
+    EXPECT_AS_STRING(error.pointer(), "/properties/foo");
+  }
+}
+
+TEST(unsupported_keyword_value_error_required_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "type": "string" } },
+    "required": true
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an array value");
+    EXPECT_EQ(error.keyword(), "required");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_required_item_not_string) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "type": "string" } },
+    "required": [ 5 ]
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an array of string values");
+    EXPECT_EQ(error.keyword(), "required");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_pattern_properties_not_object) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "patternProperties": true
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an object value");
+    EXPECT_EQ(error.keyword(), "patternProperties");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_prefix_items_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+    "prefixItems": true
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an array value");
+    EXPECT_EQ(error.keyword(), "prefixItems");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_enum_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": 5
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected an array value");
+    EXPECT_EQ(error.keyword(), "enum");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_any_of_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "anyOf": true
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "anyOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_any_of_empty) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "anyOf": []
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "anyOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_one_of_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": 5
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "oneOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_one_of_empty) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": []
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "oneOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_all_of_not_array) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": { "type": "string" }
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "allOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_value_error_all_of_empty) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": []
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (
+      const sourcemeta::blaze::CodegenUnsupportedKeywordValueError &error) {
+    EXPECT_STREQ(error.what(), "Expected a non-empty array value");
+    EXPECT_EQ(error.keyword(), "allOf");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unsupported_keyword_error_draft4_empty_enum) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "enum": []
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (const sourcemeta::blaze::CodegenUnsupportedKeywordError &error) {
+    EXPECT_STREQ(error.what(), "Unsupported keyword in subschema");
+    EXPECT_EQ(error.keyword(), "not");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(draft7_empty_enum) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "enum": []
+  })JSON")};
+
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  std::ostringstream output;
+  sourcemeta::blaze::generate<sourcemeta::blaze::TypeScript>(output, result);
+
+  EXPECT_EQ(output.str(), "export type Schema = never;\n");
 }

--- a/test/codegen/codegen_test.cc
+++ b/test/codegen/codegen_test.cc
@@ -380,3 +380,76 @@ TEST(draft7_empty_enum) {
 
   EXPECT_EQ(output.str(), "export type Schema = never;\n");
 }
+
+TEST(unexpected_schema_error_required_property_not_allowed) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "type": "string" } },
+    "required": [ "bar" ],
+    "additionalProperties": false
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (const sourcemeta::blaze::CodegenUnexpectedSchemaError &error) {
+    EXPECT_STREQ(error.what(),
+                 "This schema requires a property that it does not allow");
+    EXPECT_AS_STRING(error.pointer(), "");
+  }
+}
+
+TEST(unexpected_schema_error_required_property_not_allowed_nested) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "foo": {
+        "type": "object",
+        "properties": { "qux": { "type": "string" } },
+        "required": [ "bar" ],
+        "additionalProperties": false
+      }
+    }
+  })JSON")};
+
+  try {
+    sourcemeta::blaze::compile(schema, sourcemeta::blaze::schema_walker,
+                               sourcemeta::blaze::schema_resolver,
+                               sourcemeta::blaze::default_compiler);
+    FAIL();
+  } catch (const sourcemeta::blaze::CodegenUnexpectedSchemaError &error) {
+    EXPECT_STREQ(error.what(),
+                 "This schema requires a property that it does not allow");
+    EXPECT_AS_STRING(error.pointer(), "/properties/foo");
+  }
+}
+
+TEST(required_property_not_in_properties_open) {
+  const sourcemeta::core::JSON schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": { "foo": { "type": "string" } },
+    "required": [ "bar" ]
+  })JSON")};
+
+  const auto result{sourcemeta::blaze::compile(
+      schema, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver, sourcemeta::blaze::default_compiler)};
+
+  std::ostringstream output;
+  sourcemeta::blaze::generate<sourcemeta::blaze::TypeScript>(output, result);
+
+  EXPECT_EQ(output.str(), "export type SchemaFoo = string;\n"
+                          "\n"
+                          "export type SchemaBar = unknown;\n"
+                          "\n"
+                          "export interface Schema {\n"
+                          "  \"foo\"?: SchemaFoo;\n"
+                          "  \"bar\": SchemaBar;\n"
+                          "  [key: string]: unknown | undefined;\n"
+                          "}\n");
+}

--- a/test/codegen/e2e/typescript/2020-12/empty_enum/expected.d.ts
+++ b/test/codegen/e2e/typescript/2020-12/empty_enum/expected.d.ts
@@ -1,0 +1,10 @@
+export type EmptyEnumName = string;
+
+export type EmptyEnumImpossible = never;
+
+export type EmptyEnumAdditionalProperties = never;
+
+export interface EmptyEnum {
+  "name": EmptyEnumName;
+  "impossible"?: EmptyEnumImpossible;
+}

--- a/test/codegen/e2e/typescript/2020-12/empty_enum/options.json
+++ b/test/codegen/e2e/typescript/2020-12/empty_enum/options.json
@@ -1,0 +1,3 @@
+{
+  "defaultPrefix": "EmptyEnum"
+}

--- a/test/codegen/e2e/typescript/2020-12/empty_enum/schema.json
+++ b/test/codegen/e2e/typescript/2020-12/empty_enum/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/empty-enum",
+  "type": "object",
+  "required": [ "name" ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "impossible": {
+      "enum": []
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/codegen/e2e/typescript/2020-12/empty_enum/test.ts
+++ b/test/codegen/e2e/typescript/2020-12/empty_enum/test.ts
@@ -1,0 +1,47 @@
+import { EmptyEnum, EmptyEnumImpossible } from "./expected";
+
+
+// Valid: the property an empty enumeration describes can only be left out
+const valid: EmptyEnum = {
+  name: "foo"
+};
+
+// Valid: an absent property reads as undefined
+const absent: EmptyEnum = {
+  name: "foo",
+  impossible: undefined
+};
+
+// Invalid: no value at all satisfies an empty enumeration
+const withString: EmptyEnum = {
+  name: "foo",
+  // @ts-expect-error - nothing can be assigned to never
+  impossible: "bar"
+};
+
+const withNull: EmptyEnum = {
+  name: "foo",
+  // @ts-expect-error - nothing can be assigned to never
+  impossible: null
+};
+
+const withNumber: EmptyEnum = {
+  name: "foo",
+  // @ts-expect-error - nothing can be assigned to never
+  impossible: 0
+};
+
+// Invalid: name is required
+// @ts-expect-error - name is required
+const missingName: EmptyEnum = {};
+
+// Invalid: extra property (additionalProperties: false)
+const extraProperty: EmptyEnum = {
+  name: "foo",
+  // @ts-expect-error - extra property not allowed
+  extra: "not allowed"
+};
+
+// Test the standalone impossible type
+// @ts-expect-error - nothing can be assigned to never
+const impossible: EmptyEnumImpossible = "anything";

--- a/test/evaluator/tracesuite_canonical.cc
+++ b/test/evaluator/tracesuite_canonical.cc
@@ -16,6 +16,18 @@
 #include <utility>    // std::move
 
 namespace {
+auto declared_dialect(const sourcemeta::core::JSON &schema)
+    -> sourcemeta::core::JSON::String {
+  if (!schema.is_object()) {
+    return {};
+  }
+
+  const auto *dialect{schema.try_at("$schema")};
+  return (dialect != nullptr && dialect->is_string())
+             ? dialect->to_string()
+             : sourcemeta::core::JSON::String{};
+}
+
 auto run_canonicalize_test(const sourcemeta::core::JSON &data,
                            const sourcemeta::blaze::Mode mode) -> void {
   auto schema{data.at("schema")};
@@ -25,9 +37,7 @@ auto run_canonicalize_test(const sourcemeta::core::JSON &data,
   // Canonicalisation can collapse an unsatisfiable schema into a boolean,
   // which has no room for the dialect the document declares, so hold on to
   // that dialect for the compilation that follows
-  const auto dialect{schema.is_object() && schema.defines("$schema")
-                         ? schema.at("$schema").to_string()
-                         : sourcemeta::core::JSON::String{}};
+  const auto dialect{declared_dialect(schema)};
 
   sourcemeta::blaze::canonicalize(schema, sourcemeta::blaze::schema_walker,
                                   sourcemeta::blaze::schema_resolver, dialect);

--- a/test/evaluator/tracesuite_canonical.cc
+++ b/test/evaluator/tracesuite_canonical.cc
@@ -22,13 +22,20 @@ auto run_canonicalize_test(const sourcemeta::core::JSON &data,
   const auto &instance{data.at("instance")};
   const bool expected_valid{data.at("valid").to_boolean()};
 
+  // Canonicalisation can collapse an unsatisfiable schema into a boolean,
+  // which has no room for the dialect the document declares, so hold on to
+  // that dialect for the compilation that follows
+  const auto dialect{schema.is_object() && schema.defines("$schema")
+                         ? schema.at("$schema").to_string()
+                         : sourcemeta::core::JSON::String{}};
+
   sourcemeta::blaze::canonicalize(schema, sourcemeta::blaze::schema_walker,
-                                  sourcemeta::blaze::schema_resolver);
+                                  sourcemeta::blaze::schema_resolver, dialect);
 
   const auto compiled_schema{sourcemeta::blaze::compile(
       schema, sourcemeta::blaze::schema_walker,
       sourcemeta::blaze::schema_resolver,
-      sourcemeta::blaze::default_schema_compiler, mode)};
+      sourcemeta::blaze::default_schema_compiler, mode, dialect)};
   __ASSERT_TEMPLATE_JSON_SERIALISATION(compiled_schema);
 
   sourcemeta::blaze::Evaluator evaluator;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

