### PR TITLE
Support bounding how many locations `SchemaFrame` may register

### DIFF
--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::ranges::all_of, std::ranges::contains, std::ranges::sort
 #include <cassert>       // assert
+#include <cstdint>       // std::uint64_t
 #include <deque>         // std::deque
 #include <functional>    // std::hash, std::less, std::reference_wrapper
 #include <map>           // std::map
@@ -388,7 +389,8 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
 }
 
 template <typename Locations>
-auto store(Locations &frame, const sourcemeta::blaze::SchemaReferenceType type,
+auto store(Locations &frame, const std::uint64_t max_locations,
+           const sourcemeta::blaze::SchemaReferenceType type,
            const sourcemeta::blaze::SchemaFrame::LocationType entry_type,
            sourcemeta::core::JSON::String uri, const std::string_view base,
            const sourcemeta::core::WeakPointer &pointer_from_root,
@@ -419,6 +421,15 @@ auto store(Locations &frame, const sourcemeta::blaze::SchemaReferenceType type,
           sourcemeta::core::to_pointer(iterator->second.pointer));
     }
     throw_already_exists(iterator->first.second);
+  }
+
+  // Charging for a location that got registered rather than for an attempt to
+  // register one keeps this limit and what the frame reports holding in the
+  // same units. Charging after the fact also leaves a schema that is invalid
+  // on its own terms reporting why it is invalid, rather than reporting the
+  // limit in place of it
+  if (frame.size() > max_locations) {
+    throw sourcemeta::blaze::SchemaFrameLimitError(max_locations);
   }
 
   if (inserted && iterator->first.second == base) {
@@ -752,7 +763,8 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
                          const std::string_view default_dialect,
                          const std::string_view default_id,
                          const SchemaFrame::IdentifierMode identifier_mode,
-                         const SchemaFrame::Paths &paths)
+                         const SchemaFrame::Paths &paths,
+                         const std::uint64_t max_locations)
     : mode_{mode}, cache_{std::make_unique<Cache>()} {
   // This mode reports on a single schema. Framing a wrapper that holds more
   // than one has no single schema to report on, so there is nothing to analyse
@@ -850,7 +862,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
       // Borrow `this->root_` as the base for now, as the location that owns
       // that URI does not exist yet. We re-point this entry at that location
       // key once the traversal below is done
-      store(this->locations_, SchemaReferenceType::Static,
+      store(this->locations_, max_locations, SchemaReferenceType::Static,
             SchemaFrame::LocationType::Resource, default_id_canonical,
             this->root_, path, path.size(), root_dialect,
             root_base_dialect.value(), std::nullopt, false, false);
@@ -886,7 +898,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
 
       const auto location_uri{
           root_id.value_or(sourcemeta::core::JSON::String{})};
-      store(this->locations_, SchemaReferenceType::Static,
+      store(this->locations_, max_locations, SchemaReferenceType::Static,
             root_id.has_value() ? SchemaFrame::LocationType::Resource
                                 : SchemaFrame::LocationType::Subschema,
             location_uri, location_uri, path, path.size(), root_dialect,
@@ -1036,7 +1048,8 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
                 maybe_match == this->locations_.cend()) {
               assert(entry.common.base_dialect.has_value());
 
-              store(this->locations_, SchemaReferenceType::Static,
+              store(this->locations_, max_locations,
+                    SchemaReferenceType::Static,
                     SchemaFrame::LocationType::Resource, new_id, new_id,
                     common_pointer_weak, common_pointer_weak.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
@@ -1106,7 +1119,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
           const auto relative_anchor_uri{anchor_uri.recompose()};
 
           if (type == AnchorType::Static || type == AnchorType::All) {
-            store(this->locations_, SchemaReferenceType::Static,
+            store(this->locations_, max_locations, SchemaReferenceType::Static,
                   SchemaFrame::LocationType::Anchor, relative_anchor_uri, "",
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
@@ -1115,7 +1128,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
           }
 
           if (type == AnchorType::Dynamic || type == AnchorType::All) {
-            store(this->locations_, SchemaReferenceType::Dynamic,
+            store(this->locations_, max_locations, SchemaReferenceType::Dynamic,
                   SchemaFrame::LocationType::Anchor, relative_anchor_uri, "",
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
@@ -1128,7 +1141,8 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
             if (type == AnchorType::Dynamic &&
                 entry.common.vocabularies.contains(
                     SchemaVocabularies::Known::JSON_Schema_2020_12_Core)) {
-              store(this->locations_, SchemaReferenceType::Static,
+              store(this->locations_, max_locations,
+                    SchemaReferenceType::Static,
                     SchemaFrame::LocationType::Anchor, relative_anchor_uri, "",
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
@@ -1158,7 +1172,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
                     : std::string_view{base_string}};
 
             if (type == AnchorType::Static || type == AnchorType::All) {
-              store(this->locations_,
+              store(this->locations_, max_locations,
                     sourcemeta::blaze::SchemaReferenceType::Static,
                     SchemaFrame::LocationType::Anchor, anchor_uri, base_view,
                     common_pointer_weak, bases.second.size(),
@@ -1168,7 +1182,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
             }
 
             if (type == AnchorType::Dynamic || type == AnchorType::All) {
-              store(this->locations_,
+              store(this->locations_, max_locations,
                     sourcemeta::blaze::SchemaReferenceType::Dynamic,
                     SchemaFrame::LocationType::Anchor, anchor_uri, base_view,
                     common_pointer_weak, bases.second.size(),
@@ -1179,7 +1193,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
               if (type == AnchorType::Dynamic &&
                   entry.common.vocabularies.contains(
                       SchemaVocabularies::Known::JSON_Schema_2020_12_Core)) {
-                store(this->locations_,
+                store(this->locations_, max_locations,
                       sourcemeta::blaze::SchemaReferenceType::Static,
                       SchemaFrame::LocationType::Anchor, anchor_uri, base_view,
                       common_pointer_weak, bases.second.size(),
@@ -1287,7 +1301,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
           }
 
           if (is_subschema) {
-            store(this->locations_, SchemaReferenceType::Static,
+            store(this->locations_, max_locations, SchemaReferenceType::Static,
                   SchemaFrame::LocationType::Subschema, std::move(result),
                   base_view, pointer_weak, nearest_base_depth,
                   dialect_for_pointer, base_dialect_for_pointer,
@@ -1306,7 +1320,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
             const bool parent_orphan{parent_subschema_it != subschemas.cend() &&
                                      parent_subschema_it->second.orphan};
 
-            store(this->locations_, SchemaReferenceType::Static,
+            store(this->locations_, max_locations, SchemaReferenceType::Static,
                   SchemaFrame::LocationType::Pointer, std::move(result),
                   base_view, pointer_weak, nearest_base_depth,
                   dialect_for_pointer, base_dialect_for_pointer, parent_pointer,
@@ -1552,7 +1566,7 @@ SchemaFrame::SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
                             ? combined.dialect_match->second
                             : base_entry->second.pointer};
       const auto parent_subschema{subschemas.find(parent)};
-      store(this->locations_, SchemaReferenceType::Static,
+      store(this->locations_, max_locations, SchemaReferenceType::Static,
             SchemaFrame::LocationType::Pointer,
             sourcemeta::core::JSON::String{reference.second.destination},
             nearest_base_view, pointer_weak, nearest_base_depth,

--- a/src/foundation/frame.cc
+++ b/src/foundation/frame.cc
@@ -425,9 +425,10 @@ auto store(Locations &frame, const std::uint64_t max_locations,
 
   // Charging for a location that got registered rather than for an attempt to
   // register one keeps this limit and what the frame reports holding in the
-  // same units. Charging after the fact also leaves a schema that is invalid
-  // on its own terms reporting why it is invalid, rather than reporting the
-  // limit in place of it
+  // same units. It also settles what an insertion that both collides and runs
+  // past the limit reports, as a schema that is invalid on its own terms is
+  // worth saying so about. A limit that runs out before framing ever reaches
+  // the collision still reports the limit
   if (frame.size() > max_locations) {
     throw sourcemeta::blaze::SchemaFrameLimitError(max_locations);
   }

--- a/src/foundation/include/sourcemeta/blaze/foundation_error.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_error.h
@@ -7,6 +7,7 @@
 
 #include <sourcemeta/core/jsonpointer.h>
 
+#include <cstdint>     // std::uint64_t
 #include <exception>   // std::exception
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -219,6 +220,27 @@ public:
 private:
   std::string identifier_;
   const char *message_;
+};
+
+/// @ingroup foundation
+/// An error that represents a schema that needs more frame locations than the
+/// caller was willing to spend on analysing it
+class SOURCEMETA_BLAZE_FOUNDATION_EXPORT SchemaFrameLimitError
+    : public std::exception {
+public:
+  SchemaFrameLimitError(const std::uint64_t limit) : limit_{limit} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "The schema exceeds the maximum number of frame locations";
+  }
+
+  /// The maximum number of locations that framing was allowed to register
+  [[nodiscard]] auto limit() const noexcept -> std::uint64_t {
+    return this->limit_;
+  }
+
+private:
+  std::uint64_t limit_;
 };
 
 /// @ingroup foundation

--- a/src/foundation/include/sourcemeta/blaze/foundation_frame.h
+++ b/src/foundation/include/sourcemeta/blaze/foundation_frame.h
@@ -17,6 +17,7 @@
 #include <cstdint>    // std::uint8_t
 #include <deque>      // std::deque
 #include <functional> // std::reference_wrapper
+#include <limits>     // std::numeric_limits
 #include <map>        // std::map
 #include <memory>     // std::unique_ptr
 #include <optional>   // std::optional
@@ -150,12 +151,24 @@ public:
   /// `default_dialect`, as a location that has no dialect of its own reports
   /// the default back as a view into what the caller passed. In contrast,
   /// `default_id` is copied, so it does not need to outlive this call
-  SchemaFrame(const Mode mode, const sourcemeta::core::JSON &root,
-              const SchemaWalker &walker, const SchemaResolver &resolver,
-              std::string_view default_dialect = "",
-              std::string_view default_id = "",
-              IdentifierMode identifier_mode = IdentifierMode::Additional,
-              const Paths &paths = {sourcemeta::core::EMPTY_WEAK_POINTER});
+  ///
+  /// Framing a schema that declares nested identifiers registers a location
+  /// per enclosing base, so what an untrusted schema costs to analyse grows
+  /// faster than the schema itself does. Pass `max_locations` to bound that,
+  /// throwing sourcemeta::blaze::SchemaFrameLimitError rather than analysing
+  /// past it. What the limit buys depends on the mode, as
+  /// sourcemeta::blaze::SchemaFrame::Mode::Pointers locates every JSON Pointer
+  /// of the document rather than only the schemas of it. Note this bounds what
+  /// framing registers rather than every last thing it does, as walking the
+  /// document costs something even where nothing comes of it. Bounding the
+  /// size of the document remains the caller's to do
+  SchemaFrame(
+      const Mode mode, const sourcemeta::core::JSON &root,
+      const SchemaWalker &walker, const SchemaResolver &resolver,
+      std::string_view default_dialect = "", std::string_view default_id = "",
+      IdentifierMode identifier_mode = IdentifierMode::Additional,
+      const Paths &paths = {sourcemeta::core::EMPTY_WEAK_POINTER},
+      std::uint64_t max_locations = std::numeric_limits<std::uint64_t>::max());
 
   /// Get a specific reference entry by type and pointer
   [[nodiscard]] auto

--- a/test/foundation/CMakeLists.txt
+++ b/test/foundation/CMakeLists.txt
@@ -15,7 +15,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT blaze NAME foundation
     foundation_error_test.cc
     foundation_resolver_test.cc
     foundation_frame_test.cc
-    foundation_frame_error_test.cc)
+    foundation_frame_error_test.cc
+    foundation_frame_limit_test.cc)
 
 target_link_libraries(sourcemeta_blaze_foundation_unit
   PRIVATE sourcemeta::core::json)

--- a/test/foundation/foundation_frame_limit_test.cc
+++ b/test/foundation/foundation_frame_limit_test.cc
@@ -1,0 +1,184 @@
+#include <sourcemeta/core/test.h>
+
+#include <sourcemeta/blaze/foundation.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonpointer.h>
+
+#include <cstdint>
+#include <limits>
+
+static const sourcemeta::core::JSON DOCUMENT =
+    sourcemeta::core::parse_json(R"JSON({
+  "$id": "https://www.sourcemeta.com/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": { "type": "string" },
+    "bar": { "type": "number" }
+  }
+})JSON");
+
+TEST(references_location_count) {
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, DOCUMENT,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+  EXPECT_EQ(frame.location_count(), 3);
+}
+
+TEST(limit_equal_to_location_count_succeeds) {
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References,
+      DOCUMENT,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      "",
+      "",
+      sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+      {sourcemeta::core::EMPTY_WEAK_POINTER},
+      3};
+  EXPECT_EQ(frame.location_count(), 3);
+}
+
+TEST(limit_one_below_location_count_throws) {
+  try {
+    [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::References,
+        DOCUMENT,
+        sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        "",
+        "",
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+        {sourcemeta::core::EMPTY_WEAK_POINTER},
+        2};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameLimitError &error) {
+    EXPECT_STREQ(error.what(),
+                 "The schema exceeds the maximum number of frame locations");
+    EXPECT_EQ(error.limit(), 2);
+  }
+}
+
+TEST(limit_of_zero_throws) {
+  try {
+    [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::References,
+        DOCUMENT,
+        sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        "",
+        "",
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+        {sourcemeta::core::EMPTY_WEAK_POINTER},
+        0};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameLimitError &error) {
+    EXPECT_EQ(error.limit(), 0);
+  }
+}
+
+TEST(default_limit_is_unbounded) {
+  const sourcemeta::blaze::SchemaFrame frame{
+      sourcemeta::blaze::SchemaFrame::Mode::Pointers, DOCUMENT,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+  EXPECT_EQ(frame.location_count(), 8);
+}
+
+// A location per JSON Pointer rather than per schema costs more of the same
+// limit, which is what tells the caller these modes are not interchangeable
+TEST(pointers_mode_consumes_more_than_references_mode) {
+  const sourcemeta::blaze::SchemaFrame references{
+      sourcemeta::blaze::SchemaFrame::Mode::References,
+      DOCUMENT,
+      sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      "",
+      "",
+      sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+      {sourcemeta::core::EMPTY_WEAK_POINTER},
+      3};
+  EXPECT_EQ(references.location_count(), 3);
+
+  try {
+    [[maybe_unused]] const sourcemeta::blaze::SchemaFrame pointers{
+        sourcemeta::blaze::SchemaFrame::Mode::Pointers,
+        DOCUMENT,
+        sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        "",
+        "",
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+        {sourcemeta::core::EMPTY_WEAK_POINTER},
+        3};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameLimitError &error) {
+    EXPECT_EQ(error.limit(), 3);
+  }
+}
+
+// A schema that is invalid on its own terms reports why it is invalid whether
+// or not a limit is in play, so setting one never rewrites an existing error
+TEST(limit_does_not_mask_an_identifier_collision) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "items": { "id": "schema" }
+  })JSON");
+
+  try {
+    [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::References,
+        document,
+        sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        "",
+        "",
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+        {sourcemeta::core::EMPTY_WEAK_POINTER},
+        std::numeric_limits<std::uint64_t>::max()};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameError &error) {
+    EXPECT_STREQ(error.what(), "Schema identifier already exists");
+  }
+}
+
+// Every subschema is registered once per base that encloses it, so nesting
+// identifiers costs more locations than the same shape without them. That is
+// what makes framing grow faster than the schema does, and what the limit
+// exists to catch
+TEST(nested_identifiers_cost_more_than_the_same_shape_without_them) {
+  const sourcemeta::core::JSON anonymous = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "properties": {
+          "bar": { "properties": { "baz": { "type": "string" } } }
+        }
+      }
+    }
+  })JSON");
+
+  const sourcemeta::core::JSON identified =
+      sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "$id": "nested",
+        "properties": {
+          "bar": { "$id": "deep", "properties": { "baz": { "type": "string" } } }
+        }
+      }
+    }
+  })JSON");
+
+  const sourcemeta::blaze::SchemaFrame anonymous_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, anonymous,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+  EXPECT_EQ(anonymous_frame.location_count(), 4);
+
+  const sourcemeta::blaze::SchemaFrame identified_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, identified,
+      sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
+  EXPECT_EQ(identified_frame.location_count(), 9);
+}

--- a/test/foundation/foundation_frame_limit_test.cc
+++ b/test/foundation/foundation_frame_limit_test.cc
@@ -115,29 +115,51 @@ TEST(pointers_mode_consumes_more_than_references_mode) {
   }
 }
 
-// A schema that is invalid on its own terms reports why it is invalid whether
-// or not a limit is in play, so setting one never rewrites an existing error
-TEST(limit_does_not_mask_an_identifier_collision) {
-  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "id": "https://www.sourcemeta.com/schema",
-    "$schema": "http://json-schema.org/draft-00/schema#",
-    "items": { "id": "schema" }
-  })JSON");
+static const sourcemeta::core::JSON COLLIDING_DOCUMENT =
+    sourcemeta::core::parse_json(R"JSON({
+  "id": "https://www.sourcemeta.com/schema",
+  "$schema": "http://json-schema.org/draft-00/schema#",
+  "items": { "id": "schema" }
+})JSON");
 
+// The insertion that collides is checked for collision before it is charged,
+// so a schema that is invalid on its own terms is still reported as invalid
+// rather than as too expensive
+TEST(collision_wins_when_the_same_insertion_also_exceeds_the_limit) {
   try {
     [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame{
         sourcemeta::blaze::SchemaFrame::Mode::References,
-        document,
+        COLLIDING_DOCUMENT,
         sourcemeta::blaze::schema_walker,
         sourcemeta::blaze::schema_resolver,
         "",
         "",
         sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
         {sourcemeta::core::EMPTY_WEAK_POINTER},
-        std::numeric_limits<std::uint64_t>::max()};
+        1};
     FAIL();
   } catch (const sourcemeta::blaze::SchemaFrameError &error) {
     EXPECT_STREQ(error.what(), "Schema identifier already exists");
+  }
+}
+
+// Whereas a limit that runs out before framing ever reaches the collision
+// reports the limit, as framing never got far enough to find the collision
+TEST(limit_wins_when_it_runs_out_before_the_collision) {
+  try {
+    [[maybe_unused]] const sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::References,
+        COLLIDING_DOCUMENT,
+        sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        "",
+        "",
+        sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+        {sourcemeta::core::EMPTY_WEAK_POINTER},
+        0};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameLimitError &error) {
+    EXPECT_EQ(error.limit(), 0);
   }
 }
 
@@ -146,7 +168,8 @@ TEST(limit_does_not_mask_an_identifier_collision) {
 // what makes framing grow faster than the schema does, and what the limit
 // exists to catch
 TEST(nested_identifiers_cost_more_than_the_same_shape_without_them) {
-  const sourcemeta::core::JSON anonymous = sourcemeta::core::parse_json(R"JSON({
+  const sourcemeta::core::JSON without_identifiers =
+      sourcemeta::core::parse_json(R"JSON({
     "$id": "https://www.sourcemeta.com/schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
@@ -158,7 +181,7 @@ TEST(nested_identifiers_cost_more_than_the_same_shape_without_them) {
     }
   })JSON");
 
-  const sourcemeta::core::JSON identified =
+  const sourcemeta::core::JSON with_identifiers =
       sourcemeta::core::parse_json(R"JSON({
     "$id": "https://www.sourcemeta.com/schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -172,13 +195,13 @@ TEST(nested_identifiers_cost_more_than_the_same_shape_without_them) {
     }
   })JSON");
 
-  const sourcemeta::blaze::SchemaFrame anonymous_frame{
-      sourcemeta::blaze::SchemaFrame::Mode::References, anonymous,
+  const sourcemeta::blaze::SchemaFrame without_identifiers_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, without_identifiers,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
-  EXPECT_EQ(anonymous_frame.location_count(), 4);
+  EXPECT_EQ(without_identifiers_frame.location_count(), 4);
 
-  const sourcemeta::blaze::SchemaFrame identified_frame{
-      sourcemeta::blaze::SchemaFrame::Mode::References, identified,
+  const sourcemeta::blaze::SchemaFrame with_identifiers_frame{
+      sourcemeta::blaze::SchemaFrame::Mode::References, with_identifiers,
       sourcemeta::blaze::schema_walker, sourcemeta::blaze::schema_resolver};
-  EXPECT_EQ(identified_frame.location_count(), 9);
+  EXPECT_EQ(with_identifiers_frame.location_count(), 9);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

