### PR TITLE
Support bounding how much work compiling a schema may do

### DIFF
--- a/src/compiler/compile.cc
+++ b/src/compiler/compile.cc
@@ -205,6 +205,30 @@ auto keyword_shape_error(
   }
 }
 
+// Compiling a subschema recurses back into itself through the keyword
+// handlers, so what bounds that recursion has to survive across those calls.
+// A guard that throws never incremented, and so never decrements either
+class DepthGuard {
+public:
+  DepthGuard(std::uint64_t &depth, const std::uint64_t limit) : depth_{depth} {
+    if (this->depth_ >= limit) [[unlikely]] {
+      throw sourcemeta::blaze::CompilerDepthLimitError{limit};
+    }
+
+    this->depth_ += 1;
+  }
+
+  ~DepthGuard() { this->depth_ -= 1; }
+
+  DepthGuard(const DepthGuard &) = delete;
+  auto operator=(const DepthGuard &) -> DepthGuard & = delete;
+  DepthGuard(DepthGuard &&) = delete;
+  auto operator=(DepthGuard &&) -> DepthGuard & = delete;
+
+private:
+  std::uint64_t &depth_;
+};
+
 auto compile_subschema(const sourcemeta::blaze::Context &context,
                        const sourcemeta::blaze::SchemaContext &schema_context,
                        const sourcemeta::blaze::DynamicContext &dynamic_context)
@@ -212,6 +236,7 @@ auto compile_subschema(const sourcemeta::blaze::Context &context,
   using namespace sourcemeta::blaze;
   assert((schema_context.schema.is_object() ||
           schema_context.schema.is_boolean()));
+  const DepthGuard depth_guard{context.depth, context.tweaks.max_depth};
 
   // A boolean in a keyword position is settled by the keyword's own contract,
   // which the shape check below applies. What is left is the root of a schema
@@ -623,7 +648,8 @@ auto compile(const sourcemeta::core::JSON &schema,
   auto unevaluated{
       sourcemeta::blaze::unevaluated(schema, frame, walker, resolver)};
 
-  std::vector<InstructionExtra> instruction_extra;
+  std::uint64_t compilation_depth{0};
+  InstructionExtras instruction_extra{effective_tweaks.max_instructions};
   std::vector<SchemaVocabularies::URI> instruction_vocabularies;
   const Context context{.root = schema,
                         .frame = frame,
@@ -637,6 +663,7 @@ auto compile(const sourcemeta::core::JSON &schema,
                         .unevaluated = std::move(unevaluated),
                         .tweaks = effective_tweaks,
                         .targets = std::move(targets_map),
+                        .depth = compilation_depth,
                         .extra = instruction_extra,
                         .vocabularies = instruction_vocabularies};
 
@@ -761,7 +788,7 @@ auto compile(const sourcemeta::core::JSON &schema,
           .track = track,
           .targets = std::move(compiled_targets),
           .labels = std::move(labels_map),
-          .extra = std::move(instruction_extra),
+          .extra = std::move(instruction_extra).release(),
           .vocabularies = std::move(template_vocabularies)};
 }
 
@@ -772,7 +799,8 @@ auto compile(const sourcemeta::core::JSON &schema,
              const std::string_view default_dialect,
              const std::string_view default_id,
              const std::string_view entrypoint,
-             const std::optional<Tweaks> &tweaks) -> Template {
+             const std::optional<Tweaks> &tweaks,
+             const std::uint64_t max_locations) -> Template {
   assert((schema.is_object() || schema.is_boolean()));
 
   // Make sure the input schema is bundled, otherwise we won't be able to
@@ -780,7 +808,8 @@ auto compile(const sourcemeta::core::JSON &schema,
   // can determine vocabularies through the resolver
   const sourcemeta::core::JSON result{sourcemeta::blaze::bundle(
       schema, walker, resolver, sourcemeta::blaze::BundleMode::References,
-      default_dialect, default_id)};
+      default_dialect, default_id, std::nullopt,
+      {sourcemeta::core::EMPTY_WEAK_POINTER}, max_locations)};
 
   sourcemeta::blaze::SchemaFrame frame{
       sourcemeta::blaze::SchemaFrame::Mode::References,
@@ -788,7 +817,10 @@ auto compile(const sourcemeta::core::JSON &schema,
       walker,
       resolver,
       default_dialect,
-      default_id};
+      default_id,
+      sourcemeta::blaze::SchemaFrame::IdentifierMode::Additional,
+      {sourcemeta::core::EMPTY_WEAK_POINTER},
+      max_locations};
   return compile(result, walker, resolver, compiler, frame,
                  entrypoint.empty() ? frame.root() : entrypoint, mode, tweaks);
 }

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -16,8 +16,9 @@
 #include <sourcemeta/core/uri.h>
 
 #include <cstddef>       // std::size_t
-#include <cstdint>       // std::uint8_t
+#include <cstdint>       // std::uint8_t, std::uint64_t
 #include <functional>    // std::function
+#include <limits>        // std::numeric_limits
 #include <map>           // std::map
 #include <optional>      // std::optional, std::nullopt
 #include <string>        // std::string
@@ -88,6 +89,58 @@ enum class Mode : std::uint8_t {
 };
 
 /// @ingroup compiler
+/// An accumulator for instruction metadata that refuses to grow past a limit.
+/// Compilation makes one entry here for every instruction it makes, including
+/// the ones it goes on to throw away and the copies that inlining leaves
+/// behind, so what this holds is what compiling the schema cost
+class SOURCEMETA_BLAZE_COMPILER_EXPORT InstructionExtras {
+public:
+  explicit InstructionExtras(const std::uint64_t limit) : limit_{limit} {}
+
+  /// Make room for another instruction, throwing
+  /// sourcemeta::blaze::CompilerInstructionLimitError once out of room
+  auto push_back(InstructionExtra &&entry) -> void {
+    if (this->entries_.size() >= this->limit_) [[unlikely]] {
+      throw CompilerInstructionLimitError{this->limit_};
+    }
+
+    this->entries_.push_back(std::move(entry));
+  }
+
+  [[nodiscard]] auto size() const noexcept -> std::size_t {
+    return this->entries_.size();
+  }
+
+  [[nodiscard]] auto operator[](const std::size_t index) const noexcept
+      -> const InstructionExtra & {
+    return this->entries_[index];
+  }
+
+  [[nodiscard]] auto operator[](const std::size_t index) noexcept
+      -> InstructionExtra & {
+    return this->entries_[index];
+  }
+
+  /// Hand the accumulated entries over to the template that will own them
+  [[nodiscard]] auto release() && -> std::vector<InstructionExtra> {
+    return std::move(this->entries_);
+  }
+
+private:
+// Exporting symbols that depends on the standard C++ library is considered
+// safe.
+// https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170&redirectedfrom=MSDN
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251 4275)
+#endif
+  std::vector<InstructionExtra> entries_;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251 4275)
+#endif
+  std::uint64_t limit_;
+};
+
+/// @ingroup compiler
 /// Advanced knobs that you can tweak for higher control and optimisations
 struct Tweaks {
   /// Always unroll `properties` in a logical AND operation
@@ -103,6 +156,18 @@ struct Tweaks {
   /// mode and none in fast mode
   std::optional<std::unordered_set<sourcemeta::core::JSON::StringView>>
       annotations{};
+  /// How many instructions compilation may make before it gives up, throwing
+  /// sourcemeta::blaze::CompilerInstructionLimitError. A schema compiles every
+  /// target it can be entered through, and inlining copies what it inlines, so
+  /// what an untrusted schema costs to compile grows faster than the schema
+  /// itself does
+  std::uint64_t max_instructions{std::numeric_limits<std::uint64_t>::max()};
+  /// How deep compilation may descend into a schema before it gives up,
+  /// throwing sourcemeta::blaze::CompilerDepthLimitError. Compiling a
+  /// subschema recurses back into itself through the keyword handlers, so
+  /// without this a schema nested deeply enough runs the stack out rather than
+  /// reporting anything the caller can catch
+  std::uint64_t max_depth{std::numeric_limits<std::uint64_t>::max()};
 };
 
 /// @ingroup compiler
@@ -138,8 +203,10 @@ struct Context {
                             std::string_view, bool>,
                  std::pair<std::size_t, const sourcemeta::core::WeakPointer *>>
       targets;
+  /// How deep into the schema compilation currently is
+  std::uint64_t &depth;
   /// Accumulator for instruction extra data during compilation
-  std::vector<InstructionExtra> &extra;
+  InstructionExtras &extra;
   /// Accumulator for the vocabularies that instructions refer to
   std::vector<SchemaVocabularies::URI> &vocabularies;
   // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -176,6 +243,14 @@ auto SOURCEMETA_BLAZE_COMPILER_EXPORT default_schema_compiler(
 ///
 /// // Evaluate or encode
 /// ```
+///
+/// This overload bundles and frames the schema before compiling it, and
+/// neither of those is bounded by sourcemeta::blaze::Tweaks. Pass
+/// `max_locations` to bound them, throwing
+/// sourcemeta::blaze::SchemaFrameLimitError. Bundling and framing each get
+/// this budget rather than sharing one, so the preamble costs at most twice
+/// it. The overload that takes a frame does neither, and so takes no such
+/// limit
 auto SOURCEMETA_BLAZE_COMPILER_EXPORT
 compile(const sourcemeta::core::JSON &schema,
         const sourcemeta::blaze::SchemaWalker &walker,
@@ -184,7 +259,9 @@ compile(const sourcemeta::core::JSON &schema,
         const std::string_view default_dialect = "",
         const std::string_view default_id = "",
         const std::string_view entrypoint = "",
-        const std::optional<Tweaks> &tweaks = std::nullopt) -> Template;
+        const std::optional<Tweaks> &tweaks = std::nullopt,
+        std::uint64_t max_locations = std::numeric_limits<std::uint64_t>::max())
+    -> Template;
 
 /// @ingroup compiler
 ///

--- a/src/compiler/include/sourcemeta/blaze/compiler.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler.h
@@ -97,8 +97,7 @@ class SOURCEMETA_BLAZE_COMPILER_EXPORT InstructionExtras {
 public:
   explicit InstructionExtras(const std::uint64_t limit) : limit_{limit} {}
 
-  /// Make room for another instruction, throwing
-  /// sourcemeta::blaze::CompilerInstructionLimitError once out of room
+  /// Make room for another instruction, throwing once out of room
   auto push_back(InstructionExtra &&entry) -> void {
     if (this->entries_.size() >= this->limit_) [[unlikely]] {
       throw CompilerInstructionLimitError{this->limit_};
@@ -156,17 +155,15 @@ struct Tweaks {
   /// mode and none in fast mode
   std::optional<std::unordered_set<sourcemeta::core::JSON::StringView>>
       annotations{};
-  /// How many instructions compilation may make before it gives up, throwing
-  /// sourcemeta::blaze::CompilerInstructionLimitError. A schema compiles every
-  /// target it can be entered through, and inlining copies what it inlines, so
-  /// what an untrusted schema costs to compile grows faster than the schema
-  /// itself does
+  /// How many instructions compilation may make before it gives up and
+  /// throws. A schema compiles every target it can be entered through, and
+  /// inlining copies what it inlines, so what an untrusted schema costs to
+  /// compile grows faster than the schema itself does
   std::uint64_t max_instructions{std::numeric_limits<std::uint64_t>::max()};
-  /// How deep compilation may descend into a schema before it gives up,
-  /// throwing sourcemeta::blaze::CompilerDepthLimitError. Compiling a
-  /// subschema recurses back into itself through the keyword handlers, so
-  /// without this a schema nested deeply enough runs the stack out rather than
-  /// reporting anything the caller can catch
+  /// How deep compilation may descend into a schema before it gives up and
+  /// throws. Compiling a subschema recurses back into itself through the
+  /// keyword handlers, so without this a schema nested deeply enough runs the
+  /// stack out rather than reporting anything the caller can catch
   std::uint64_t max_depth{std::numeric_limits<std::uint64_t>::max()};
 };
 
@@ -245,12 +242,10 @@ auto SOURCEMETA_BLAZE_COMPILER_EXPORT default_schema_compiler(
 /// ```
 ///
 /// This overload bundles and frames the schema before compiling it, and
-/// neither of those is bounded by sourcemeta::blaze::Tweaks. Pass
-/// `max_locations` to bound them, throwing
-/// sourcemeta::blaze::SchemaFrameLimitError. Bundling and framing each get
-/// this budget rather than sharing one, so the preamble costs at most twice
-/// it. The overload that takes a frame does neither, and so takes no such
-/// limit
+/// neither of those is bounded by the compiler tweaks. Pass `max_locations`
+/// to bound them instead. Bundling and framing each get this budget rather
+/// than sharing one, so the preamble costs at most twice it. The overload
+/// that takes a frame does neither, and so takes no such limit
 auto SOURCEMETA_BLAZE_COMPILER_EXPORT
 compile(const sourcemeta::core::JSON &schema,
         const sourcemeta::blaze::SchemaWalker &walker,

--- a/src/compiler/include/sourcemeta/blaze/compiler_error.h
+++ b/src/compiler/include/sourcemeta/blaze/compiler_error.h
@@ -8,6 +8,7 @@
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/uri.h>
 
+#include <cstdint>     // std::uint64_t
 #include <exception>   // std::exception
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -124,6 +125,48 @@ public:
 private:
   std::string identifier_;
   sourcemeta::core::Pointer schema_location_;
+};
+
+/// @ingroup foundation
+/// An error that represents a schema that compiles into more instructions than
+/// the caller was willing to spend on it
+class SOURCEMETA_BLAZE_COMPILER_EXPORT CompilerInstructionLimitError
+    : public std::exception {
+public:
+  CompilerInstructionLimitError(const std::uint64_t limit) : limit_{limit} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "The schema exceeds the maximum number of compiled instructions";
+  }
+
+  /// The maximum number of instructions that compilation was allowed to make
+  [[nodiscard]] auto limit() const noexcept -> std::uint64_t {
+    return this->limit_;
+  }
+
+private:
+  std::uint64_t limit_;
+};
+
+/// @ingroup foundation
+/// An error that represents a schema that nests deeper than the caller was
+/// willing to descend into
+class SOURCEMETA_BLAZE_COMPILER_EXPORT CompilerDepthLimitError
+    : public std::exception {
+public:
+  CompilerDepthLimitError(const std::uint64_t limit) : limit_{limit} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "The schema exceeds the maximum compilation depth";
+  }
+
+  /// The deepest that compilation was allowed to descend
+  [[nodiscard]] auto limit() const noexcept -> std::uint64_t {
+    return this->limit_;
+  }
+
+private:
+  std::uint64_t limit_;
 };
 
 /// @ingroup foundation

--- a/src/compiler/postprocess.h
+++ b/src/compiler/postprocess.h
@@ -102,7 +102,7 @@ inline auto convert_to_property_type_assertions(Instructions &instructions)
 }
 
 inline auto duplicate_metadata(Instruction &instruction,
-                               std::vector<InstructionExtra> &extra) -> void {
+                               InstructionExtras &extra) -> void {
   const auto new_index{extra.size()};
   auto source_extra{extra[instruction.extra_index]};
   extra.push_back(std::move(source_extra));
@@ -135,8 +135,7 @@ inline auto is_pass_through_instruction(const InstructionIndex type) noexcept
 // conditional's parent, and the children of pass-through instructions.
 // Condition children and ordinary nested children stay relative to their
 // parent instruction and must be left alone
-inline auto rebase_anchored(Instruction &instruction,
-                            std::vector<InstructionExtra> &extra,
+inline auto rebase_anchored(Instruction &instruction, InstructionExtras &extra,
                             const sourcemeta::core::Pointer &schema_prefix)
     -> void {
   extra[instruction.extra_index].relative_schema_location =
@@ -156,8 +155,7 @@ inline auto rebase_anchored(Instruction &instruction,
   }
 }
 
-inline auto rebase(Instruction &instruction,
-                   std::vector<InstructionExtra> &extra,
+inline auto rebase(Instruction &instruction, InstructionExtras &extra,
                    const sourcemeta::core::Pointer &schema_prefix,
                    const sourcemeta::core::Pointer &instance_prefix) -> void {
   instruction.relative_instance_location =
@@ -184,9 +182,8 @@ inline auto collect_statistics(const Instructions &instructions,
   }
 }
 
-inline auto
-instruction_parent_location(const Instruction &instruction,
-                            const std::vector<InstructionExtra> &extra)
+inline auto instruction_parent_location(const Instruction &instruction,
+                                        const InstructionExtras &extra)
     -> std::optional<std::pair<sourcemeta::core::Pointer, std::string>> {
   const auto &metadata{extra[instruction.extra_index]};
   if (metadata.relative_schema_location.empty()) {
@@ -206,7 +203,7 @@ instruction_parent_location(const Instruction &instruction,
 }
 
 inline auto fuse_numeric_bounds(Instructions &instructions,
-                                std::vector<InstructionExtra> &extra) -> bool {
+                                InstructionExtras &extra) -> bool {
   for (std::size_t type_index = 0; type_index < instructions.size();
        ++type_index) {
     const auto &type_instruction{instructions[type_index]};
@@ -301,14 +298,12 @@ inline auto fuse_numeric_bounds(Instructions &instructions,
   return false;
 }
 
-inline auto
-transform_instruction(Instruction &instruction, Instructions &output,
-                      std::vector<InstructionExtra> &extra,
-                      const std::vector<Instructions> &targets,
-                      const std::vector<TargetStatistics> &statistics,
-                      TargetStatistics &current_stats, const Tweaks &tweaks,
-                      const bool uses_dynamic_scopes, const bool positional)
-    -> bool {
+inline auto transform_instruction(
+    Instruction &instruction, Instructions &output, InstructionExtras &extra,
+    const std::vector<Instructions> &targets,
+    const std::vector<TargetStatistics> &statistics,
+    TargetStatistics &current_stats, const Tweaks &tweaks,
+    const bool uses_dynamic_scopes, const bool positional) -> bool {
   // A positional owner pairs each child with an entry of its own data by
   // index, and inlining a jump expands one child into many, which would
   // re-pair the rest
@@ -519,9 +514,8 @@ transform_instruction(Instruction &instruction, Instructions &output,
 }
 
 inline auto postprocess(std::vector<Instructions> &targets,
-                        std::vector<InstructionExtra> &extra,
-                        const Tweaks &tweaks, const bool uses_dynamic_scopes)
-    -> void {
+                        InstructionExtras &extra, const Tweaks &tweaks,
+                        const bool uses_dynamic_scopes) -> void {
   std::vector<TargetStatistics> statistics;
   statistics.reserve(targets.size());
   for (const auto &target : targets) {

--- a/test/bundle/bundle_limit_test.cc
+++ b/test/bundle/bundle_limit_test.cc
@@ -10,6 +10,7 @@
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
+// NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
 static auto chain_resolver(std::string_view identifier)
     -> sourcemeta::blaze::SchemaResolverResult {
   if (identifier == "https://www.sourcemeta.com/chain-1") {
@@ -18,21 +19,25 @@ static auto chain_resolver(std::string_view identifier)
       "$id": "https://www.sourcemeta.com/chain-1",
       "$ref": "chain-2"
     })JSON");
-  } else if (identifier == "https://www.sourcemeta.com/chain-2") {
+  }
+
+  if (identifier == "https://www.sourcemeta.com/chain-2") {
     return sourcemeta::core::parse_json(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/chain-2",
       "$ref": "chain-3"
     })JSON");
-  } else if (identifier == "https://www.sourcemeta.com/chain-3") {
+  }
+
+  if (identifier == "https://www.sourcemeta.com/chain-3") {
     return sourcemeta::core::parse_json(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/chain-3",
       "type": "string"
     })JSON");
-  } else {
-    return sourcemeta::blaze::schema_resolver(identifier);
   }
+
+  return sourcemeta::blaze::schema_resolver(identifier);
 }
 
 // Pulls in a single remote, and so costs a single remote's worth of framing
@@ -182,3 +187,4 @@ TEST(dependencies_one_below_the_required_limit_throws) {
     EXPECT_EQ(error.limit(), 6);
   }
 }
+// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)

--- a/test/bundle/bundle_limit_test.cc
+++ b/test/bundle/bundle_limit_test.cc
@@ -10,7 +10,6 @@
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
-// NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
 static auto chain_resolver(std::string_view identifier)
     -> sourcemeta::blaze::SchemaResolverResult {
   if (identifier == "https://www.sourcemeta.com/chain-1") {
@@ -40,6 +39,7 @@ static auto chain_resolver(std::string_view identifier)
   return sourcemeta::blaze::schema_resolver(identifier);
 }
 
+// NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
 // Pulls in a single remote, and so costs a single remote's worth of framing
 static const sourcemeta::core::JSON SINGLE =
     sourcemeta::core::parse_json(R"JSON({
@@ -76,6 +76,11 @@ static const sourcemeta::core::JSON BUNDLED_CHAIN =
     }
   }
 })JSON");
+
+static const std::vector<std::string> CHAIN_DEPENDENCIES{
+    "https://www.sourcemeta.com/chain-1", "https://www.sourcemeta.com/chain-2",
+    "https://www.sourcemeta.com/chain-3"};
+// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)
 
 TEST(bundle_default_limit_is_unbounded) {
   const auto result{sourcemeta::blaze::bundle(
@@ -153,10 +158,6 @@ TEST(bundle_in_place_respects_the_limit) {
   }
 }
 
-static const std::vector<std::string> CHAIN_DEPENDENCIES{
-    "https://www.sourcemeta.com/chain-1", "https://www.sourcemeta.com/chain-2",
-    "https://www.sourcemeta.com/chain-3"};
-
 TEST(dependencies_default_limit_is_unbounded) {
   std::vector<std::string> identifiers;
   sourcemeta::blaze::dependencies(
@@ -187,4 +188,3 @@ TEST(dependencies_one_below_the_required_limit_throws) {
     EXPECT_EQ(error.limit(), 6);
   }
 }
-// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)

--- a/test/compiler/CMakeLists.txt
+++ b/test/compiler/CMakeLists.txt
@@ -3,6 +3,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT blaze NAME compiler
     compiler_unevaluated_2019_09_test.cc
     compiler_unevaluated_2020_12_test.cc
     compiler_json_test.cc
+    compiler_limit_test.cc
     compiler_test_utils.h)
 
 target_link_libraries(sourcemeta_blaze_compiler_unit

--- a/test/compiler/compiler_limit_test.cc
+++ b/test/compiler/compiler_limit_test.cc
@@ -7,6 +7,19 @@
 #include <optional>    // std::nullopt
 #include <string_view> // std::string_view
 
+static auto remote_resolver(std::string_view identifier)
+    -> sourcemeta::blaze::SchemaResolverResult {
+  if (identifier == "https://www.sourcemeta.com/remote") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://www.sourcemeta.com/remote",
+      "type": "string"
+    })JSON");
+  }
+
+  return sourcemeta::blaze::schema_resolver(identifier);
+}
+
 // NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
 static const sourcemeta::core::JSON SCHEMA =
     sourcemeta::core::parse_json(R"JSON({
@@ -17,6 +30,24 @@ static const sourcemeta::core::JSON SCHEMA =
     "bar": { "type": "number" }
   }
 })JSON");
+
+// Compiling a subschema recurses back into itself through the keyword
+// handlers, so a schema deep enough would otherwise run the stack out rather
+// than report anything a caller could catch
+static const sourcemeta::core::JSON NESTED =
+    sourcemeta::core::parse_json(R"JSON({
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "not": { "not": { "not": { "type": "string" } } }
+})JSON");
+
+// Compiling from a schema rather than from a frame bundles it and frames it
+// first, and neither of those is bounded by what compilation itself may spend
+static const sourcemeta::core::JSON WITH_REMOTE =
+    sourcemeta::core::parse_json(R"JSON({
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://www.sourcemeta.com/remote"
+})JSON");
+// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)
 
 TEST(instructions_default_limit_is_unbounded) {
   const auto schema_template{
@@ -70,15 +101,6 @@ TEST(instruction_limit_of_zero_throws) {
   }
 }
 
-// Compiling a subschema recurses back into itself through the keyword
-// handlers, so a schema deep enough would otherwise run the stack out rather
-// than report anything a caller could catch
-static const sourcemeta::core::JSON NESTED =
-    sourcemeta::core::parse_json(R"JSON({
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "not": { "not": { "not": { "type": "string" } } }
-})JSON");
-
 TEST(depth_default_limit_is_unbounded) {
   [[maybe_unused]] const auto schema_template{
       sourcemeta::blaze::compile(NESTED, sourcemeta::blaze::schema_walker,
@@ -113,27 +135,6 @@ TEST(depth_limit_one_below_the_nesting_throws) {
   }
 }
 
-static auto remote_resolver(std::string_view identifier)
-    -> sourcemeta::blaze::SchemaResolverResult {
-  if (identifier == "https://www.sourcemeta.com/remote") {
-    return sourcemeta::core::parse_json(R"JSON({
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://www.sourcemeta.com/remote",
-      "type": "string"
-    })JSON");
-  }
-
-  return sourcemeta::blaze::schema_resolver(identifier);
-}
-
-// Compiling from a schema rather than from a frame bundles it and frames it
-// first, and neither of those is bounded by what compilation itself may spend
-static const sourcemeta::core::JSON WITH_REMOTE =
-    sourcemeta::core::parse_json(R"JSON({
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$ref": "https://www.sourcemeta.com/remote"
-})JSON");
-
 TEST(locations_default_limit_is_unbounded) {
   [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
       WITH_REMOTE, sourcemeta::blaze::schema_walker, remote_resolver,
@@ -153,4 +154,3 @@ TEST(location_limit_bounds_the_bundling_and_framing_preamble) {
     EXPECT_EQ(error.limit(), 2);
   }
 }
-// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)

--- a/test/compiler/compiler_limit_test.cc
+++ b/test/compiler/compiler_limit_test.cc
@@ -1,0 +1,156 @@
+#include <sourcemeta/core/test.h>
+
+#include <sourcemeta/blaze/compiler.h>
+
+#include <sourcemeta/core/json.h>
+
+#include <optional>    // std::nullopt
+#include <string_view> // std::string_view
+
+// NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
+static const sourcemeta::core::JSON SCHEMA =
+    sourcemeta::core::parse_json(R"JSON({
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "foo": { "type": "string" },
+    "bar": { "type": "number" }
+  }
+})JSON");
+
+TEST(instructions_default_limit_is_unbounded) {
+  const auto schema_template{
+      sourcemeta::blaze::compile(SCHEMA, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+  EXPECT_EQ(schema_template.extra.size(), 8);
+}
+
+TEST(instruction_limit_equal_to_the_count_succeeds) {
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.max_instructions = 8;
+  const auto schema_template{sourcemeta::blaze::compile(
+      SCHEMA, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+  EXPECT_EQ(schema_template.extra.size(), 8);
+}
+
+TEST(instruction_limit_one_below_the_count_throws) {
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.max_instructions = 7;
+  try {
+    [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+        SCHEMA, sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        sourcemeta::blaze::default_schema_compiler,
+        sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+    FAIL();
+  } catch (const sourcemeta::blaze::CompilerInstructionLimitError &error) {
+    EXPECT_STREQ(
+        error.what(),
+        "The schema exceeds the maximum number of compiled instructions");
+    EXPECT_EQ(error.limit(), 7);
+  }
+}
+
+TEST(instruction_limit_of_zero_throws) {
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.max_instructions = 0;
+  try {
+    [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+        SCHEMA, sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        sourcemeta::blaze::default_schema_compiler,
+        sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+    FAIL();
+  } catch (const sourcemeta::blaze::CompilerInstructionLimitError &error) {
+    EXPECT_EQ(error.limit(), 0);
+  }
+}
+
+// Compiling a subschema recurses back into itself through the keyword
+// handlers, so a schema deep enough would otherwise run the stack out rather
+// than report anything a caller could catch
+static const sourcemeta::core::JSON NESTED =
+    sourcemeta::core::parse_json(R"JSON({
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "not": { "not": { "not": { "type": "string" } } }
+})JSON");
+
+TEST(depth_default_limit_is_unbounded) {
+  [[maybe_unused]] const auto schema_template{
+      sourcemeta::blaze::compile(NESTED, sourcemeta::blaze::schema_walker,
+                                 sourcemeta::blaze::schema_resolver,
+                                 sourcemeta::blaze::default_schema_compiler)};
+}
+
+TEST(depth_limit_equal_to_the_nesting_succeeds) {
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.max_depth = 4;
+  [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+      NESTED, sourcemeta::blaze::schema_walker,
+      sourcemeta::blaze::schema_resolver,
+      sourcemeta::blaze::default_schema_compiler,
+      sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+}
+
+TEST(depth_limit_one_below_the_nesting_throws) {
+  sourcemeta::blaze::Tweaks tweaks;
+  tweaks.max_depth = 3;
+  try {
+    [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+        NESTED, sourcemeta::blaze::schema_walker,
+        sourcemeta::blaze::schema_resolver,
+        sourcemeta::blaze::default_schema_compiler,
+        sourcemeta::blaze::Mode::FastValidation, "", "", "", tweaks)};
+    FAIL();
+  } catch (const sourcemeta::blaze::CompilerDepthLimitError &error) {
+    EXPECT_STREQ(error.what(),
+                 "The schema exceeds the maximum compilation depth");
+    EXPECT_EQ(error.limit(), 3);
+  }
+}
+
+static auto remote_resolver(std::string_view identifier)
+    -> sourcemeta::blaze::SchemaResolverResult {
+  if (identifier == "https://www.sourcemeta.com/remote") {
+    return sourcemeta::core::parse_json(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://www.sourcemeta.com/remote",
+      "type": "string"
+    })JSON");
+  }
+
+  return sourcemeta::blaze::schema_resolver(identifier);
+}
+
+// Compiling from a schema rather than from a frame bundles it and frames it
+// first, and neither of those is bounded by what compilation itself may spend
+static const sourcemeta::core::JSON WITH_REMOTE =
+    sourcemeta::core::parse_json(R"JSON({
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://www.sourcemeta.com/remote"
+})JSON");
+
+TEST(locations_default_limit_is_unbounded) {
+  [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+      WITH_REMOTE, sourcemeta::blaze::schema_walker, remote_resolver,
+      sourcemeta::blaze::default_schema_compiler)};
+}
+
+TEST(location_limit_bounds_the_bundling_and_framing_preamble) {
+  try {
+    [[maybe_unused]] const auto schema_template{sourcemeta::blaze::compile(
+        WITH_REMOTE, sourcemeta::blaze::schema_walker, remote_resolver,
+        sourcemeta::blaze::default_schema_compiler,
+        sourcemeta::blaze::Mode::FastValidation, "", "", "", std::nullopt, 2)};
+    FAIL();
+  } catch (const sourcemeta::blaze::SchemaFrameLimitError &error) {
+    EXPECT_STREQ(error.what(),
+                 "The schema exceeds the maximum number of frame locations");
+    EXPECT_EQ(error.limit(), 2);
+  }
+}
+// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/blaze/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

